### PR TITLE
Event queue stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist
 node_modules
 data/
+.env

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
   "license": "MIT",
   "dependencies": {
     "@connectome/context-manager": "file:../context-manager",
-    "chronicle": "file:../record-store",
+    "chronicle": "file:../chronicle",
+    "discord.js": "^14.25.1",
+    "dotenv": "^17.2.3",
     "membrane": "file:../membrane",
     "ws": "^8.18.0"
   },

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -32,6 +32,9 @@ import type {
   InferenceTailParams,
   InferenceInspectParams,
   InferenceSearchParams,
+  EventsTailParams,
+  EventsInspectParams,
+  EventsSearchParams,
   AgentInfo,
   ModuleInfo,
   BranchInfo,
@@ -317,6 +320,14 @@ export class ApiServer {
         // Don't broadcast raw queue events
         break;
 
+      case 'event:handled':
+        this.broadcast('event:handled', {
+          timestamp: Date.now(),
+          event: event.event,
+          responses: event.responses,
+        });
+        break;
+
       case 'module:start':
         this.broadcast('module:started', { moduleName: event.moduleName });
         break;
@@ -386,6 +397,14 @@ export class ApiServer {
         return this.cmdInferenceInspect(params as unknown as InferenceInspectParams);
       case 'inference.search':
         return this.cmdInferenceSearch(params as unknown as InferenceSearchParams);
+
+      // Event logs
+      case 'events.tail':
+        return this.cmdEventsTail(params as unknown as EventsTailParams);
+      case 'events.inspect':
+        return this.cmdEventsInspect(params as unknown as EventsInspectParams);
+      case 'events.search':
+        return this.cmdEventsSearch(params as unknown as EventsSearchParams);
 
       default:
         throw new Error(`Unknown command: ${command}`);
@@ -699,6 +718,44 @@ export class ApiServer {
       offset: params?.offset,
       pattern: params?.pattern,
       errorsOnly: params?.errorsOnly,
+    });
+
+    return result;
+  }
+
+  // ==========================================================================
+  // Event Log Commands
+  // ==========================================================================
+
+  private async cmdEventsTail(params?: EventsTailParams): Promise<{ entries: unknown[] }> {
+    const entries = this.framework.tailEventLogs(
+      params?.count ?? 10,
+      params?.eventType
+    );
+
+    return { entries };
+  }
+
+  private async cmdEventsInspect(params: EventsInspectParams): Promise<{ entry: unknown }> {
+    if (params.sequence === undefined || params.sequence === null) {
+      throw new Error('sequence is required');
+    }
+
+    const entry = this.framework.getEventLog(params.sequence);
+    if (!entry) {
+      throw new Error(`Event log not found: ${params.sequence}`);
+    }
+
+    return { entry };
+  }
+
+  private async cmdEventsSearch(params?: EventsSearchParams): Promise<unknown> {
+    const result = this.framework.queryEventLogs({
+      eventType: params?.eventType,
+      moduleName: params?.moduleName,
+      limit: params?.limit,
+      offset: params?.offset,
+      pattern: params?.pattern,
     });
 
     return result;

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -35,6 +35,8 @@ import type {
   EventsTailParams,
   EventsInspectParams,
   EventsSearchParams,
+  EventsSubscribeParams,
+  PersistedEvent,
   AgentInfo,
   ModuleInfo,
   BranchInfo,
@@ -405,6 +407,8 @@ export class ApiServer {
         return this.cmdEventsInspect(params as unknown as EventsInspectParams);
       case 'events.search':
         return this.cmdEventsSearch(params as unknown as EventsSearchParams);
+      case 'events.subscribe':
+        return this.cmdEventsSubscribe(params as unknown as EventsSubscribeParams);
 
       default:
         throw new Error(`Unknown command: ${command}`);
@@ -761,6 +765,53 @@ export class ApiServer {
     return result;
   }
 
+  private async cmdEventsSubscribe(
+    params?: EventsSubscribeParams
+  ): Promise<{ subscribed: string[]; history: PersistedEvent[] }> {
+    const types = params?.types ?? ['*'];
+    const limit = params?.limit ?? 100;
+
+    // Get historical events from the event log
+    const eventEntries = this.framework.tailEventLogs(limit);
+
+    // Convert EventLogEntry to PersistedEvent format
+    const history: PersistedEvent[] = eventEntries.map((item) => {
+      const { sequence, entry } = item;
+      const event = entry.event;
+      const timestamp = entry.timestamp;
+
+      // Extract agent/module info from event if available
+      const agentName =
+        (event as Record<string, unknown>).agentName as string | undefined;
+      const moduleName =
+        (event as Record<string, unknown>).moduleName as string | undefined;
+
+      return {
+        id: `evt-${sequence}`,
+        sequence,
+        timestamp,
+        type: event?.type ?? 'unknown',
+        payload: event,
+        source: 'chronicle',
+        agentName,
+        moduleName,
+      };
+    });
+
+    // Filter by types if not wildcard
+    const filteredHistory =
+      types.includes('*')
+        ? history
+        : history.filter((evt) =>
+            types.some((pattern) => matchEventType(pattern, evt.type))
+          );
+
+    return {
+      subscribed: types,
+      history: filteredHistory,
+    };
+  }
+
   // ==========================================================================
   // HTTP Handling (optional REST endpoints)
   // ==========================================================================
@@ -948,4 +999,17 @@ export class ApiServer {
       }
     }
   }
+}
+
+/**
+ * Check if an event type matches a pattern.
+ * Supports wildcards like 'inference:*' or exact matches.
+ */
+function matchEventType(pattern: string, eventType: string): boolean {
+  if (pattern === '*') return true;
+  if (pattern.endsWith(':*')) {
+    const prefix = pattern.slice(0, -1);
+    return eventType.startsWith(prefix);
+  }
+  return pattern === eventType;
 }

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -520,19 +520,15 @@ export class ApiServer {
   }
 
   private async cmdModuleList(): Promise<{ modules: ModuleInfo[] }> {
-    // Get modules through the framework
-    // Note: We need to expose getAllModules from framework
-    const store = this.framework.getStore();
-
-    // For now, list module states from store
-    const states = store.listStates();
-    const moduleStates = states.filter((s) => s.id.startsWith('modules/'));
-    const moduleNames = [...new Set(moduleStates.map((s) => s.id.split('/')[1]))];
+    const modules = this.framework.getAllModules();
+    const allTools = this.framework.getAllTools();
 
     return {
-      modules: moduleNames.map((name) => ({
-        name,
-        tools: [], // Would need framework access
+      modules: modules.map((module) => ({
+        name: module.name,
+        tools: allTools
+          .filter((t) => t.name.startsWith(`${module.name}:`))
+          .map((t) => t.name),
       })),
     };
   }

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -10,7 +10,7 @@ import { WebSocketServer, WebSocket } from 'ws';
 import { createServer, IncomingMessage, ServerResponse } from 'node:http';
 import type { ContentBlock } from 'membrane';
 import type { AgentFramework } from '../framework.js';
-import type { FrameworkEvent, InferenceRequest, QueueEvent } from '../types/index.js';
+import type { TraceEvent, ProcessEvent } from '../types/index.js';
 import type {
   ApiServerConfig,
   ApiRequest,
@@ -100,9 +100,9 @@ export class ApiServer {
       this.handleConnection(ws);
     });
 
-    // Subscribe to framework events
-    this.framework.on((event) => {
-      this.handleFrameworkEvent(event);
+    // Subscribe to trace events
+    this.framework.onTrace((event) => {
+      this.handleTraceEvent(event);
     });
 
     // Start listening
@@ -262,82 +262,18 @@ export class ApiServer {
   }
 
   // ==========================================================================
-  // Framework Event Handling
+  // Trace Event Handling
   // ==========================================================================
 
-  private handleFrameworkEvent(event: FrameworkEvent): void {
-    switch (event.type) {
-      case 'inference:start':
-        this.broadcast('inference:start', { agentName: event.agentName });
-        break;
-
-      case 'inference:complete':
-        this.broadcast('inference:complete', {
-          agentName: event.agentName,
-          durationMs: event.durationMs,
-        });
-        break;
-
-      case 'inference:error':
-        this.broadcast('inference:error', {
-          agentName: event.agentName,
-          error: event.error.message,
-        });
-        break;
-
-      case 'tool:start':
-        this.broadcast('tool:start', {
-          moduleName: event.moduleName,
-          toolName: event.toolName,
-          callId: event.callId,
-        });
-        break;
-
-      case 'tool:complete':
-        this.broadcast('tool:complete', {
-          moduleName: event.moduleName,
-          toolName: event.toolName,
-          callId: event.callId,
-          durationMs: event.durationMs,
-        });
-        break;
-
-      case 'tool:error':
-        this.broadcast('tool:error', {
-          moduleName: event.moduleName,
-          toolName: event.toolName,
-          callId: event.callId,
-          error: event.error.message,
-        });
-        break;
-
-      case 'message:added':
-        this.broadcast('message:added', {
-          messageId: event.messageId,
-          source: event.source,
-        });
-        break;
-
-      case 'queue:event':
-        // Don't broadcast raw queue events
-        break;
-
-      case 'event:handled':
-        this.broadcast('event:handled', {
-          timestamp: Date.now(),
-          event: event.event,
-          responses: event.responses,
-        });
-        break;
-
-      case 'module:start':
-        this.broadcast('module:started', { moduleName: event.moduleName });
-        break;
-
-      case 'module:stop':
-        this.broadcast('module:stopped', { moduleName: event.moduleName });
-        break;
+  private handleTraceEvent(event: TraceEvent): void {
+    // Skip process:received — clients don't need raw input events
+    if (event.type === 'process:received') {
+      return;
     }
+
+    // Broadcast all other trace events directly — no translation needed
+    // TraceEvents are already serializable (error is string, not Error)
+    this.broadcast(event.type, event);
   }
 
   // ==========================================================================
@@ -431,7 +367,7 @@ export class ApiServer {
       content: params.content,
       triggerInference: params.triggerInference ?? true,
       targetAgents: params.targetAgents,
-    } as QueueEvent);
+    } as ProcessEvent);
 
     return { messageId: 'pending' }; // TODO: return actual ID
   }
@@ -460,7 +396,7 @@ export class ApiServer {
       type: 'api:inference-request',
       agentName: params?.agentName,
       reason: params?.reason,
-    } as QueueEvent);
+    } as ProcessEvent);
 
     return { queued: true };
   }
@@ -732,7 +668,7 @@ export class ApiServer {
   // ==========================================================================
 
   private async cmdEventsTail(params?: EventsTailParams): Promise<{ entries: unknown[] }> {
-    const entries = this.framework.tailEventLogs(
+    const entries = this.framework.tailProcessLogs(
       params?.count ?? 10,
       params?.eventType
     );
@@ -745,16 +681,16 @@ export class ApiServer {
       throw new Error('sequence is required');
     }
 
-    const entry = this.framework.getEventLog(params.sequence);
+    const entry = this.framework.getProcessLog(params.sequence);
     if (!entry) {
-      throw new Error(`Event log not found: ${params.sequence}`);
+      throw new Error(`Process log not found: ${params.sequence}`);
     }
 
     return { entry };
   }
 
   private async cmdEventsSearch(params?: EventsSearchParams): Promise<unknown> {
-    const result = this.framework.queryEventLogs({
+    const result = this.framework.queryProcessLogs({
       eventType: params?.eventType,
       moduleName: params?.moduleName,
       limit: params?.limit,
@@ -771,13 +707,13 @@ export class ApiServer {
     const types = params?.types ?? ['*'];
     const limit = params?.limit ?? 100;
 
-    // Get historical events from the event log
-    const eventEntries = this.framework.tailEventLogs(limit);
+    // Get historical events from the process log
+    const processEntries = this.framework.tailProcessLogs(limit);
 
-    // Convert EventLogEntry to PersistedEvent format
-    const history: PersistedEvent[] = eventEntries.map((item) => {
+    // Convert ProcessLogEntry to PersistedEvent format
+    const history: PersistedEvent[] = processEntries.map((item) => {
       const { sequence, entry } = item;
-      const event = entry.event;
+      const event = entry.processEvent;
       const timestamp = entry.timestamp;
 
       // Extract agent/module info from event if available

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -87,7 +87,8 @@ export type ApiCommand =
   // Event logs
   | 'events.tail'
   | 'events.inspect'
-  | 'events.search';
+  | 'events.search'
+  | 'events.subscribe';
 
 // ============================================================================
 // Command Parameters
@@ -222,6 +223,34 @@ export interface EventsSearchParams {
   offset?: number;
   /** Regex pattern to match against log content */
   pattern?: string;
+}
+
+export interface EventsSubscribeParams {
+  /** Event type patterns to subscribe to (e.g., 'inference:*', 'tool:*') */
+  types?: string[];
+  /** Maximum number of historical events to return (default: 100) */
+  limit?: number;
+}
+
+export interface PersistedEvent {
+  /** Unique event ID */
+  id: string;
+  /** Sequence number in the event log */
+  sequence?: number;
+  /** Event timestamp */
+  timestamp: number;
+  /** Event type */
+  type: string;
+  /** Event payload */
+  payload: unknown;
+  /** Source of the event */
+  source: string;
+  /** ID of event that caused this one */
+  causedBy?: string;
+  /** Agent name (if applicable) */
+  agentName?: string;
+  /** Module name (if applicable) */
+  moduleName?: string;
 }
 
 // --- Subscription Parameters ---

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -83,7 +83,11 @@ export type ApiCommand =
   // Inference logs
   | 'inference.tail'
   | 'inference.inspect'
-  | 'inference.search';
+  | 'inference.search'
+  // Event logs
+  | 'events.tail'
+  | 'events.inspect'
+  | 'events.search';
 
 // ============================================================================
 // Command Parameters
@@ -193,6 +197,33 @@ export interface InferenceSearchParams {
   errorsOnly?: boolean;
 }
 
+// --- Event Log Parameters ---
+
+export interface EventsTailParams {
+  /** Number of recent entries to return (default: 10) */
+  count?: number;
+  /** Filter by event type */
+  eventType?: string;
+}
+
+export interface EventsInspectParams {
+  /** Sequence number of the log entry to inspect */
+  sequence: number;
+}
+
+export interface EventsSearchParams {
+  /** Filter by event type */
+  eventType?: string;
+  /** Filter by module name */
+  moduleName?: string;
+  /** Maximum number of results (default: 20) */
+  limit?: number;
+  /** Skip first N results for pagination (default: 0) */
+  offset?: number;
+  /** Regex pattern to match against log content */
+  pattern?: string;
+}
+
 // --- Subscription Parameters ---
 
 export interface StoreSubscribeParams {
@@ -295,6 +326,7 @@ export type ApiEventType =
   | 'tool:start'
   | 'tool:complete'
   | 'tool:error'
+  | 'event:handled'
   | 'speech'
   | 'message:added'
   | 'message:edited'

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -348,25 +348,24 @@ export interface StateInfo {
 // ============================================================================
 
 export type ApiEventType =
-  // Framework events
-  | 'inference:start'
-  | 'inference:complete'
-  | 'inference:error'
-  | 'tool:start'
-  | 'tool:complete'
-  | 'tool:error'
-  | 'event:handled'
-  | 'speech'
+  // Trace events (from framework)
+  | 'process:completed'
+  | 'inference:started'
+  | 'inference:completed'
+  | 'inference:failed'
+  | 'tool:started'
+  | 'tool:completed'
+  | 'tool:failed'
+  | 'module:added'
+  | 'module:removed'
   | 'message:added'
-  | 'message:edited'
-  | 'message:removed'
+  // Server-specific events
+  | 'connected'
+  | 'speech'
   // Branch events
   | 'branch:switched'
   | 'branch:created'
   | 'branch:deleted'
-  // Module events
-  | 'module:started'
-  | 'module:stopped'
   // Store subscription events
   | 'store:record'
   | 'store:state_snapshot'

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -650,7 +650,8 @@ export class AgentFramework {
     const responses: ModuleProcessResponse[] = [];
     for (const module of this.moduleRegistry.getAllModules()) {
       try {
-        const response = await module.onProcess(event);
+        const processState = this.moduleRegistry.createProcessState(module.name);
+        const response = await module.onProcess(event, processState);
         responses.push({ moduleName: module.name, response });
       } catch (error) {
         console.error(`Module ${module.name} error handling process event:`, error);
@@ -658,8 +659,8 @@ export class AgentFramework {
     }
 
     // Apply responses
-    for (const { response } of responses) {
-      await this.applyProcessResponse(response, event);
+    for (const { moduleName, response } of responses) {
+      await this.applyProcessResponse(response, event, moduleName);
     }
 
     // Handle tool results specially
@@ -692,7 +693,11 @@ export class AgentFramework {
     }
   }
 
-  private async applyProcessResponse(response: EventResponse, event: ProcessEvent): Promise<void> {
+  private async applyProcessResponse(
+    response: EventResponse,
+    event: ProcessEvent,
+    moduleName: string
+  ): Promise<void> {
     // Add messages
     if (response.addMessages) {
       for (const msg of response.addMessages) {
@@ -713,6 +718,11 @@ export class AgentFramework {
       for (const id of response.removeMessages) {
         this.removeMessage(id);
       }
+    }
+
+    // Apply module state update atomically with message operations
+    if (response.stateUpdate !== undefined) {
+      this.moduleRegistry.setModuleState(moduleName, response.stateUpdate);
     }
 
     // Queue inference requests

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -17,6 +17,7 @@ import type {
   InferenceLogSummary,
   QueueEvent,
   EventResponse,
+  ModuleEventResponse,
   ToolCall,
   ToolResult,
   AgentConfig,
@@ -471,19 +472,19 @@ export class AgentFramework {
   }
 
   private async handleEvent(event: QueueEvent): Promise<void> {
-    // Dispatch to all modules
-    const responses: EventResponse[] = [];
+    // Dispatch to all modules, tracking responses with module names
+    const responses: ModuleEventResponse[] = [];
     for (const module of this.moduleRegistry.getAllModules()) {
       try {
         const response = await module.onEvent(event);
-        responses.push(response);
+        responses.push({ moduleName: module.name, response });
       } catch (error) {
         console.error(`Module ${module.name} error handling event:`, error);
       }
     }
 
     // Apply responses
-    for (const response of responses) {
+    for (const { response } of responses) {
       await this.applyEventResponse(response, event);
     }
 
@@ -505,6 +506,9 @@ export class AgentFramework {
         }
       }
     }
+
+    // Emit for observability
+    this.emit({ type: 'event:handled', event, responses });
   }
 
   private async applyEventResponse(response: EventResponse, event: QueueEvent): Promise<void> {

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -15,6 +15,11 @@ import type {
   InferenceLogQueryResult,
   InferenceLogEntryWithId,
   InferenceLogSummary,
+  EventLogEntry,
+  EventLogQuery,
+  EventLogQueryResult,
+  EventLogEntryWithId,
+  EventLogSummary,
   QueueEvent,
   EventResponse,
   ModuleEventResponse,
@@ -31,6 +36,7 @@ import { ModuleRegistry } from './module-registry.js';
 
 const FRAMEWORK_STATE_ID = 'framework/state';
 const INFERENCE_LOG_ID = 'framework/inference-log';
+const EVENT_LOG_ID = 'framework/event-log';
 
 /**
  * Default inference policy - infer if any request exists for the agent.
@@ -417,6 +423,136 @@ export class AgentFramework {
   }
 
   /**
+   * Query event logs.
+   * Returns entries with summary info (doesn't resolve blobs).
+   */
+  queryEventLogs(query?: EventLogQuery): EventLogQueryResult {
+    const limit = query?.limit ?? 50;
+    const offset = query?.offset ?? 0;
+    const pattern = query?.pattern ? new RegExp(query.pattern, 'i') : null;
+
+    const allEntries: EventLogEntryWithId[] = [];
+    const stateInfo = this.store.listStates().find((s) => s.id === EVENT_LOG_ID);
+
+    if (stateInfo) {
+      const data = this.store.getStateJson(EVENT_LOG_ID);
+      if (Array.isArray(data)) {
+        for (let i = 0; i < data.length; i++) {
+          const entry = data[i] as EventLogEntry;
+
+          // Build summary
+          const responsesIsBlob = !!(
+            entry.responses &&
+            typeof entry.responses === 'object' &&
+            'blobId' in entry.responses
+          );
+
+          // Extract summary info from responses if not a blob
+          let moduleCount = 0;
+          const modulesRequestingInference: string[] = [];
+          const modulesAddingMessages: string[] = [];
+
+          if (!responsesIsBlob && Array.isArray(entry.responses)) {
+            moduleCount = entry.responses.length;
+            for (const { moduleName, response } of entry.responses) {
+              if (response.requestInference) {
+                modulesRequestingInference.push(moduleName);
+              }
+              if (response.addMessages?.length) {
+                modulesAddingMessages.push(moduleName);
+              }
+            }
+          }
+
+          const summary: EventLogSummary = {
+            timestamp: entry.timestamp,
+            eventType: entry.event.type,
+            moduleCount,
+            modulesRequestingInference,
+            modulesAddingMessages,
+            responsesIsBlob,
+          };
+
+          allEntries.push({ sequence: i, entry, summary });
+        }
+      }
+    }
+
+    // Filter entries
+    let filtered = allEntries;
+
+    if (query?.eventType) {
+      filtered = filtered.filter((e) => e.entry.event.type === query.eventType);
+    }
+
+    if (query?.moduleName) {
+      filtered = filtered.filter((e) => {
+        if (e.summary?.responsesIsBlob) return false;
+        const responses = e.entry.responses as ModuleEventResponse[];
+        return responses.some((r) => r.moduleName === query.moduleName);
+      });
+    }
+
+    if (pattern) {
+      filtered = filtered.filter((e) => {
+        const content = JSON.stringify(e.summary);
+        return pattern.test(content);
+      });
+    }
+
+    // Reverse to get most recent first
+    filtered = filtered.reverse();
+
+    // Paginate
+    const total = filtered.length;
+    const paged = filtered.slice(offset, offset + limit);
+
+    return {
+      entries: paged,
+      total,
+      hasMore: offset + limit < total,
+    };
+  }
+
+  /**
+   * Get a specific event log entry by sequence number.
+   * Resolves blob references to full content.
+   */
+  getEventLog(sequence: number, resolveBlobs = true): EventLogEntryWithId | null {
+    const data = this.store.getStateJson(EVENT_LOG_ID);
+    if (Array.isArray(data) && sequence >= 0 && sequence < data.length) {
+      const entry = data[sequence] as EventLogEntry;
+
+      if (resolveBlobs && entry.responses && typeof entry.responses === 'object' && 'blobId' in entry.responses) {
+        const resolved = { ...entry };
+        const blob = this.store.getBlob((entry.responses as { blobId: string }).blobId);
+        if (blob) {
+          try {
+            resolved.responses = JSON.parse(blob.toString());
+          } catch {
+            resolved.responses = [];
+          }
+        }
+        return { sequence, entry: resolved };
+      }
+
+      return { sequence, entry };
+    }
+    return null;
+  }
+
+  /**
+   * Get the most recent event logs (tail).
+   */
+  tailEventLogs(count = 10, eventType?: string): EventLogEntryWithId[] {
+    const result = this.queryEventLogs({
+      limit: count,
+      eventType,
+    });
+    return result.entries;
+  }
+
+  /**
    * Run until the queue is empty and all agents are idle.
    * Useful for testing.
    */
@@ -507,8 +643,9 @@ export class AgentFramework {
       }
     }
 
-    // Emit for observability
+    // Emit for observability and log to Chronicle
     this.emit({ type: 'event:handled', event, responses });
+    this.logEvent(event, responses);
   }
 
   private async applyEventResponse(response: EventResponse, event: QueueEvent): Promise<void> {
@@ -700,6 +837,30 @@ export class AgentFramework {
     const entries = Array.isArray(data) ? data : [];
     entries.push(entryToStore);
     this.store.setStateJson(INFERENCE_LOG_ID, entries);
+  }
+
+  private logEvent(event: QueueEvent, responses: ModuleEventResponse[]): void {
+    const entry: EventLogEntry = {
+      timestamp: Date.now(),
+      event,
+      responses,
+    };
+
+    // Blob threshold: 10KB
+    const BLOB_THRESHOLD = 10000;
+
+    const entryToStore = { ...entry };
+    const responsesJson = JSON.stringify(responses);
+    if (responsesJson.length > BLOB_THRESHOLD) {
+      const blobId = this.store.storeBlob(Buffer.from(responsesJson), 'application/json');
+      entryToStore.responses = { blobId };
+    }
+
+    // Append to the event log state
+    const data = this.store.getStateJson(EVENT_LOG_ID);
+    const entries = Array.isArray(data) ? data : [];
+    entries.push(entryToStore);
+    this.store.setStateJson(EVENT_LOG_ID, entries);
   }
 
   private dispatchToolCall(agentName: string, call: ToolCall): void {

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -683,10 +683,8 @@ export class AgentFramework {
 
     const durationMs = Date.now() - startTime;
 
-    // Emit trace for observability (if enabled)
-    if (this.processLoggingBroadcast) {
-      this.emitTrace({ type: 'process:completed', processEvent: event, responses, durationMs });
-    }
+    // Always emit trace for observability (UI needs this)
+    this.emitTrace({ type: 'process:completed', processEvent: event, responses, durationMs });
 
     // Log to Chronicle (if enabled)
     if (this.processLoggingPersist) {

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -86,6 +86,8 @@ export class AgentFramework {
   private eventListeners: FrameworkEventListener[] = [];
   private syncIntervalMs: number;
   private syncTimer: ReturnType<typeof setInterval> | null = null;
+  private eventLoggingPersist: boolean;
+  private eventLoggingBroadcast: boolean;
 
   private constructor(
     store: JsStore,
@@ -93,7 +95,9 @@ export class AgentFramework {
     membrane: Membrane,
     inferencePolicy: InferencePolicy,
     errorPolicy: ErrorPolicy,
-    syncIntervalMs: number
+    syncIntervalMs: number,
+    eventLoggingPersist: boolean,
+    eventLoggingBroadcast: boolean
   ) {
     this.store = store;
     this.ownsStore = ownsStore;
@@ -101,6 +105,8 @@ export class AgentFramework {
     this.inferencePolicy = inferencePolicy;
     this.errorPolicy = errorPolicy;
     this.syncIntervalMs = syncIntervalMs;
+    this.eventLoggingPersist = eventLoggingPersist;
+    this.eventLoggingBroadcast = eventLoggingBroadcast;
     this.queue = new EventQueueImpl();
 
     // Initialize module registry with callbacks
@@ -148,13 +154,33 @@ export class AgentFramework {
       // Already registered
     }
 
+    // Event logging config (default: disabled)
+    const eventLoggingPersist = config.eventLogging?.persist ?? false;
+    const eventLoggingBroadcast = config.eventLogging?.broadcast ?? false;
+
+    // Register event log state only if persistence is enabled
+    if (eventLoggingPersist) {
+      try {
+        store.registerState({
+          id: EVENT_LOG_ID,
+          strategy: 'append_log',
+          deltaSnapshotEvery: 100,
+          fullSnapshotEvery: 20,
+        });
+      } catch {
+        // Already registered
+      }
+    }
+
     const framework = new AgentFramework(
       store,
       ownsStore,
       config.membrane,
       config.inferencePolicy ?? new DefaultInferencePolicy(),
       config.errorPolicy ?? new DefaultErrorPolicy(),
-      config.syncIntervalMs ?? DEFAULT_SYNC_INTERVAL_MS
+      config.syncIntervalMs ?? DEFAULT_SYNC_INTERVAL_MS,
+      eventLoggingPersist,
+      eventLoggingBroadcast
     );
 
     // Create agents
@@ -277,6 +303,16 @@ export class AgentFramework {
    */
   getAllAgents(): Agent[] {
     return Array.from(this.agents.values());
+  }
+
+  /**
+   * Check if event logging is enabled.
+   */
+  isEventLoggingEnabled(): { persist: boolean; broadcast: boolean } {
+    return {
+      persist: this.eventLoggingPersist,
+      broadcast: this.eventLoggingBroadcast,
+    };
   }
 
   /**
@@ -643,9 +679,15 @@ export class AgentFramework {
       }
     }
 
-    // Emit for observability and log to Chronicle
-    this.emit({ type: 'event:handled', event, responses });
-    this.logEvent(event, responses);
+    // Emit for observability (if enabled)
+    if (this.eventLoggingBroadcast) {
+      this.emit({ type: 'event:handled', event, responses });
+    }
+
+    // Log to Chronicle (if enabled)
+    if (this.eventLoggingPersist) {
+      this.logEvent(event, responses);
+    }
   }
 
   private async applyEventResponse(response: EventResponse, event: QueueEvent): Promise<void> {

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -306,6 +306,20 @@ export class AgentFramework {
   }
 
   /**
+   * Get all registered modules.
+   */
+  getAllModules(): Module[] {
+    return this.moduleRegistry.getAllModules();
+  }
+
+  /**
+   * Get all available tools from all modules.
+   */
+  getAllTools(): import('./types/index.js').ToolDefinition[] {
+    return this.moduleRegistry.getAllTools();
+  }
+
+  /**
    * Check if process logging is enabled.
    */
   isProcessLoggingEnabled(): { persist: boolean; broadcast: boolean } {

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -8,21 +8,21 @@ import type {
   ErrorPolicy,
   ErrorAction,
   FrameworkState,
-  FrameworkEvent,
-  FrameworkEventListener,
+  TraceEvent,
+  TraceEventListener,
   InferenceLogEntry,
   InferenceLogQuery,
   InferenceLogQueryResult,
   InferenceLogEntryWithId,
   InferenceLogSummary,
-  EventLogEntry,
-  EventLogQuery,
-  EventLogQueryResult,
-  EventLogEntryWithId,
-  EventLogSummary,
-  QueueEvent,
+  ProcessLogEntry,
+  ProcessLogQuery,
+  ProcessLogQueryResult,
+  ProcessLogEntryWithId,
+  ProcessLogSummary,
+  ProcessEvent,
   EventResponse,
-  ModuleEventResponse,
+  ModuleProcessResponse,
   ToolCall,
   ToolResult,
   AgentConfig,
@@ -30,13 +30,13 @@ import type {
   AgentState,
   Module,
 } from './types/index.js';
-import { EventQueueImpl } from './queue.js';
+import { ProcessQueueImpl } from './queue.js';
 import { Agent } from './agent.js';
 import { ModuleRegistry } from './module-registry.js';
 
 const FRAMEWORK_STATE_ID = 'framework/state';
 const INFERENCE_LOG_ID = 'framework/inference-log';
-const EVENT_LOG_ID = 'framework/event-log';
+const PROCESS_LOG_ID = 'framework/process-log';
 
 /**
  * Default inference policy - infer if any request exists for the agent.
@@ -75,7 +75,7 @@ export class AgentFramework {
   private store: JsStore;
   private ownsStore: boolean;
   private membrane: Membrane;
-  private queue: EventQueueImpl;
+  private queue: ProcessQueueImpl;
   private agents: Map<string, Agent> = new Map();
   private moduleRegistry: ModuleRegistry;
   private inferencePolicy: InferencePolicy;
@@ -83,11 +83,11 @@ export class AgentFramework {
   private pendingRequests: InferenceRequest[] = [];
   private running = false;
   private loopPromise: Promise<void> | null = null;
-  private eventListeners: FrameworkEventListener[] = [];
+  private traceListeners: TraceEventListener[] = [];
   private syncIntervalMs: number;
   private syncTimer: ReturnType<typeof setInterval> | null = null;
-  private eventLoggingPersist: boolean;
-  private eventLoggingBroadcast: boolean;
+  private processLoggingPersist: boolean;
+  private processLoggingBroadcast: boolean;
 
   private constructor(
     store: JsStore,
@@ -96,8 +96,8 @@ export class AgentFramework {
     inferencePolicy: InferencePolicy,
     errorPolicy: ErrorPolicy,
     syncIntervalMs: number,
-    eventLoggingPersist: boolean,
-    eventLoggingBroadcast: boolean
+    processLoggingPersist: boolean,
+    processLoggingBroadcast: boolean
   ) {
     this.store = store;
     this.ownsStore = ownsStore;
@@ -105,9 +105,9 @@ export class AgentFramework {
     this.inferencePolicy = inferencePolicy;
     this.errorPolicy = errorPolicy;
     this.syncIntervalMs = syncIntervalMs;
-    this.eventLoggingPersist = eventLoggingPersist;
-    this.eventLoggingBroadcast = eventLoggingBroadcast;
-    this.queue = new EventQueueImpl();
+    this.processLoggingPersist = processLoggingPersist;
+    this.processLoggingBroadcast = processLoggingBroadcast;
+    this.queue = new ProcessQueueImpl();
 
     // Initialize module registry with callbacks
     this.moduleRegistry = new ModuleRegistry(store, this.queue, {
@@ -154,15 +154,15 @@ export class AgentFramework {
       // Already registered
     }
 
-    // Event logging config (default: disabled)
-    const eventLoggingPersist = config.eventLogging?.persist ?? false;
-    const eventLoggingBroadcast = config.eventLogging?.broadcast ?? false;
+    // Process logging config (default: disabled)
+    const processLoggingPersist = config.processLogging?.persist ?? false;
+    const processLoggingBroadcast = config.processLogging?.broadcast ?? false;
 
-    // Register event log state only if persistence is enabled
-    if (eventLoggingPersist) {
+    // Register process log state only if persistence is enabled
+    if (processLoggingPersist) {
       try {
         store.registerState({
-          id: EVENT_LOG_ID,
+          id: PROCESS_LOG_ID,
           strategy: 'append_log',
           deltaSnapshotEvery: 100,
           fullSnapshotEvery: 20,
@@ -179,8 +179,8 @@ export class AgentFramework {
       config.inferencePolicy ?? new DefaultInferencePolicy(),
       config.errorPolicy ?? new DefaultErrorPolicy(),
       config.syncIntervalMs ?? DEFAULT_SYNC_INTERVAL_MS,
-      eventLoggingPersist,
-      eventLoggingBroadcast
+      processLoggingPersist,
+      processLoggingBroadcast
     );
 
     // Create agents
@@ -251,27 +251,27 @@ export class AgentFramework {
   }
 
   /**
-   * Push an event to the queue.
+   * Push a process event to the queue.
    */
-  pushEvent(event: QueueEvent): void {
+  pushEvent(event: ProcessEvent): void {
     this.queue.push(event);
-    this.emit({ type: 'queue:event', event });
+    this.emitTrace({ type: 'process:received', processEvent: event });
   }
 
   /**
-   * Add an event listener.
+   * Add a trace event listener for observability.
    */
-  on(listener: FrameworkEventListener): void {
-    this.eventListeners.push(listener);
+  onTrace(listener: TraceEventListener): void {
+    this.traceListeners.push(listener);
   }
 
   /**
-   * Remove an event listener.
+   * Remove a trace event listener.
    */
-  off(listener: FrameworkEventListener): void {
-    const index = this.eventListeners.indexOf(listener);
+  offTrace(listener: TraceEventListener): void {
+    const index = this.traceListeners.indexOf(listener);
     if (index >= 0) {
-      this.eventListeners.splice(index, 1);
+      this.traceListeners.splice(index, 1);
     }
   }
 
@@ -280,7 +280,7 @@ export class AgentFramework {
    */
   async addModule(module: Module): Promise<void> {
     await this.moduleRegistry.addModule(module);
-    this.emit({ type: 'module:start', moduleName: module.name });
+    this.emitTrace({ type: 'module:added', moduleName: module.name });
   }
 
   /**
@@ -288,7 +288,7 @@ export class AgentFramework {
    */
   async removeModule(name: string): Promise<void> {
     await this.moduleRegistry.removeModule(name);
-    this.emit({ type: 'module:stop', moduleName: name });
+    this.emitTrace({ type: 'module:removed', moduleName: name });
   }
 
   /**
@@ -306,12 +306,12 @@ export class AgentFramework {
   }
 
   /**
-   * Check if event logging is enabled.
+   * Check if process logging is enabled.
    */
-  isEventLoggingEnabled(): { persist: boolean; broadcast: boolean } {
+  isProcessLoggingEnabled(): { persist: boolean; broadcast: boolean } {
     return {
-      persist: this.eventLoggingPersist,
-      broadcast: this.eventLoggingBroadcast,
+      persist: this.processLoggingPersist,
+      broadcast: this.processLoggingBroadcast,
     };
   }
 
@@ -459,22 +459,22 @@ export class AgentFramework {
   }
 
   /**
-   * Query event logs.
+   * Query process logs.
    * Returns entries with summary info (doesn't resolve blobs).
    */
-  queryEventLogs(query?: EventLogQuery): EventLogQueryResult {
+  queryProcessLogs(query?: ProcessLogQuery): ProcessLogQueryResult {
     const limit = query?.limit ?? 50;
     const offset = query?.offset ?? 0;
     const pattern = query?.pattern ? new RegExp(query.pattern, 'i') : null;
 
-    const allEntries: EventLogEntryWithId[] = [];
-    const stateInfo = this.store.listStates().find((s) => s.id === EVENT_LOG_ID);
+    const allEntries: ProcessLogEntryWithId[] = [];
+    const stateInfo = this.store.listStates().find((s) => s.id === PROCESS_LOG_ID);
 
     if (stateInfo) {
-      const data = this.store.getStateJson(EVENT_LOG_ID);
+      const data = this.store.getStateJson(PROCESS_LOG_ID);
       if (Array.isArray(data)) {
         for (let i = 0; i < data.length; i++) {
-          const entry = data[i] as EventLogEntry;
+          const entry = data[i] as ProcessLogEntry;
 
           // Build summary
           const responsesIsBlob = !!(
@@ -500,9 +500,9 @@ export class AgentFramework {
             }
           }
 
-          const summary: EventLogSummary = {
+          const summary: ProcessLogSummary = {
             timestamp: entry.timestamp,
-            eventType: entry.event.type,
+            eventType: entry.processEvent.type,
             moduleCount,
             modulesRequestingInference,
             modulesAddingMessages,
@@ -518,13 +518,13 @@ export class AgentFramework {
     let filtered = allEntries;
 
     if (query?.eventType) {
-      filtered = filtered.filter((e) => e.entry.event.type === query.eventType);
+      filtered = filtered.filter((e) => e.entry.processEvent.type === query.eventType);
     }
 
     if (query?.moduleName) {
       filtered = filtered.filter((e) => {
         if (e.summary?.responsesIsBlob) return false;
-        const responses = e.entry.responses as ModuleEventResponse[];
+        const responses = e.entry.responses as ModuleProcessResponse[];
         return responses.some((r) => r.moduleName === query.moduleName);
       });
     }
@@ -551,13 +551,13 @@ export class AgentFramework {
   }
 
   /**
-   * Get a specific event log entry by sequence number.
+   * Get a specific process log entry by sequence number.
    * Resolves blob references to full content.
    */
-  getEventLog(sequence: number, resolveBlobs = true): EventLogEntryWithId | null {
-    const data = this.store.getStateJson(EVENT_LOG_ID);
+  getProcessLog(sequence: number, resolveBlobs = true): ProcessLogEntryWithId | null {
+    const data = this.store.getStateJson(PROCESS_LOG_ID);
     if (Array.isArray(data) && sequence >= 0 && sequence < data.length) {
-      const entry = data[sequence] as EventLogEntry;
+      const entry = data[sequence] as ProcessLogEntry;
 
       if (resolveBlobs && entry.responses && typeof entry.responses === 'object' && 'blobId' in entry.responses) {
         const resolved = { ...entry };
@@ -578,10 +578,10 @@ export class AgentFramework {
   }
 
   /**
-   * Get the most recent event logs (tail).
+   * Get the most recent process logs (tail).
    */
-  tailEventLogs(count = 10, eventType?: string): EventLogEntryWithId[] {
-    const result = this.queryEventLogs({
+  tailProcessLogs(count = 10, eventType?: string): ProcessLogEntryWithId[] {
+    const result = this.queryProcessLogs({
       limit: count,
       eventType,
     });
@@ -627,11 +627,11 @@ export class AgentFramework {
   }
 
   private async processNextEvent(): Promise<void> {
-    // Try to get next event (with timeout to check running flag)
+    // Try to get next process event (with timeout to check running flag)
     const event = this.queue.tryPop();
 
     if (event) {
-      await this.handleEvent(event);
+      await this.handleProcessEvent(event);
     }
 
     // Check for inference requests
@@ -643,21 +643,23 @@ export class AgentFramework {
     }
   }
 
-  private async handleEvent(event: QueueEvent): Promise<void> {
+  private async handleProcessEvent(event: ProcessEvent): Promise<void> {
+    const startTime = Date.now();
+
     // Dispatch to all modules, tracking responses with module names
-    const responses: ModuleEventResponse[] = [];
+    const responses: ModuleProcessResponse[] = [];
     for (const module of this.moduleRegistry.getAllModules()) {
       try {
-        const response = await module.onEvent(event);
+        const response = await module.onProcess(event);
         responses.push({ moduleName: module.name, response });
       } catch (error) {
-        console.error(`Module ${module.name} error handling event:`, error);
+        console.error(`Module ${module.name} error handling process event:`, error);
       }
     }
 
     // Apply responses
     for (const { response } of responses) {
-      await this.applyEventResponse(response, event);
+      await this.applyProcessResponse(response, event);
     }
 
     // Handle tool results specially
@@ -679,23 +681,25 @@ export class AgentFramework {
       }
     }
 
-    // Emit for observability (if enabled)
-    if (this.eventLoggingBroadcast) {
-      this.emit({ type: 'event:handled', event, responses });
+    const durationMs = Date.now() - startTime;
+
+    // Emit trace for observability (if enabled)
+    if (this.processLoggingBroadcast) {
+      this.emitTrace({ type: 'process:completed', processEvent: event, responses, durationMs });
     }
 
     // Log to Chronicle (if enabled)
-    if (this.eventLoggingPersist) {
-      this.logEvent(event, responses);
+    if (this.processLoggingPersist) {
+      this.logProcessEvent(event, responses);
     }
   }
 
-  private async applyEventResponse(response: EventResponse, event: QueueEvent): Promise<void> {
+  private async applyProcessResponse(response: EventResponse, event: ProcessEvent): Promise<void> {
     // Add messages
     if (response.addMessages) {
       for (const msg of response.addMessages) {
         const id = this.addMessage(msg.participant, msg.content, msg.metadata);
-        this.emit({ type: 'message:added', messageId: id, source: event.type });
+        this.emitTrace({ type: 'message:added', messageId: id, source: event.type });
       }
     }
 
@@ -777,7 +781,7 @@ export class AgentFramework {
   }
 
   private async runAgentInference(agent: Agent, attempt = 0, trigger?: InferenceRequest): Promise<void> {
-    this.emit({ type: 'inference:start', agentName: agent.name });
+    this.emitTrace({ type: 'inference:started', agentName: agent.name });
     const startTime = Date.now();
     const requestId = `${agent.name}-${startTime}-${Math.random().toString(36).slice(2, 8)}`;
 
@@ -786,7 +790,10 @@ export class AgentFramework {
       const result = await agent.runInference(tools);
 
       const durationMs = Date.now() - startTime;
-      this.emit({ type: 'inference:complete', agentName: agent.name, durationMs });
+      const tokenUsage = result.usage
+        ? { input: result.usage.inputTokens, output: result.usage.outputTokens }
+        : undefined;
+      this.emitTrace({ type: 'inference:completed', agentName: agent.name, durationMs, tokenUsage });
 
       // Log successful inference
       this.logInference({
@@ -827,7 +834,12 @@ export class AgentFramework {
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
       const durationMs = Date.now() - startTime;
-      this.emit({ type: 'inference:error', agentName: agent.name, error: err });
+      this.emitTrace({
+        type: 'inference:failed',
+        agentName: agent.name,
+        error: err.message,
+        stack: err.stack,
+      });
 
       // Log failed inference
       this.logInference({
@@ -881,10 +893,10 @@ export class AgentFramework {
     this.store.setStateJson(INFERENCE_LOG_ID, entries);
   }
 
-  private logEvent(event: QueueEvent, responses: ModuleEventResponse[]): void {
-    const entry: EventLogEntry = {
+  private logProcessEvent(event: ProcessEvent, responses: ModuleProcessResponse[]): void {
+    const entry: ProcessLogEntry = {
       timestamp: Date.now(),
-      event,
+      processEvent: event,
       responses,
     };
 
@@ -898,21 +910,21 @@ export class AgentFramework {
       entryToStore.responses = { blobId };
     }
 
-    // Append to the event log state
-    const data = this.store.getStateJson(EVENT_LOG_ID);
+    // Append to the process log state
+    const data = this.store.getStateJson(PROCESS_LOG_ID);
     const entries = Array.isArray(data) ? data : [];
     entries.push(entryToStore);
-    this.store.setStateJson(EVENT_LOG_ID, entries);
+    this.store.setStateJson(PROCESS_LOG_ID, entries);
   }
 
   private dispatchToolCall(agentName: string, call: ToolCall): void {
     const colonIndex = call.name.indexOf(':');
     const moduleName = colonIndex >= 0 ? call.name.substring(0, colonIndex) : 'unknown';
 
-    this.emit({
-      type: 'tool:start',
-      moduleName,
-      toolName: call.name,
+    this.emitTrace({
+      type: 'tool:started',
+      module: moduleName,
+      tool: call.name,
       callId: call.id,
     });
 
@@ -923,10 +935,10 @@ export class AgentFramework {
       .handleToolCall(call)
       .then((result) => {
         const durationMs = Date.now() - startTime;
-        this.emit({
-          type: 'tool:complete',
-          moduleName,
-          toolName: call.name,
+        this.emitTrace({
+          type: 'tool:completed',
+          module: moduleName,
+          tool: call.name,
           callId: call.id,
           durationMs,
         });
@@ -942,12 +954,13 @@ export class AgentFramework {
       })
       .catch((error) => {
         const err = error instanceof Error ? error : new Error(String(error));
-        this.emit({
-          type: 'tool:error',
-          moduleName,
-          toolName: call.name,
+        this.emitTrace({
+          type: 'tool:failed',
+          module: moduleName,
+          tool: call.name,
           callId: call.id,
-          error: err,
+          error: err.message,
+          stack: err.stack,
         });
 
         // Push error result to queue
@@ -1010,12 +1023,17 @@ export class AgentFramework {
     };
   }
 
-  private emit(event: FrameworkEvent): void {
-    for (const listener of this.eventListeners) {
+  private emitTrace(event: { type: TraceEvent['type']; [key: string]: unknown }): void {
+    const traceEvent = {
+      ...event,
+      timestamp: Date.now(),
+    } as TraceEvent;
+
+    for (const listener of this.traceListeners) {
       try {
-        listener(event);
+        listener(traceEvent);
       } catch (error) {
-        console.error('Event listener error:', error);
+        console.error('Trace listener error:', error);
       }
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ export * from './types/index.js';
 // Core classes
 export { AgentFramework } from './framework.js';
 export { Agent } from './agent.js';
-export { EventQueueImpl } from './queue.js';
+export { ProcessQueueImpl } from './queue.js';
 export { ModuleRegistry } from './module-registry.js';
 
 // Built-in modules

--- a/src/module-registry.ts
+++ b/src/module-registry.ts
@@ -4,6 +4,7 @@ import type { MessageId, MessageMetadata } from '@connectome/context-manager';
 import type {
   Module,
   ModuleContext,
+  ProcessState,
   ProcessQueue,
   ToolDefinition,
   ToolCall,
@@ -129,6 +130,39 @@ export class ModuleRegistry {
    */
   getAllModules(): Module[] {
     return Array.from(this.modules.values());
+  }
+
+  /**
+   * Set state for a module by name.
+   * Used by the framework to apply stateUpdate from EventResponse atomically.
+   */
+  setModuleState(moduleName: string, state: unknown): void {
+    const ctx = this.moduleContexts.get(moduleName);
+    if (ctx) {
+      ctx.setState(state);
+    }
+  }
+
+  /**
+   * Get state for a module by name.
+   */
+  getModuleState<T>(moduleName: string): T | null {
+    const ctx = this.moduleContexts.get(moduleName);
+    if (ctx) {
+      return ctx.getState<T>();
+    }
+    return null;
+  }
+
+  /**
+   * Create a ProcessState for a module to use during event processing.
+   */
+  createProcessState(moduleName: string): ProcessState {
+    const ctx = this.moduleContexts.get(moduleName);
+    if (!ctx) {
+      throw new Error(`Module ${moduleName} not found`);
+    }
+    return new ProcessStateImpl(moduleName, ctx, this);
   }
 
   /**
@@ -398,5 +432,44 @@ class ModuleContextImpl implements ModuleContext {
       ...currentState,
       externalIdMap: Object.fromEntries(this.externalIdMap),
     });
+  }
+}
+
+/**
+ * Implementation of ProcessState - read-only state access during event processing.
+ */
+class ProcessStateImpl implements ProcessState {
+  private moduleName: string;
+  private ctx: ModuleContextImpl;
+  private registry: ModuleRegistry;
+
+  constructor(moduleName: string, ctx: ModuleContextImpl, registry: ModuleRegistry) {
+    this.moduleName = moduleName;
+    this.ctx = ctx;
+    this.registry = registry;
+  }
+
+  getState<T>(): T | null {
+    return this.ctx.getState<T>();
+  }
+
+  getModuleState<T>(name: string): T | null {
+    return this.registry.getModuleState<T>(name);
+  }
+
+  findMessageByExternalId(source: string, externalId: string): MessageId | null {
+    return this.ctx.findMessageByExternalId(source, externalId);
+  }
+
+  getAgents(): AgentInfo[] {
+    return this.ctx.getAgents();
+  }
+
+  getActiveTools(): ToolDefinition[] {
+    return this.ctx.getActiveTools();
+  }
+
+  get queue(): ProcessQueue {
+    return this.ctx.queue;
   }
 }

--- a/src/module-registry.ts
+++ b/src/module-registry.ts
@@ -4,7 +4,7 @@ import type { MessageId, MessageMetadata } from '@connectome/context-manager';
 import type {
   Module,
   ModuleContext,
-  EventQueue,
+  ProcessQueue,
   ToolDefinition,
   ToolCall,
   ToolResult,
@@ -35,7 +35,7 @@ export class ModuleRegistry {
   private moduleContexts: Map<string, ModuleContextImpl> = new Map();
   private speechHandlers: SpeechHandler[] = [];
   private store: JsStore;
-  private queue: EventQueue;
+  private queue: ProcessQueue;
   private getAgents: () => Agent[];
   private addMessageFn: (participant: string, content: ContentBlock[], metadata?: MessageMetadata) => MessageId;
   private editMessageFn: (id: MessageId, content: ContentBlock[]) => void;
@@ -43,7 +43,7 @@ export class ModuleRegistry {
 
   constructor(
     store: JsStore,
-    queue: EventQueue,
+    queue: ProcessQueue,
     options: {
       getAgents: () => Agent[];
       addMessage: (participant: string, content: ContentBlock[], metadata?: MessageMetadata) => MessageId;
@@ -275,7 +275,7 @@ class ModuleContextImpl implements ModuleContext {
   private moduleName: string;
   private store: JsStore;
   private stateId: string;
-  readonly queue: EventQueue;
+  readonly queue: ProcessQueue;
   private registry: ModuleRegistry;
   readonly isRestart: boolean;
   private getAgentsFn: () => Agent[];
@@ -290,7 +290,7 @@ class ModuleContextImpl implements ModuleContext {
     moduleName: string,
     store: JsStore,
     stateId: string,
-    queue: EventQueue,
+    queue: ProcessQueue,
     registry: ModuleRegistry,
     isRestart: boolean,
     getAgents: () => Agent[],

--- a/src/modules/api/index.ts
+++ b/src/modules/api/index.ts
@@ -8,6 +8,7 @@
 import type {
   Module,
   ModuleContext,
+  ProcessState,
   ProcessEvent,
   EventResponse,
   ToolCall,
@@ -42,7 +43,7 @@ export class ApiModule implements Module {
     return { success: false, error: 'Unknown tool' };
   }
 
-  async onProcess(event: ProcessEvent): Promise<EventResponse> {
+  async onProcess(event: ProcessEvent, _state: ProcessState): Promise<EventResponse> {
     if (!event.type.startsWith('api:')) {
       return {};
     }

--- a/src/modules/api/index.ts
+++ b/src/modules/api/index.ts
@@ -8,7 +8,7 @@
 import type {
   Module,
   ModuleContext,
-  QueueEvent,
+  ProcessEvent,
   EventResponse,
   ToolCall,
   ToolResult,
@@ -42,7 +42,7 @@ export class ApiModule implements Module {
     return { success: false, error: 'Unknown tool' };
   }
 
-  async onEvent(event: QueueEvent): Promise<EventResponse> {
+  async onProcess(event: ProcessEvent): Promise<EventResponse> {
     if (!event.type.startsWith('api:')) {
       return {};
     }

--- a/src/modules/discord/discord-js-client.ts
+++ b/src/modules/discord/discord-js-client.ts
@@ -76,6 +76,11 @@ export class DiscordJsClient implements DiscordClientInterface {
   }
 
   private shouldHandleMessage(message: Message): boolean {
+    // Never process our own messages (prevents feedback loop)
+    if (message.author.id === this.client.user?.id) {
+      return false;
+    }
+
     // Filter by guild
     if (this.guildIds && this.guildIds.length > 0) {
       if (!message.guildId || !this.guildIds.includes(message.guildId)) {

--- a/src/modules/discord/index.ts
+++ b/src/modules/discord/index.ts
@@ -11,6 +11,7 @@ import type { ContentBlock } from 'membrane';
 import type {
   Module,
   ModuleContext,
+  ProcessState,
   ProcessEvent,
   EventResponse,
   ToolDefinition,
@@ -24,6 +25,9 @@ import type {
   ConversationContext,
   DiscordClientInterface,
   DiscordMessageData,
+  DiscordMessageEvent,
+  DiscordEditEvent,
+  DiscordDeleteEvent,
   SendInput,
   SendDMInput,
   ReplyInput,
@@ -33,6 +37,9 @@ import type {
   CreateThreadInput,
   SetReplyContextInput,
 } from './types.js';
+
+// Re-export event types for consumers who want to handle them
+export type { DiscordMessageEvent, DiscordEditEvent, DiscordDeleteEvent } from './types.js';
 
 export * from './types.js';
 export { DiscordJsClient, type DiscordJsClientConfig } from './discord-js-client.js';
@@ -277,26 +284,85 @@ export class DiscordModule implements Module {
     }
   }
 
-  async onProcess(event: ProcessEvent): Promise<EventResponse> {
-    // Handle external messages from Discord - trigger inference
-    if (event.type === 'external-message' && event.source === 'discord') {
-      // The message was already added to conversation in handleDiscordMessage()
-      // Here we just signal that inference should run
-      const targetAgents = event.targetAgents;
+  async onProcess(event: ProcessEvent, state: ProcessState): Promise<EventResponse> {
+    // Handle new Discord message
+    if (event.type === 'discord:message') {
+      const msg = event as DiscordMessageEvent;
+      const currentState = state.getState<DiscordModuleState>() ?? {
+        connectedGuilds: [],
+        conversations: {},
+        rateLimits: {},
+      };
+
+      // Build conversation state update
+      const convKey = msg.guildId ? `${msg.guildId}:${msg.channelId}` : `dm:${msg.authorId}`;
+      const conversation: ConversationContext = {
+        channelId: msg.channelId,
+        userId: msg.authorId,
+        guildId: msg.guildId ?? null,
+        replyToMessageId: msg.discordMessageId,
+        lastActivity: Date.now(),
+      };
+
+      // Update in-memory reply context (ephemeral, not persisted)
+      this.replyContexts.set('default', conversation);
+
+      // Build new state with updated conversation
+      const newState: DiscordModuleState = {
+        ...currentState,
+        conversations: {
+          ...currentState.conversations,
+          [convKey]: conversation,
+        },
+      };
+
+      // Update local state reference for tool handlers
+      this.state = newState;
+
+      // Return declarative response - framework applies all writes atomically
       return {
-        requestInference: targetAgents ?? true,
+        addMessages: [
+          {
+            participant: msg.authorName,
+            content: [{ type: 'text', text: msg.content }],
+            metadata: {
+              external: { source: 'discord', id: msg.discordMessageId },
+              timestamp: msg.timestamp,
+            },
+          },
+        ],
+        stateUpdate: newState,
+        requestInference: true,
       };
     }
 
-    // Handle message edits and deletes that came through the queue
-    if (event.type === 'message-edited' && event.source === 'discord') {
-      // Already handled by the Discord event handlers
-      return {};
+    // Handle Discord message edit
+    if (event.type === 'discord:edit') {
+      const edit = event as DiscordEditEvent;
+      const internalId = state.findMessageByExternalId('discord', edit.discordMessageId);
+      if (!internalId) {
+        return {};
+      }
+      return {
+        editMessages: [
+          {
+            messageId: internalId,
+            content: [{ type: 'text', text: edit.newContent }],
+          },
+        ],
+      };
     }
 
-    if (event.type === 'message-removed' && event.source === 'discord') {
-      // Already handled by the Discord event handlers
-      return {};
+    // Handle Discord message delete
+    if (event.type === 'discord:delete') {
+      const del = event as DiscordDeleteEvent;
+      const internalId = state.findMessageByExternalId('discord', del.discordMessageId);
+      if (!internalId) {
+        return {};
+      }
+      return {
+        removeMessages: [internalId],
+      };
     }
 
     return {};
@@ -372,81 +438,39 @@ export class DiscordModule implements Module {
       return;
     }
 
-    // Create/update conversation context
-    const convKey = message.guildId
-      ? `${message.guildId}:${message.channelId}`
-      : `dm:${message.authorId}`;
-
-    const conversation: ConversationContext = {
-      channelId: message.channelId,
-      userId: message.authorId,
-      guildId: message.guildId,
-      replyToMessageId: message.id,
-      lastActivity: Date.now(),
-    };
-
-    this.state.conversations[convKey] = conversation;
-    this.replyContexts.set('default', conversation);
-
-    // Add message to conversation
-    const messageId = this.ctx.addMessage(
-      message.authorName,
-      [{ type: 'text', text: message.content }],
-      {
-        external: { source: 'discord', id: message.id },
-        timestamp: message.timestamp,
-      }
-    );
-
-    // Push event to queue
+    // Only queue the event - all state writes happen in onProcess()
     this.ctx.queue.push({
-      type: 'external-message',
-      source: 'discord',
+      type: 'discord:message',
+      discordMessageId: message.id,
+      channelId: message.channelId,
+      guildId: message.guildId,
+      authorId: message.authorId,
+      authorName: message.authorName,
       content: message.content,
-      metadata: {
-        messageId,
-        discordMessageId: message.id,
-        channelId: message.channelId,
-        guildId: message.guildId,
-        authorId: message.authorId,
-        authorName: message.authorName,
-      },
-      triggerInference: true,
+      timestamp: message.timestamp,
+      attachments: message.attachments,
     });
-
-    // Save state
-    this.ctx.setState(this.state);
   }
 
   private handleDiscordMessageEdit(messageId: string, newContent: string): void {
     if (!this.ctx) return;
 
-    const internalId = this.ctx.findMessageByExternalId('discord', messageId);
-    if (internalId) {
-      this.ctx.editMessage(internalId, [{ type: 'text', text: newContent }]);
-
-      this.ctx.queue.push({
-        type: 'message-edited',
-        source: 'discord',
-        messageId: internalId,
-        newContent: [{ type: 'text', text: newContent }],
-      });
-    }
+    // Only queue the event - state writes happen in onProcess()
+    this.ctx.queue.push({
+      type: 'discord:edit',
+      discordMessageId: messageId,
+      newContent,
+    });
   }
 
   private handleDiscordMessageDelete(messageId: string): void {
     if (!this.ctx) return;
 
-    const internalId = this.ctx.findMessageByExternalId('discord', messageId);
-    if (internalId) {
-      this.ctx.removeMessage(internalId);
-
-      this.ctx.queue.push({
-        type: 'message-removed',
-        source: 'discord',
-        messageId: internalId,
-      });
-    }
+    // Only queue the event - state writes happen in onProcess()
+    this.ctx.queue.push({
+      type: 'discord:delete',
+      discordMessageId: messageId,
+    });
   }
 
   // ==========================================================================

--- a/src/modules/discord/index.ts
+++ b/src/modules/discord/index.ts
@@ -35,6 +35,7 @@ import type {
 } from './types.js';
 
 export * from './types.js';
+export { DiscordJsClient, type DiscordJsClientConfig } from './discord-js-client.js';
 
 const DEFAULT_CONFIG: Partial<DiscordModuleConfig> = {
   handleDMs: true,

--- a/src/modules/discord/index.ts
+++ b/src/modules/discord/index.ts
@@ -11,7 +11,7 @@ import type { ContentBlock } from 'membrane';
 import type {
   Module,
   ModuleContext,
-  QueueEvent,
+  ProcessEvent,
   EventResponse,
   ToolDefinition,
   ToolCall,
@@ -277,7 +277,7 @@ export class DiscordModule implements Module {
     }
   }
 
-  async onEvent(event: QueueEvent): Promise<EventResponse> {
+  async onProcess(event: ProcessEvent): Promise<EventResponse> {
     // Handle external messages from Discord - trigger inference
     if (event.type === 'external-message' && event.source === 'discord') {
       // The message was already added to conversation in handleDiscordMessage()

--- a/src/modules/discord/types.ts
+++ b/src/modules/discord/types.ts
@@ -217,6 +217,51 @@ export interface DiscordAttachment {
 }
 
 // ============================================================================
+// Discord Custom Events (for event queue)
+// ============================================================================
+
+/**
+ * Custom event for new Discord messages.
+ * Pushed to queue by callbacks, processed in onProcess().
+ */
+export interface DiscordMessageEvent {
+  type: 'discord:message';
+  discordMessageId: string;
+  channelId: string;
+  guildId: string | null;
+  authorId: string;
+  authorName: string;
+  content: string;
+  timestamp: Date;
+  attachments: DiscordAttachment[];
+  [key: string]: unknown; // Required for CustomEvent compatibility
+}
+
+/**
+ * Custom event for Discord message edits.
+ */
+export interface DiscordEditEvent {
+  type: 'discord:edit';
+  discordMessageId: string;
+  newContent: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Custom event for Discord message deletions.
+ */
+export interface DiscordDeleteEvent {
+  type: 'discord:delete';
+  discordMessageId: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Union of all Discord custom events.
+ */
+export type DiscordEvent = DiscordMessageEvent | DiscordEditEvent | DiscordDeleteEvent;
+
+// ============================================================================
 // Discord Client Interface (for abstraction)
 // ============================================================================
 

--- a/src/modules/files/index.ts
+++ b/src/modules/files/index.ts
@@ -12,6 +12,7 @@ import type { JsStore } from 'chronicle';
 import type {
   Module,
   ModuleContext,
+  ProcessState,
   ProcessEvent,
   EventResponse,
   ToolDefinition,
@@ -286,7 +287,7 @@ export class FilesModule implements Module {
     }
   }
 
-  async onProcess(_event: ProcessEvent): Promise<EventResponse> {
+  async onProcess(_event: ProcessEvent, _state: ProcessState): Promise<EventResponse> {
     // Files module doesn't handle process events
     return {};
   }

--- a/src/modules/files/index.ts
+++ b/src/modules/files/index.ts
@@ -12,7 +12,7 @@ import type { JsStore } from 'chronicle';
 import type {
   Module,
   ModuleContext,
-  QueueEvent,
+  ProcessEvent,
   EventResponse,
   ToolDefinition,
   ToolCall,
@@ -286,8 +286,8 @@ export class FilesModule implements Module {
     }
   }
 
-  async onEvent(_event: QueueEvent): Promise<EventResponse> {
-    // Files module doesn't handle events
+  async onProcess(_event: ProcessEvent): Promise<EventResponse> {
+    // Files module doesn't handle process events
     return {};
   }
 

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -20,7 +20,8 @@ export type {
   SyncInput,
 } from './files/index.js';
 
-export { DiscordModule } from './discord/index.js';
+export { DiscordModule, DiscordJsClient } from './discord/index.js';
+export type { DiscordJsClientConfig } from './discord/index.js';
 export type {
   DiscordModuleConfig,
   DiscordModuleState,

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -1,18 +1,18 @@
-import type { QueueEvent, EventQueue as IEventQueue } from './types/index.js';
+import type { ProcessEvent, ProcessQueue } from './types/index.js';
 
 /**
- * Event queue for the framework.
- * Events from external sources and internal operations flow through here.
+ * Process queue for the framework.
+ * ProcessEvents from external sources and internal operations flow through here.
  */
-export class EventQueueImpl implements IEventQueue {
-  private queue: QueueEvent[] = [];
-  private waiters: Array<(event: QueueEvent) => void> = [];
+export class ProcessQueueImpl implements ProcessQueue {
+  private queue: ProcessEvent[] = [];
+  private waiters: Array<(event: ProcessEvent) => void> = [];
   private closed = false;
 
   /**
-   * Push an event to the queue.
+   * Push a process event to the queue.
    */
-  push(event: QueueEvent): void {
+  push(event: ProcessEvent): void {
     if (this.closed) {
       throw new Error('Queue is closed');
     }
@@ -27,10 +27,10 @@ export class EventQueueImpl implements IEventQueue {
   }
 
   /**
-   * Pop the next event from the queue.
+   * Pop the next process event from the queue.
    * Returns immediately if an event is available, otherwise waits.
    */
-  async pop(): Promise<QueueEvent> {
+  async pop(): Promise<ProcessEvent> {
     if (this.closed) {
       throw new Error('Queue is closed');
     }
@@ -48,17 +48,17 @@ export class EventQueueImpl implements IEventQueue {
   }
 
   /**
-   * Try to pop an event without waiting.
+   * Try to pop a process event without waiting.
    * Returns null if queue is empty.
    */
-  tryPop(): QueueEvent | null {
+  tryPop(): ProcessEvent | null {
     return this.queue.shift() ?? null;
   }
 
   /**
-   * Peek at the next event without removing it.
+   * Peek at the next process event without removing it.
    */
-  peek(): QueueEvent | null {
+  peek(): ProcessEvent | null {
     return this.queue[0] ?? null;
   }
 

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -12,12 +12,14 @@ export type ToolCallId = string;
 export type ToolDefinition = MembraneToolDefinition;
 
 /**
- * Events that flow through the framework's event queue.
+ * Events that flow through the framework's processing queue.
+ *
+ * ProcessEvents represent work to be done — modules respond to them via onProcess().
+ * They are distinct from TraceEvents, which are observability-only notifications.
  *
  * Modules can define their own namespaced events (e.g., 'api:message', 'discord:reaction').
- * The framework dispatches all events to modules via onEvent().
  */
-export type QueueEvent =
+export type ProcessEvent =
   | ExternalMessageEvent
   | ToolResultEvent
   | TimerFiredEvent

--- a/src/types/framework.ts
+++ b/src/types/framework.ts
@@ -1,8 +1,16 @@
 import type { JsStore } from 'chronicle';
 import type { Membrane } from 'membrane';
-import type { Module } from './module.js';
+import type { Module, EventResponse } from './module.js';
 import type { AgentConfig, InferenceRequest } from './agent.js';
 import type { QueueEvent } from './events.js';
+
+/**
+ * A module's response to an event, tagged with the module name.
+ */
+export interface ModuleEventResponse {
+  moduleName: string;
+  response: EventResponse;
+}
 
 /**
  * Configuration for the agent framework.
@@ -101,7 +109,8 @@ export type FrameworkEvent =
   | { type: 'tool:error'; moduleName: string; toolName: string; callId: string; error: Error }
   | { type: 'module:start'; moduleName: string }
   | { type: 'module:stop'; moduleName: string }
-  | { type: 'queue:event'; event: QueueEvent };
+  | { type: 'queue:event'; event: QueueEvent }
+  | { type: 'event:handled'; event: QueueEvent; responses: ModuleEventResponse[] };
 
 /**
  * Listener for framework events.

--- a/src/types/framework.ts
+++ b/src/types/framework.ts
@@ -140,3 +140,64 @@ export interface InferenceLogEntry {
   /** Stop reason from the model */
   stopReason?: string;
 }
+
+/**
+ * Entry in the event log - records a processed event with all module responses.
+ */
+export interface EventLogEntry {
+  timestamp: number;
+  /** The event that was processed */
+  event: QueueEvent;
+  /** Responses from all modules, or blob ID if large */
+  responses: ModuleEventResponse[] | { blobId: string };
+}
+
+/**
+ * Query options for event logs.
+ */
+export interface EventLogQuery {
+  /** Filter by event type */
+  eventType?: string;
+  /** Filter by module name (modules that responded) */
+  moduleName?: string;
+  /** Max number of logs to return */
+  limit?: number;
+  /** Skip first N logs (for pagination) */
+  offset?: number;
+  /** Search pattern for content (regex) */
+  pattern?: string;
+}
+
+/**
+ * Result from querying event logs.
+ */
+export interface EventLogQueryResult {
+  entries: EventLogEntryWithId[];
+  total: number;
+  hasMore: boolean;
+}
+
+/**
+ * Event log entry with Chronicle sequence ID.
+ */
+export interface EventLogEntryWithId {
+  sequence: number;
+  entry: EventLogEntry;
+  /** Summary for display without resolving blobs */
+  summary?: EventLogSummary;
+}
+
+/**
+ * Summary view of an event log (without full responses).
+ */
+export interface EventLogSummary {
+  timestamp: number;
+  eventType: string;
+  moduleCount: number;
+  /** Modules that requested inference */
+  modulesRequestingInference: string[];
+  /** Modules that added messages */
+  modulesAddingMessages: string[];
+  /** Whether responses are stored as blob */
+  responsesIsBlob: boolean;
+}

--- a/src/types/framework.ts
+++ b/src/types/framework.ts
@@ -13,6 +13,16 @@ export interface ModuleEventResponse {
 }
 
 /**
+ * Configuration for event logging.
+ */
+export interface EventLoggingConfig {
+  /** Persist event logs to Chronicle (default: false) */
+  persist?: boolean;
+  /** Broadcast event:handled via WebSocket/emit (default: false) */
+  broadcast?: boolean;
+}
+
+/**
  * Configuration for the agent framework.
  */
 export interface FrameworkConfig {
@@ -39,6 +49,9 @@ export interface FrameworkConfig {
 
   /** Interval for periodic store sync in milliseconds (default: 1000ms, 0 to disable) */
   syncIntervalMs?: number;
+
+  /** Event logging configuration (default: disabled) */
+  eventLogging?: EventLoggingConfig;
 }
 
 /**

--- a/src/types/framework.ts
+++ b/src/types/framework.ts
@@ -2,23 +2,26 @@ import type { JsStore } from 'chronicle';
 import type { Membrane } from 'membrane';
 import type { Module, EventResponse } from './module.js';
 import type { AgentConfig, InferenceRequest } from './agent.js';
-import type { QueueEvent } from './events.js';
+import type { ProcessEvent } from './events.js';
+
+// Re-export trace types
+export type { TraceEvent, TraceEventListener } from './trace.js';
 
 /**
- * A module's response to an event, tagged with the module name.
+ * A module's response to a process event, tagged with the module name.
  */
-export interface ModuleEventResponse {
+export interface ModuleProcessResponse {
   moduleName: string;
   response: EventResponse;
 }
 
 /**
- * Configuration for event logging.
+ * Configuration for process event logging.
  */
-export interface EventLoggingConfig {
-  /** Persist event logs to Chronicle (default: false) */
+export interface ProcessLoggingConfig {
+  /** Persist process logs to Chronicle (default: false) */
   persist?: boolean;
-  /** Broadcast event:handled via WebSocket/emit (default: false) */
+  /** Broadcast process:completed trace events (default: false) */
   broadcast?: boolean;
 }
 
@@ -50,8 +53,8 @@ export interface FrameworkConfig {
   /** Interval for periodic store sync in milliseconds (default: 1000ms, 0 to disable) */
   syncIntervalMs?: number;
 
-  /** Event logging configuration (default: disabled) */
-  eventLogging?: EventLoggingConfig;
+  /** Process logging configuration (default: disabled) */
+  processLogging?: ProcessLoggingConfig;
 }
 
 /**
@@ -90,7 +93,7 @@ export interface ErrorPolicy {
  */
 export type ErrorAction =
   | { retry: true; delayMs: number }
-  | { retry: false; emit?: QueueEvent };
+  | { retry: false; emit?: ProcessEvent };
 
 /**
  * Framework state exposed to policies.
@@ -108,27 +111,6 @@ export interface FrameworkState {
   /** Current queue depth */
   queueDepth: number;
 }
-
-/**
- * Events emitted by the framework for observability.
- */
-export type FrameworkEvent =
-  | { type: 'message:added'; messageId: string; source: string }
-  | { type: 'inference:start'; agentName: string }
-  | { type: 'inference:complete'; agentName: string; durationMs: number }
-  | { type: 'inference:error'; agentName: string; error: Error }
-  | { type: 'tool:start'; moduleName: string; toolName: string; callId: string }
-  | { type: 'tool:complete'; moduleName: string; toolName: string; callId: string; durationMs: number }
-  | { type: 'tool:error'; moduleName: string; toolName: string; callId: string; error: Error }
-  | { type: 'module:start'; moduleName: string }
-  | { type: 'module:stop'; moduleName: string }
-  | { type: 'queue:event'; event: QueueEvent }
-  | { type: 'event:handled'; event: QueueEvent; responses: ModuleEventResponse[] };
-
-/**
- * Listener for framework events.
- */
-export type FrameworkEventListener = (event: FrameworkEvent) => void;
 
 /**
  * Entry in the inference log.
@@ -155,21 +137,21 @@ export interface InferenceLogEntry {
 }
 
 /**
- * Entry in the event log - records a processed event with all module responses.
+ * Entry in the process log - records a processed event with all module responses.
  */
-export interface EventLogEntry {
+export interface ProcessLogEntry {
   timestamp: number;
-  /** The event that was processed */
-  event: QueueEvent;
+  /** The process event that was handled */
+  processEvent: ProcessEvent;
   /** Responses from all modules, or blob ID if large */
-  responses: ModuleEventResponse[] | { blobId: string };
+  responses: ModuleProcessResponse[] | { blobId: string };
 }
 
 /**
- * Query options for event logs.
+ * Query options for process logs.
  */
-export interface EventLogQuery {
-  /** Filter by event type */
+export interface ProcessLogQuery {
+  /** Filter by process event type */
   eventType?: string;
   /** Filter by module name (modules that responded) */
   moduleName?: string;
@@ -182,28 +164,28 @@ export interface EventLogQuery {
 }
 
 /**
- * Result from querying event logs.
+ * Result from querying process logs.
  */
-export interface EventLogQueryResult {
-  entries: EventLogEntryWithId[];
+export interface ProcessLogQueryResult {
+  entries: ProcessLogEntryWithId[];
   total: number;
   hasMore: boolean;
 }
 
 /**
- * Event log entry with Chronicle sequence ID.
+ * Process log entry with Chronicle sequence ID.
  */
-export interface EventLogEntryWithId {
+export interface ProcessLogEntryWithId {
   sequence: number;
-  entry: EventLogEntry;
+  entry: ProcessLogEntry;
   /** Summary for display without resolving blobs */
-  summary?: EventLogSummary;
+  summary?: ProcessLogSummary;
 }
 
 /**
- * Summary view of an event log (without full responses).
+ * Summary view of a process log (without full responses).
  */
-export interface EventLogSummary {
+export interface ProcessLogSummary {
   timestamp: number;
   eventType: string;
   moduleCount: number;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,4 +2,5 @@ export * from './events.js';
 export * from './module.js';
 export * from './agent.js';
 export * from './framework.js';
+export * from './trace.js';
 export * from './inference-log.js';

--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -36,8 +36,11 @@ export interface Module {
   /**
    * Handle a process event from the queue.
    * Return response indicating what actions to take.
+   *
+   * @param event - The event to process
+   * @param state - Read-only state snapshot for accessing module state and lookups
    */
-  onProcess(event: ProcessEvent): Promise<EventResponse>;
+  onProcess(event: ProcessEvent, state: ProcessState): Promise<EventResponse>;
 
   /**
    * Handle agent speech (if registered as speech handler).
@@ -131,6 +134,42 @@ export interface ModuleContext {
 }
 
 /**
+ * Read-only state snapshot provided to modules during event processing.
+ * State writes happen via EventResponse, not through this interface.
+ */
+export interface ProcessState {
+  /**
+   * Get this module's state.
+   */
+  getState<T>(): T | null;
+
+  /**
+   * Get another module's state by name.
+   */
+  getModuleState<T>(name: string): T | null;
+
+  /**
+   * Find a message by external ID.
+   */
+  findMessageByExternalId(source: string, externalId: string): MessageId | null;
+
+  /**
+   * Get info about all agents.
+   */
+  getAgents(): AgentInfo[];
+
+  /**
+   * Get all currently available tools.
+   */
+  getActiveTools(): ToolDefinition[];
+
+  /**
+   * Queue for emitting follow-up events.
+   */
+  readonly queue: ProcessQueue;
+}
+
+/**
  * Reference to an external system's ID.
  */
 export interface ExternalIdRef {
@@ -193,6 +232,13 @@ export interface EventResponse {
    * Signal that this module's tools have changed.
    */
   toolsChanged?: boolean;
+
+  /**
+   * Module state update. Applied atomically with message operations.
+   * The framework will call setState() with this value after applying
+   * message changes, ensuring consistent state.
+   */
+  stateUpdate?: unknown;
 }
 
 /**

--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -1,6 +1,6 @@
 import type { ContentBlock } from 'membrane';
 import type { MessageId, MessageMetadata } from '@connectome/context-manager';
-import type { QueueEvent, ToolDefinition, ToolCall, ToolResult } from './events.js';
+import type { ProcessEvent, ToolDefinition, ToolCall, ToolResult } from './events.js';
 
 /**
  * A pluggable module that provides capabilities to the framework.
@@ -34,10 +34,10 @@ export interface Module {
   handleToolCall(call: ToolCall): Promise<ToolResult>;
 
   /**
-   * Handle an event from the queue.
+   * Handle a process event from the queue.
    * Return response indicating what actions to take.
    */
-  onEvent(event: QueueEvent): Promise<EventResponse>;
+  onProcess(event: ProcessEvent): Promise<EventResponse>;
 
   /**
    * Handle agent speech (if registered as speech handler).
@@ -66,9 +66,9 @@ export interface ModuleContext {
   setState<T>(state: T): void;
 
   /**
-   * Event queue for pushing events from external listeners.
+   * Process queue for pushing events from external listeners.
    */
-  readonly queue: EventQueue;
+  readonly queue: ProcessQueue;
 
   /**
    * Get another module by name.
@@ -139,13 +139,13 @@ export interface ExternalIdRef {
 }
 
 /**
- * Event queue interface for modules.
+ * Process queue interface for modules.
  */
-export interface EventQueue {
+export interface ProcessQueue {
   /**
-   * Push an event to the queue.
+   * Push a process event to the queue.
    */
-  push(event: QueueEvent): void;
+  push(event: ProcessEvent): void;
 }
 
 /**

--- a/src/types/trace.ts
+++ b/src/types/trace.ts
@@ -1,0 +1,90 @@
+import type { ProcessEvent } from './events.js';
+import type { ModuleProcessResponse } from './framework.js';
+
+/**
+ * Base for all trace events.
+ * TraceEvents are observability-only — they NEVER drive logic.
+ */
+export interface TraceEventBase {
+  /** When this trace was emitted */
+  timestamp: number;
+  /** Optional correlation ID for distributed tracing */
+  traceId?: string;
+}
+
+/**
+ * Observability events emitted by the framework.
+ * Subscribe via framework.onTrace() to monitor system behavior.
+ *
+ * These are purely informational — use them for:
+ * - UI updates (showing inference progress, tool execution)
+ * - Logging and debugging
+ * - Metrics and monitoring
+ * - Broadcasting to WebSocket clients
+ *
+ * They should NEVER be used to drive application logic.
+ * For that, use ProcessEvent via the event queue.
+ */
+export type TraceEvent =
+  // Process lifecycle
+  | (TraceEventBase & { type: 'process:received'; processEvent: ProcessEvent })
+  | (TraceEventBase & {
+      type: 'process:completed';
+      processEvent: ProcessEvent;
+      responses: ModuleProcessResponse[];
+      durationMs: number;
+    })
+
+  // Inference lifecycle
+  | (TraceEventBase & { type: 'inference:started'; agentName: string })
+  | (TraceEventBase & {
+      type: 'inference:completed';
+      agentName: string;
+      durationMs: number;
+      tokenUsage?: { input: number; output: number };
+    })
+  | (TraceEventBase & {
+      type: 'inference:failed';
+      agentName: string;
+      error: string;
+      stack?: string;
+    })
+
+  // Tool lifecycle
+  | (TraceEventBase & {
+      type: 'tool:started';
+      module: string;
+      tool: string;
+      callId: string;
+    })
+  | (TraceEventBase & {
+      type: 'tool:completed';
+      module: string;
+      tool: string;
+      callId: string;
+      durationMs: number;
+    })
+  | (TraceEventBase & {
+      type: 'tool:failed';
+      module: string;
+      tool: string;
+      callId: string;
+      error: string;
+      stack?: string;
+    })
+
+  // Module lifecycle
+  | (TraceEventBase & { type: 'module:added'; moduleName: string })
+  | (TraceEventBase & { type: 'module:removed'; moduleName: string })
+
+  // Message lifecycle
+  | (TraceEventBase & {
+      type: 'message:added';
+      messageId: string;
+      source: string;
+    });
+
+/**
+ * Listener for trace events.
+ */
+export type TraceEventListener = (event: TraceEvent) => void;

--- a/test/framework.test.ts
+++ b/test/framework.test.ts
@@ -31,9 +31,17 @@ function createMockResponse(
   content: ContentBlock[],
   stopReason: NormalizedResponse['stopReason'] = 'end_turn'
 ): NormalizedResponse {
+  const rawText = content
+    .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
+    .map((b) => b.text)
+    .join('');
+
   return {
     content,
     stopReason,
+    rawAssistantText: rawText,
+    toolCalls: [],
+    toolResults: [],
     usage: { inputTokens: 10, outputTokens: 5 },
     details: {
       stop: { reason: stopReason, wasTruncated: false },

--- a/test/framework.test.ts
+++ b/test/framework.test.ts
@@ -11,6 +11,7 @@ import type { NormalizedRequest, NormalizedResponse, ContentBlock } from 'membra
 import type {
   Module,
   ModuleContext,
+  ProcessState,
   ProcessEvent,
   EventResponse,
   ToolDefinition,
@@ -121,7 +122,7 @@ class TestModule implements Module {
     return { success: false, error: 'Unknown tool', isError: true };
   }
 
-  async onProcess(event: ProcessEvent): Promise<EventResponse> {
+  async onProcess(event: ProcessEvent, _state: ProcessState): Promise<EventResponse> {
     this.events.push(event);
 
     // Handle external message by requesting inference
@@ -362,10 +363,10 @@ describe('AgentFramework', () => {
 
     await framework.runUntilIdle();
 
-    assert.ok(events.includes('queue:event'));
-    assert.ok(events.includes('inference:start'));
-    assert.ok(events.includes('inference:complete'));
-    assert.ok(events.includes('message:added'));
+    assert.ok(events.includes('process:received'), 'Should emit process:received');
+    assert.ok(events.includes('inference:started'), 'Should emit inference:started');
+    assert.ok(events.includes('inference:completed'), 'Should emit inference:completed');
+    assert.ok(events.includes('message:added'), 'Should emit message:added');
 
     await framework.stop();
     rmSync(tempDir, { recursive: true });

--- a/test/framework.test.ts
+++ b/test/framework.test.ts
@@ -11,13 +11,13 @@ import type { NormalizedRequest, NormalizedResponse, ContentBlock } from 'membra
 import type {
   Module,
   ModuleContext,
-  QueueEvent,
+  ProcessEvent,
   EventResponse,
   ToolDefinition,
   ToolCall,
   ToolResult,
 } from '../src/index.js';
-import { AgentFramework, EventQueueImpl } from '../src/index.js';
+import { AgentFramework, ProcessQueueImpl } from '../src/index.js';
 
 // ============================================================================
 // Mock Membrane - minimal interface that framework needs
@@ -85,7 +85,7 @@ class MockMembrane implements MinimalMembrane {
 class TestModule implements Module {
   readonly name = 'test';
   ctx: ModuleContext | null = null;
-  events: QueueEvent[] = [];
+  events: ProcessEvent[] = [];
   toolCalls: ToolCall[] = [];
 
   async start(ctx: ModuleContext): Promise<void> {
@@ -121,7 +121,7 @@ class TestModule implements Module {
     return { success: false, error: 'Unknown tool', isError: true };
   }
 
-  async onEvent(event: QueueEvent): Promise<EventResponse> {
+  async onProcess(event: ProcessEvent): Promise<EventResponse> {
     this.events.push(event);
 
     // Handle external message by requesting inference
@@ -145,10 +145,10 @@ class TestModule implements Module {
 // Tests
 // ============================================================================
 
-describe('EventQueueImpl', () => {
+describe('ProcessQueueImpl', () => {
   it('should push and pop events', () => {
-    const queue = new EventQueueImpl();
-    const event: QueueEvent = {
+    const queue = new ProcessQueueImpl();
+    const event: ProcessEvent = {
       type: 'timer-fired',
       timerId: 'test',
       reason: 'test',
@@ -165,13 +165,13 @@ describe('EventQueueImpl', () => {
   });
 
   it('should return null when queue is empty', () => {
-    const queue = new EventQueueImpl();
+    const queue = new ProcessQueueImpl();
     assert.strictEqual(queue.tryPop(), null);
   });
 
   it('should peek without removing', () => {
-    const queue = new EventQueueImpl();
-    const event: QueueEvent = {
+    const queue = new ProcessQueueImpl();
+    const event: ProcessEvent = {
       type: 'timer-fired',
       timerId: 'test',
       reason: 'test',
@@ -183,7 +183,7 @@ describe('EventQueueImpl', () => {
   });
 
   it('should clear all events', () => {
-    const queue = new EventQueueImpl();
+    const queue = new ProcessQueueImpl();
     queue.push({ type: 'timer-fired', timerId: '1', reason: 'test' });
     queue.push({ type: 'timer-fired', timerId: '2', reason: 'test' });
 
@@ -192,7 +192,7 @@ describe('EventQueueImpl', () => {
   });
 
   it('should close and prevent further pushes', () => {
-    const queue = new EventQueueImpl();
+    const queue = new ProcessQueueImpl();
     queue.close();
 
     assert.throws(() => {
@@ -349,7 +349,7 @@ describe('AgentFramework', () => {
       modules: [testModule],
     });
 
-    framework.on((event) => {
+    framework.onTrace((event) => {
       events.push(event.type);
     });
 
@@ -494,7 +494,7 @@ describe('Module state persistence', () => {
       async handleToolCall(): Promise<ToolResult> {
         return { success: false, error: 'No tools', isError: true };
       }
-      async onEvent(): Promise<EventResponse> { return {}; }
+      async onProcess(): Promise<EventResponse> { return {}; }
     }
 
     const storePath = join(tempDir, 'state.chronicle');
@@ -538,7 +538,7 @@ describe('Module state persistence', () => {
       async handleToolCall(): Promise<ToolResult> {
         return { success: false, error: 'No tools', isError: true };
       }
-      async onEvent(): Promise<EventResponse> { return {}; }
+      async onProcess(): Promise<EventResponse> { return {}; }
     }
 
     const module = new IdTrackingModule();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,8 +13,13 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "composite": true
   },
   "include": ["src/**/*", "test/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist"],
+  "references": [
+    { "path": "../membrane" },
+    { "path": "../context-manager" }
+  ]
 }

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -3,15 +3,18 @@ import { onMounted, watch } from 'vue';
 import { useWebSocket } from './composables/useWebSocket';
 import { useEventsStore } from './stores/events';
 import { useAgentsStore } from './stores/agents';
+import { useEventLogsStore } from './stores/eventLogs';
 import EventTimeline from './components/EventTimeline.vue';
 import FilterPanel from './components/FilterPanel.vue';
 import AgentPanel from './components/AgentPanel.vue';
-import type { PersistedEvent, AgentInfo, BranchInfo } from './api/types';
+import EventLogPanel from './components/EventLogPanel.vue';
+import type { PersistedEvent, AgentInfo, BranchInfo, EventLogEntryWithId, ModuleEventResponse } from './api/types';
 
 const eventsStore = useEventsStore();
 const agentsStore = useAgentsStore();
+const eventLogsStore = useEventLogsStore();
 
-const { connected, error, send, on, off } = useWebSocket({
+const { connected, send, on } = useWebSocket({
   url: 'ws://localhost:8765/ws',
 });
 
@@ -25,6 +28,7 @@ watch(connected, (isConnected) => {
 
 async function loadInitialData() {
   eventsStore.setLoading(true);
+  eventLogsStore.setLoading(true);
   try {
     // Load agents
     const agentResult = await send<{ agents: AgentInfo[] }>('agent.list');
@@ -46,10 +50,22 @@ async function loadInitialData() {
     );
     eventsStore.setSubscriptions(subResult.subscribed);
     eventsStore.setEvents(subResult.history);
+
+    // Load historical event logs
+    try {
+      const eventLogsResult = await send<{ entries: EventLogEntryWithId[] }>(
+        'events.tail',
+        { count: 100 }
+      );
+      eventLogsStore.setHistoricalLogs(eventLogsResult.entries);
+    } catch (e) {
+      console.error('Failed to load event logs:', e);
+    }
   } catch (e) {
     eventsStore.setError(e instanceof Error ? e.message : String(e));
   } finally {
     eventsStore.setLoading(false);
+    eventLogsStore.setLoading(false);
   }
 }
 
@@ -73,6 +89,16 @@ function handleEvent(data: { event: string; data: unknown }) {
     const { agentName } = data.data as { agentName: string };
     agentsStore.updateAgentStatus(agentName, 'idle');
   }
+
+  // Handle event:handled for event log panel
+  if (data.event === 'event:handled') {
+    const eventData = data.data as {
+      timestamp: number;
+      event: { type: string; [key: string]: unknown };
+      responses: ModuleEventResponse[];
+    };
+    eventLogsStore.addLogFromEvent(eventData);
+  }
 }
 
 async function sendMessage(content: string) {
@@ -89,7 +115,7 @@ async function sendMessage(content: string) {
 
 // Subscribe to events
 onMounted(() => {
-  on('*', handleEvent);
+  on('*', handleEvent as (data: unknown) => void);
 });
 
 // Update subscriptions when filters change
@@ -124,8 +150,9 @@ watch(
         <FilterPanel />
       </aside>
 
-      <section class="content">
+      <section class="content content-split">
         <EventTimeline />
+        <EventLogPanel />
       </section>
     </main>
   </div>
@@ -193,6 +220,16 @@ body {
   flex: 1;
   display: flex;
   flex-direction: column;
+  min-width: 0;
+}
+
+.content-split {
+  flex-direction: row;
+  gap: 16px;
+}
+
+.content-split > * {
+  flex: 1;
   min-width: 0;
 }
 </style>

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -82,22 +82,28 @@ function handleEvent(data: { event: string; data: unknown }) {
   eventsStore.addEvent(persistedEvent);
 
   // Update agent status if relevant
-  if (data.event === 'inference:start') {
+  if (data.event === 'inference:started') {
     const { agentName } = data.data as { agentName: string };
     agentsStore.updateAgentStatus(agentName, 'inferring');
-  } else if (data.event === 'inference:complete' || data.event === 'inference:error') {
+  } else if (data.event === 'inference:completed' || data.event === 'inference:failed') {
     const { agentName } = data.data as { agentName: string };
     agentsStore.updateAgentStatus(agentName, 'idle');
   }
 
-  // Handle event:handled for event log panel
-  if (data.event === 'event:handled') {
+  // Handle process:completed for process log panel
+  if (data.event === 'process:completed') {
     const eventData = data.data as {
       timestamp: number;
-      event: { type: string; [key: string]: unknown };
+      processEvent: { type: string; [key: string]: unknown };
       responses: ModuleEventResponse[];
+      durationMs: number;
     };
-    eventLogsStore.addLogFromEvent(eventData);
+    // Convert to the format the store expects
+    eventLogsStore.addLogFromEvent({
+      timestamp: eventData.timestamp,
+      event: eventData.processEvent,
+      responses: eventData.responses,
+    });
   }
 }
 

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -49,3 +49,42 @@ export interface BranchInfo {
   name: string;
   isCurrent: boolean;
 }
+
+// Event Log Types
+
+export interface ModuleEventResponse {
+  moduleName: string;
+  response: EventResponse;
+}
+
+export interface EventResponse {
+  addMessages?: { participant: string; content: string }[];
+  editMessages?: { messageId: string; content: string }[];
+  removeMessages?: string[];
+  requestInference?: boolean | string[];
+  toolsChanged?: boolean;
+}
+
+export interface EventLogEntry {
+  timestamp: number;
+  event: {
+    type: string;
+    [key: string]: unknown;
+  };
+  responses: ModuleEventResponse[] | { blobId: string };
+}
+
+export interface EventLogSummary {
+  timestamp: number;
+  eventType: string;
+  moduleCount: number;
+  modulesRequestingInference: string[];
+  modulesAddingMessages: string[];
+  responsesIsBlob: boolean;
+}
+
+export interface EventLogEntryWithId {
+  sequence: number;
+  entry: EventLogEntry;
+  summary?: EventLogSummary;
+}

--- a/ui/src/components/EventLogItem.vue
+++ b/ui/src/components/EventLogItem.vue
@@ -1,0 +1,358 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import type { LiveEventLog } from '../stores/eventLogs';
+import type { ModuleEventResponse } from '../api/types';
+
+const props = defineProps<{
+  log: LiveEventLog;
+  selected: boolean;
+}>();
+
+defineEmits<{
+  (e: 'select'): void;
+}>();
+
+const expanded = ref(false);
+const expandedModules = ref<Set<string>>(new Set());
+
+const eventType = computed(() => props.log.event.type);
+const eventPrefix = computed(() => {
+  const parts = eventType.value.split(':');
+  return parts.length > 1 ? parts[0] : '';
+});
+const eventLabel = computed(() => {
+  const parts = eventType.value.split(':');
+  return parts.length > 1 ? parts[1] : parts[0];
+});
+
+const activeResponses = computed(() => {
+  return props.log.responses.filter((r) => hasContent(r));
+});
+
+const inactiveResponses = computed(() => {
+  return props.log.responses.filter((r) => !hasContent(r));
+});
+
+function hasContent(response: ModuleEventResponse): boolean {
+  const r = response.response;
+  return !!(
+    r.addMessages?.length ||
+    r.editMessages?.length ||
+    r.removeMessages?.length ||
+    r.requestInference ||
+    r.toolsChanged
+  );
+}
+
+function formatTime(timestamp: number): string {
+  return new Date(timestamp).toLocaleTimeString('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+}
+
+function toggleModule(moduleName: string) {
+  if (expandedModules.value.has(moduleName)) {
+    expandedModules.value.delete(moduleName);
+  } else {
+    expandedModules.value.add(moduleName);
+  }
+  // Force reactivity
+  expandedModules.value = new Set(expandedModules.value);
+}
+
+function formatResponse(response: ModuleEventResponse['response']): string {
+  const parts: string[] = [];
+
+  if (response.addMessages?.length) {
+    parts.push(`+${response.addMessages.length} msg`);
+  }
+  if (response.editMessages?.length) {
+    parts.push(`~${response.editMessages.length} edit`);
+  }
+  if (response.removeMessages?.length) {
+    parts.push(`-${response.removeMessages.length} del`);
+  }
+  if (response.requestInference) {
+    if (response.requestInference === true) {
+      parts.push('infer:all');
+    } else if (Array.isArray(response.requestInference)) {
+      parts.push(`infer:${response.requestInference.join(',')}`);
+    }
+  }
+  if (response.toolsChanged) {
+    parts.push('tools changed');
+  }
+
+  return parts.length ? parts.join(', ') : 'no action';
+}
+
+function getEventColor(type: string): string {
+  if (type.startsWith('inference:')) return '#10b981';
+  if (type.startsWith('tool:')) return '#f59e0b';
+  if (type.startsWith('api:')) return '#3b82f6';
+  if (type.startsWith('module:')) return '#8b5cf6';
+  if (type.startsWith('external')) return '#ec4899';
+  return '#6b7280';
+}
+
+function formatJson(obj: unknown): string {
+  try {
+    return JSON.stringify(obj, null, 2);
+  } catch {
+    return String(obj);
+  }
+}
+</script>
+
+<template>
+  <div
+    class="event-log-item"
+    :class="{ expanded, selected }"
+    @click="expanded = !expanded"
+  >
+    <div class="item-header">
+      <div
+        class="event-indicator"
+        :style="{ backgroundColor: getEventColor(eventType) }"
+      ></div>
+      <div class="event-type">
+        <span class="type-prefix" v-if="eventPrefix">{{ eventPrefix }}:</span>
+        <span class="type-label">{{ eventLabel }}</span>
+      </div>
+      <div class="response-badges" v-if="activeResponses.length > 0">
+        <span class="badge" v-for="r in activeResponses" :key="r.moduleName">
+          {{ r.moduleName }}
+        </span>
+      </div>
+      <div class="event-time">{{ formatTime(log.timestamp) }}</div>
+    </div>
+
+    <div v-if="expanded" class="item-details">
+      <!-- Event payload -->
+      <div class="detail-section">
+        <div class="section-header">Event</div>
+        <pre class="json-content">{{ formatJson(log.event) }}</pre>
+      </div>
+
+      <!-- Module responses -->
+      <div class="detail-section" v-if="log.responses.length > 0">
+        <div class="section-header">
+          Module Responses ({{ log.responses.length }})
+        </div>
+
+        <div class="module-responses">
+          <!-- Active responses first -->
+          <div
+            v-for="resp in activeResponses"
+            :key="resp.moduleName"
+            class="module-response active"
+          >
+            <div
+              class="module-header"
+              @click.stop="toggleModule(resp.moduleName)"
+            >
+              <span class="module-name">{{ resp.moduleName }}</span>
+              <span class="module-summary">{{ formatResponse(resp.response) }}</span>
+              <span class="expand-icon">
+                {{ expandedModules.has(resp.moduleName) ? '−' : '+' }}
+              </span>
+            </div>
+            <div
+              v-if="expandedModules.has(resp.moduleName)"
+              class="module-details"
+              @click.stop
+            >
+              <pre class="json-content">{{ formatJson(resp.response) }}</pre>
+            </div>
+          </div>
+
+          <!-- Inactive responses (collapsed by default) -->
+          <div
+            v-for="resp in inactiveResponses"
+            :key="resp.moduleName"
+            class="module-response inactive"
+          >
+            <div
+              class="module-header"
+              @click.stop="toggleModule(resp.moduleName)"
+            >
+              <span class="module-name muted">{{ resp.moduleName }}</span>
+              <span class="module-summary muted">no action</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.event-log-item {
+  background: #252525;
+  border-radius: 6px;
+  margin-bottom: 4px;
+  cursor: pointer;
+  transition: background 0.15s;
+  border: 1px solid transparent;
+}
+
+.event-log-item:hover {
+  background: #2a2a2a;
+}
+
+.event-log-item.selected {
+  border-color: #3b82f6;
+}
+
+.event-log-item.expanded {
+  background: #2a2a2a;
+}
+
+.item-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+}
+
+.event-indicator {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.event-type {
+  font-size: 13px;
+  font-family: monospace;
+  min-width: 120px;
+}
+
+.type-prefix {
+  color: #888;
+}
+
+.type-label {
+  color: #e0e0e0;
+  font-weight: 500;
+}
+
+.response-badges {
+  display: flex;
+  gap: 4px;
+  flex: 1;
+  flex-wrap: wrap;
+}
+
+.badge {
+  font-size: 10px;
+  padding: 2px 6px;
+  background: #3b3b3b;
+  border-radius: 3px;
+  color: #10b981;
+}
+
+.event-time {
+  font-size: 11px;
+  color: #666;
+  font-family: monospace;
+  flex-shrink: 0;
+}
+
+.item-details {
+  padding: 0 12px 12px;
+}
+
+.detail-section {
+  margin-top: 12px;
+}
+
+.section-header {
+  font-size: 11px;
+  font-weight: 600;
+  color: #888;
+  margin-bottom: 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.json-content {
+  margin: 0;
+  padding: 8px;
+  background: #1a1a1a;
+  border-radius: 4px;
+  font-size: 11px;
+  color: #a0a0a0;
+  white-space: pre-wrap;
+  word-break: break-all;
+  overflow-x: auto;
+}
+
+.module-responses {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.module-response {
+  background: #1f1f1f;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.module-response.active .module-header {
+  background: #252525;
+}
+
+.module-response.inactive .module-header {
+  background: #1a1a1a;
+}
+
+.module-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  cursor: pointer;
+}
+
+.module-header:hover {
+  background: #2a2a2a;
+}
+
+.module-name {
+  font-size: 12px;
+  font-weight: 500;
+  color: #e0e0e0;
+  font-family: monospace;
+}
+
+.module-name.muted {
+  color: #666;
+}
+
+.module-summary {
+  flex: 1;
+  font-size: 11px;
+  color: #10b981;
+}
+
+.module-summary.muted {
+  color: #555;
+}
+
+.expand-icon {
+  font-size: 14px;
+  color: #666;
+  width: 16px;
+  text-align: center;
+}
+
+.module-details {
+  padding: 8px 10px;
+  border-top: 1px solid #333;
+}
+</style>

--- a/ui/src/components/EventLogPanel.vue
+++ b/ui/src/components/EventLogPanel.vue
@@ -1,0 +1,139 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useEventLogsStore } from '../stores/eventLogs';
+import EventLogItem from './EventLogItem.vue';
+
+const eventLogsStore = useEventLogsStore();
+
+const logs = computed(() => eventLogsStore.allLogs);
+const loading = computed(() => eventLogsStore.loading);
+const eventTypes = computed(() => eventLogsStore.eventTypes);
+const moduleNames = computed(() => eventLogsStore.moduleNames);
+const filterEventType = computed(() => eventLogsStore.filterEventType);
+const filterModuleName = computed(() => eventLogsStore.filterModuleName);
+
+function setEventTypeFilter(type: string | null) {
+  eventLogsStore.setFilterEventType(type);
+}
+
+function setModuleFilter(name: string | null) {
+  eventLogsStore.setFilterModuleName(name);
+}
+</script>
+
+<template>
+  <div class="event-log-panel">
+    <div class="panel-header">
+      <h2>Event Log</h2>
+      <span class="log-count">{{ logs.length }} events</span>
+    </div>
+
+    <div class="filters">
+      <select
+        class="filter-select"
+        :value="filterEventType ?? ''"
+        @change="setEventTypeFilter(($event.target as HTMLSelectElement).value || null)"
+      >
+        <option value="">All event types</option>
+        <option v-for="type in eventTypes" :key="type" :value="type">
+          {{ type }}
+        </option>
+      </select>
+
+      <select
+        class="filter-select"
+        :value="filterModuleName ?? ''"
+        @change="setModuleFilter(($event.target as HTMLSelectElement).value || null)"
+      >
+        <option value="">All modules</option>
+        <option v-for="name in moduleNames" :key="name" :value="name">
+          {{ name }}
+        </option>
+      </select>
+    </div>
+
+    <div v-if="loading" class="loading">Loading event logs...</div>
+
+    <div v-else-if="logs.length === 0" class="empty">
+      No event logs to display.
+    </div>
+
+    <div v-else class="logs-list">
+      <EventLogItem
+        v-for="log in logs"
+        :key="log.id"
+        :log="log"
+        :selected="eventLogsStore.selectedLogId === log.id"
+        @select="eventLogsStore.selectLog(log.id)"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.event-log-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: #1e1e1e;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  background: #252525;
+  border-bottom: 1px solid #333;
+}
+
+.panel-header h2 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: #e0e0e0;
+}
+
+.log-count {
+  font-size: 12px;
+  color: #888;
+}
+
+.filters {
+  display: flex;
+  gap: 8px;
+  padding: 8px 12px;
+  background: #1a1a1a;
+  border-bottom: 1px solid #333;
+}
+
+.filter-select {
+  flex: 1;
+  padding: 6px 8px;
+  font-size: 12px;
+  background: #252525;
+  border: 1px solid #333;
+  border-radius: 4px;
+  color: #e0e0e0;
+}
+
+.filter-select:focus {
+  outline: none;
+  border-color: #3b82f6;
+}
+
+.loading,
+.empty {
+  padding: 24px;
+  text-align: center;
+  color: #888;
+}
+
+.logs-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+}
+</style>

--- a/ui/src/components/EventLogPanel.vue
+++ b/ui/src/components/EventLogPanel.vue
@@ -24,7 +24,7 @@ function setModuleFilter(name: string | null) {
 <template>
   <div class="event-log-panel">
     <div class="panel-header">
-      <h2>Event Log</h2>
+      <h2>Process Log</h2>
       <span class="log-count">{{ logs.length }} events</span>
     </div>
 
@@ -52,10 +52,10 @@ function setModuleFilter(name: string | null) {
       </select>
     </div>
 
-    <div v-if="loading" class="loading">Loading event logs...</div>
+    <div v-if="loading" class="loading">Loading process logs...</div>
 
     <div v-else-if="logs.length === 0" class="empty">
-      No event logs to display.
+      No process logs to display.
     </div>
 
     <div v-else class="logs-list">

--- a/ui/src/components/EventTimeline.vue
+++ b/ui/src/components/EventTimeline.vue
@@ -12,7 +12,7 @@ const loading = computed(() => eventsStore.loading);
 <template>
   <div class="event-timeline">
     <div class="timeline-header">
-      <h2>Event Timeline</h2>
+      <h2>Activity Stream</h2>
       <span class="event-count">{{ events.length }} events</span>
     </div>
 

--- a/ui/src/components/EventTimeline.vue
+++ b/ui/src/components/EventTimeline.vue
@@ -7,10 +7,6 @@ const eventsStore = useEventsStore();
 
 const events = computed(() => eventsStore.filteredEvents);
 const loading = computed(() => eventsStore.loading);
-
-function formatTime(timestamp: number): string {
-  return new Date(timestamp).toLocaleTimeString();
-}
 </script>
 
 <template>

--- a/ui/src/stores/eventLogs.ts
+++ b/ui/src/stores/eventLogs.ts
@@ -1,0 +1,161 @@
+import { defineStore } from 'pinia';
+import { ref, computed } from 'vue';
+import type { EventLogEntryWithId, ModuleEventResponse } from '../api/types';
+
+export interface LiveEventLog {
+  id: string;
+  timestamp: number;
+  event: {
+    type: string;
+    [key: string]: unknown;
+  };
+  responses: ModuleEventResponse[];
+}
+
+export const useEventLogsStore = defineStore('eventLogs', () => {
+  // State
+  const logs = ref<LiveEventLog[]>([]);
+  const historicalLogs = ref<EventLogEntryWithId[]>([]);
+  const loading = ref(false);
+  const error = ref<string | null>(null);
+  const selectedLogId = ref<string | null>(null);
+
+  // Filter state
+  const filterEventType = ref<string | null>(null);
+  const filterModuleName = ref<string | null>(null);
+
+  // Getters
+  const allLogs = computed(() => {
+    let result = [...logs.value];
+
+    if (filterEventType.value) {
+      result = result.filter((log) => log.event.type === filterEventType.value);
+    }
+
+    if (filterModuleName.value) {
+      result = result.filter((log) =>
+        log.responses.some((r) => r.moduleName === filterModuleName.value)
+      );
+    }
+
+    // Sort by timestamp descending (newest first)
+    return result.sort((a, b) => b.timestamp - a.timestamp);
+  });
+
+  const selectedLog = computed(() => {
+    if (!selectedLogId.value) return null;
+    return logs.value.find((log) => log.id === selectedLogId.value) ?? null;
+  });
+
+  const eventTypes = computed(() => {
+    const types = new Set<string>();
+    for (const log of logs.value) {
+      types.add(log.event.type);
+    }
+    return Array.from(types).sort();
+  });
+
+  const moduleNames = computed(() => {
+    const names = new Set<string>();
+    for (const log of logs.value) {
+      for (const resp of log.responses) {
+        names.add(resp.moduleName);
+      }
+    }
+    return Array.from(names).sort();
+  });
+
+  // Actions
+  function addLog(log: LiveEventLog) {
+    logs.value.push(log);
+    // Keep max 500 logs in memory
+    if (logs.value.length > 500) {
+      logs.value = logs.value.slice(-500);
+    }
+  }
+
+  function addLogFromEvent(data: {
+    timestamp: number;
+    event: { type: string; [key: string]: unknown };
+    responses: ModuleEventResponse[];
+  }) {
+    const log: LiveEventLog = {
+      id: `live-${data.timestamp}-${Math.random().toString(36).substr(2, 9)}`,
+      timestamp: data.timestamp,
+      event: data.event,
+      responses: data.responses,
+    };
+    addLog(log);
+  }
+
+  function setHistoricalLogs(entries: EventLogEntryWithId[]) {
+    historicalLogs.value = entries;
+    // Also add them to the logs for display
+    for (const entry of entries) {
+      const responses = Array.isArray(entry.entry.responses)
+        ? entry.entry.responses
+        : [];
+      const log: LiveEventLog = {
+        id: `hist-${entry.sequence}`,
+        timestamp: entry.entry.timestamp,
+        event: entry.entry.event,
+        responses,
+      };
+      // Add if not already present
+      if (!logs.value.some((l) => l.id === log.id)) {
+        logs.value.push(log);
+      }
+    }
+  }
+
+  function clearLogs() {
+    logs.value = [];
+    historicalLogs.value = [];
+  }
+
+  function selectLog(id: string | null) {
+    selectedLogId.value = id;
+  }
+
+  function setFilterEventType(type: string | null) {
+    filterEventType.value = type;
+  }
+
+  function setFilterModuleName(name: string | null) {
+    filterModuleName.value = name;
+  }
+
+  function setLoading(isLoading: boolean) {
+    loading.value = isLoading;
+  }
+
+  function setError(err: string | null) {
+    error.value = err;
+  }
+
+  return {
+    // State
+    logs,
+    historicalLogs,
+    loading,
+    error,
+    selectedLogId,
+    filterEventType,
+    filterModuleName,
+    // Getters
+    allLogs,
+    selectedLog,
+    eventTypes,
+    moduleNames,
+    // Actions
+    addLog,
+    addLogFromEvent,
+    setHistoricalLogs,
+    clearLogs,
+    selectLog,
+    setFilterEventType,
+    setFilterModuleName,
+    setLoading,
+    setError,
+  };
+});

--- a/ui/src/stores/eventLogs.ts
+++ b/ui/src/stores/eventLogs.ts
@@ -95,10 +95,12 @@ export const useEventLogsStore = defineStore('eventLogs', () => {
       const responses = Array.isArray(entry.entry.responses)
         ? entry.entry.responses
         : [];
+      // Support both old format (event) and new format (processEvent)
+      const eventData = (entry.entry as any).processEvent ?? entry.entry.event;
       const log: LiveEventLog = {
         id: `hist-${entry.sequence}`,
         timestamp: entry.entry.timestamp,
-        event: entry.entry.event,
+        event: eventData,
         responses,
       };
       // Add if not already present

--- a/ui/src/stores/events.ts
+++ b/ui/src/stores/events.ts
@@ -46,7 +46,7 @@ export const useEventsStore = defineStore('events', () => {
       if (!result[event.type]) {
         result[event.type] = [];
       }
-      result[event.type].push(event);
+      result[event.type]!.push(event);
     }
     return result;
   });


### PR DESCRIPTION
Issue: non-atomic Chronicle writes during async external events currently can result in orphaned message states, with a scenario like this:
  
  1: discord message arrives while the queue is busy
  2: discord module directly inserts a message into Chronicle 
  3: --some other stuff happens--
  4: processing catches up, creates a conversation for this message, and fires inference
  
This is rather fine when working with it live, but time-travelling to step 2 or 3 will result in 4 never happening, because the event being handled is not part of the Chronicle records, and is dropped. Meanwhile, the message itself will be left extant but orphaned.

This PR changes the module/event processing contract in a rather opinionated way:                                                                                                
  - External callbacks (Discord messageCreate, etc.) now only inject ProcessEvent into the queue — no direct Chronicle writes allowed                  
  - Event handlers (onProcess) receive read-only ProcessState and return EventResponse declaring changes (addMessages, editMessages, stateUpdate, etc.)
  - Framework applies all EventResponse operations atomically
  
  In combination, it ensures that any seq that can be branched at will have a reasonably consistent state.

  Key type: ProcessState is read-only; mutations happen via declarative EventResponse.                                                                 

  Additional Changes:

  - Event naming refactor: QueueEvent → ProcessEvent, FrameworkEvent → TraceEvent                                                                      
  - Event logging/tracing infrastructure with Chronicle persistence (serves logs on UI reload, if debugging enabled)
  - AF UI panels renamed to match new event terminology
  - driveby: Discord self-message filtering
  - driveby: MCP server tool list fix