### PR TITLE
Yielding inference

### DIFF
--- a/examples/host-mock.ts
+++ b/examples/host-mock.ts
@@ -1,0 +1,106 @@
+/**
+ * Mock host script - runs the agent framework with canned responses
+ * 
+ * No API key needed! Uses MockAdapter for testing the framework
+ * without making real LLM calls.
+ *
+ * Usage:
+ *   npx tsx examples/host-mock.ts
+ */
+
+import { Membrane, MockAdapter } from 'membrane';
+import { AgentFramework, ApiServer, ApiModule } from '../src/index.js';
+
+async function main() {
+  console.log('Starting agent framework with MOCK adapter...');
+  console.log('(No real LLM calls will be made)\n');
+
+  // Create mock adapter with some canned responses
+  const mockAdapter = new MockAdapter({
+    // First few responses are specific
+    responseQueue: [
+      'Hello! I am a mock agent running in test mode. The framework is working correctly!',
+      'I received your message. Since this is a mock adapter, I am returning pre-configured responses.',
+      'This is the third canned response. After this, I will return the default response.',
+    ],
+    // Default response after queue is exhausted
+    defaultResponse: 'Mock response: The system is operational. This is a test environment.',
+    // Simulate realistic streaming
+    streamChunkDelayMs: 15,
+    streamChunkSize: 8,
+  });
+
+  // Create membrane with mock adapter
+  const membrane = new Membrane(mockAdapter, {
+    assistantParticipant: 'assistant',
+  });
+
+  // Create framework
+  const framework = await AgentFramework.create({
+    storePath: './data/mock-agent-store',
+    membrane,
+    agents: [
+      {
+        name: 'assistant',
+        model: 'mock-model', // Model name doesn't matter for mock
+        systemPrompt: `You are a helpful assistant running in TEST MODE.
+This is a mock environment - no real LLM calls are being made.
+
+Your responses are pre-configured for testing the framework.`,
+      },
+    ],
+    modules: [new ApiModule()],
+  });
+
+  // Add event listener for debugging
+  framework.on((event) => {
+    switch (event.type) {
+      case 'inference:start':
+        console.log(`[MOCK] Inference starting for ${event.agentName}`);
+        break;
+      case 'inference:complete':
+        console.log(`[MOCK] Inference complete (${event.durationMs}ms)`);
+        break;
+      case 'inference:error':
+        console.log(`[ERROR] ${event.error.message}`);
+        break;
+      case 'message:added':
+        console.log(`[MSG] Message added: ${event.messageId}`);
+        break;
+      default:
+        // Ignore other events
+        break;
+    }
+  });
+
+  // Start framework loop
+  framework.start();
+  console.log('Framework started (mock mode)');
+
+  // Start API server
+  const api = new ApiServer(framework, { port: 8765 });
+  await api.start();
+  console.log('API server listening on ws://localhost:8765/ws');
+
+  // Handle shutdown
+  process.on('SIGINT', async () => {
+    console.log('\nShutting down...');
+    await api.stop();
+    await framework.stop();
+    process.exit(0);
+  });
+
+  console.log('\n========================================');
+  console.log('MOCK MODE - No API key required!');
+  console.log('========================================');
+  console.log('\nYou can now:');
+  console.log('1. Connect MCP tools (agent-framework in Cursor)');
+  console.log('2. Send messages via agent_send_message');
+  console.log('3. Watch mock responses flow through');
+  console.log('\nPress Ctrl+C to stop.\n');
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/mcp-wrapper.sh
+++ b/mcp-wrapper.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# MCP wrapper for agent-framework inspector
+# Connects to running agent-framework API server at ws://localhost:8765/ws
+
+# Source nvm to get node in PATH
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+
+cd "$(dirname "$0")"
+
+# Ensure node modules are available
+export PATH="./node_modules/.bin:$PATH"
+
+# Set API server URL (can be overridden via env)
+export AGENT_FRAMEWORK_WS_URL="${AGENT_FRAMEWORK_WS_URL:-ws://localhost:8765/ws}"
+
+# Run the MCP server
+exec node dist/src/api/mcp-server.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@connectome/context-manager": "file:../context-manager",
-        "chronicle": "file:../record-store",
+        "chronicle": "file:../chronicle",
         "membrane": "file:../membrane",
         "ws": "^8.18.0"
       },
@@ -20,6 +20,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/ws": "^8.5.13",
+        "discord.js": "^14.25.1",
         "tsx": "^4.21.0",
         "typescript": "^5.7.0"
       },
@@ -27,12 +28,20 @@
         "node": ">=20.0.0"
       }
     },
+    "../chronicle": {
+      "name": "@anima-research/chronicle",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@napi-rs/cli": "^2.18.0"
+      }
+    },
     "../context-manager": {
       "name": "@connectome/context-manager",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "chronicle": "file:../record-store",
+        "chronicle": "file:../chronicle",
         "membrane": "file:../membrane"
       },
       "devDependencies": {
@@ -58,17 +67,147 @@
         "node": ">=20.0.0"
       }
     },
-    "../record-store": {
-      "name": "@anima-research/chronicle",
-      "version": "0.1.0",
-      "license": "MIT",
-      "devDependencies": {
-        "@napi-rs/cli": "^2.18.0"
-      }
-    },
     "node_modules/@connectome/context-manager": {
       "resolved": "../context-manager",
       "link": true
+    },
+    "node_modules/@discordjs/builders": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.13.1.tgz",
+      "integrity": "sha512-cOU0UDHc3lp/5nKByDxkmRiNZBpdp0kx55aarbiAfakfKJHlxv/yFW1zmIqCAmwH5CRlrH9iMFKJMpvW4DPB+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/util": "^1.2.0",
+        "@sapphire/shapeshift": "^4.0.0",
+        "discord-api-types": "^0.38.33",
+        "fast-deep-equal": "^3.1.3",
+        "ts-mixer": "^6.0.4",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/collection": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.11.0"
+      }
+    },
+    "node_modules/@discordjs/formatters": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.2.tgz",
+      "integrity": "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.0.tgz",
+      "integrity": "sha512-RDYrhmpB7mTvmCKcpj+pc5k7POKszS4E2O9TYc+U+Y4iaCP+r910QdO43qmpOja8LRr1RJ0b3U+CqVsnPqzf4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.1",
+        "@discordjs/util": "^1.1.1",
+        "@sapphire/async-queue": "^1.5.3",
+        "@sapphire/snowflake": "^3.5.3",
+        "@vladfrangu/async_event_emitter": "^2.4.6",
+        "discord-api-types": "^0.38.16",
+        "magic-bytes.js": "^1.10.0",
+        "tslib": "^2.6.3",
+        "undici": "6.21.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/util": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
+      "integrity": "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
+      "integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/rest": "^2.5.1",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@types/ws": "^8.5.10",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "^0.38.1",
+        "tslib": "^2.6.2",
+        "ws": "^8.17.0"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.2",
@@ -512,10 +651,46 @@
         "node": ">=18"
       }
     },
+    "node_modules/@sapphire/async-queue": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+      "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@sapphire/shapeshift": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
+      "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=v16"
+      }
+    },
+    "node_modules/@sapphire/snowflake": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
+      "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@types/node": {
-      "version": "22.19.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.3.tgz",
-      "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
+      "version": "22.19.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.6.tgz",
+      "integrity": "sha512-qm+G8HuG6hOHQigsi7VGuLjUVu6TtBo/F05zvX04Mw2uCg9Dv0Qxy3Qw7j41SidlTcl5D/5yg0SEZqOB+EqZnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -532,9 +707,58 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@vladfrangu/async_event_emitter": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
+      "integrity": "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/chronicle": {
-      "resolved": "../record-store",
+      "resolved": "../chronicle",
       "link": true
+    },
+    "node_modules/discord-api-types": {
+      "version": "0.38.37",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.37.tgz",
+      "integrity": "sha512-Cv47jzY1jkGkh5sv0bfHYqGgKOWO1peOrGMkDFM4UmaGMOTgOW8QSexhvixa9sVOiz8MnVOBryWYyw/CEVhj7w==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "scripts/actions/documentation"
+      ]
+    },
+    "node_modules/discord.js": {
+      "version": "14.25.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.25.1.tgz",
+      "integrity": "sha512-2l0gsPOLPs5t6GFZfQZKnL1OJNYFcuC/ETWsW4VtKVD/tg4ICa9x+jb9bkPffkMdRpRpuUaO/fKkHCBeiCKh8g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/builders": "^1.13.0",
+        "@discordjs/collection": "1.5.3",
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/rest": "^2.6.0",
+        "@discordjs/util": "^1.2.0",
+        "@discordjs/ws": "^1.2.3",
+        "@sapphire/snowflake": "3.5.3",
+        "discord-api-types": "^0.38.33",
+        "fast-deep-equal": "3.1.3",
+        "lodash.snakecase": "4.1.1",
+        "magic-bytes.js": "^1.10.0",
+        "tslib": "^2.6.3",
+        "undici": "6.21.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.27.2",
@@ -578,6 +802,13 @@
         "@esbuild/win32-x64": "0.27.2"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -606,6 +837,27 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-bytes.js": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz",
+      "integrity": "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/membrane": {
       "resolved": "../membrane",
       "link": true
@@ -619,6 +871,20 @@
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
+    },
+    "node_modules/ts-mixer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -654,6 +920,16 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici": {
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -662,9 +938,9 @@
       "license": "MIT"
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -39,13 +39,13 @@
     "@connectome/context-manager": "file:../context-manager",
     "chronicle": "file:../chronicle",
     "discord.js": "^14.25.1",
-    "dotenv": "^17.2.3",
     "membrane": "file:../membrane",
     "ws": "^8.18.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/ws": "^8.5.13",
+    "discord.js": "^14.25.1",
     "tsx": "^4.21.0",
     "typescript": "^5.7.0"
   },

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,4 +1,4 @@
-import type { Membrane, NormalizedMessage, NormalizedRequest, ContentBlock } from 'membrane';
+import type { Membrane, NormalizedMessage, NormalizedRequest, ContentBlock, YieldingStream } from 'membrane';
 import type { ContextManager, TokenBudget } from '@connectome/context-manager';
 import type {
   AgentConfig,
@@ -181,8 +181,88 @@ export class Agent {
 
     // If all tools done, transition to ready
     if (this._state.pending.size === 0) {
-      this._state = { status: 'ready', toolResults: this._state.completed };
+      this._state = { status: 'ready', toolResults: this._state.completed, stream: this._state.stream };
     }
+  }
+
+  /**
+   * Start a yielding stream for inference.
+   * Returns the stream — the caller (framework) iterates it.
+   */
+  async startStream(
+    availableTools: ToolDefinition[],
+    budget?: TokenBudget
+  ): Promise<YieldingStream> {
+    if (this._state.status !== 'idle') {
+      throw new Error(`Agent ${this.name} cannot start stream in state ${this._state.status}`);
+    }
+
+    const tools = availableTools.filter((t) => this.canUseTool(t.name));
+    const messages = await this.contextManager.compile(budget);
+
+    const request: NormalizedRequest = {
+      messages,
+      system: this.systemPrompt,
+      config: {
+        model: this.model,
+        maxTokens: this.maxTokens,
+        temperature: this.temperature,
+      },
+      tools: tools.length > 0 ? tools : undefined,
+    };
+
+    const stream = this.membrane.streamYielding(request, {
+      emitTokens: true,
+      emitBlocks: false,
+      emitUsage: true,
+    });
+
+    this._state = { status: 'streaming', stream };
+    return stream;
+  }
+
+  /**
+   * Transition to waiting_for_tools when stream yields tool calls.
+   * Called by framework's driveStream.
+   */
+  enterWaitingForTools(calls: ToolCall[], stream: YieldingStream): void {
+    const pending = new Map<ToolCallId, PendingToolCall>();
+    for (const call of calls) {
+      pending.set(call.id, {
+        id: call.id,
+        name: call.name,
+        input: call.input,
+        startedAt: Date.now(),
+      });
+    }
+    this._state = { status: 'waiting_for_tools', pending, completed: [], stream };
+  }
+
+  /**
+   * Add an assistant response to context.
+   * Called by framework when stream completes.
+   */
+  addAssistantResponse(content: ContentBlock[]): void {
+    this.contextManager.addMessage(this.name, content);
+  }
+
+  /**
+   * Transition back to streaming state after tool results are provided.
+   */
+  setStreaming(stream: YieldingStream): void {
+    this._state = { status: 'streaming', stream };
+  }
+
+  /**
+   * Cancel any active stream and reset to idle.
+   */
+  cancelStream(): void {
+    if (this._state.status === 'streaming') {
+      this._state.stream.cancel();
+    } else if (this._state.status === 'waiting_for_tools' && this._state.stream) {
+      this._state.stream.cancel();
+    }
+    this._state = { status: 'idle' };
   }
 
   /**

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -220,24 +220,38 @@ export class Agent {
   private async doInference(request: NormalizedRequest): Promise<InferenceResult> {
     const response = await this.membrane.complete(request);
 
-    // Extract tool calls and speech content from response
-    const toolCalls: ToolCall[] = [];
+    // Use tool calls from Membrane (handles both XML and native modes)
+    const toolCalls = response.toolCalls;
+    
+    // Extract speech content - text/thinking that should be shown to users
+    // In XML mode, we need to strip tool call XML from text blocks
     const speechContent: ContentBlock[] = [];
-
+    
     for (const block of response.content) {
       if (block.type === 'tool_use') {
-        toolCalls.push({
-          id: block.id,
-          name: block.name,
-          input: block.input,
-        });
-      } else if (block.type === 'text' || block.type === 'thinking') {
-        // Text and thinking blocks are speech content
-        speechContent.push(block);
+        // Skip tool_use blocks (handled via toolCalls)
+        continue;
+      } else if (block.type === 'text') {
+        // Strip XML tool calls from text (they're handled separately)
+        let text = block.text;
+        // Remove <function_calls>...</function_calls> blocks
+        text = text.replace(/<(antml:)?function_calls>[\s\S]*?<\/(antml:)?function_calls>/g, '');
+        // Remove unclosed <function_calls> (when stopped by stop sequence)
+        text = text.replace(/<(antml:)?function_calls>[\s\S]*$/g, '');
+        // Remove *thinking* blocks (internal reasoning)
+        text = text.replace(/\*thinking\*[\s\S]*?(?=\n\n|<|$)/g, '');
+        text = text.trim();
+        
+        if (text) {
+          speechContent.push({ type: 'text', text });
+        }
+      } else if (block.type === 'thinking') {
+        // Don't include thinking in speech content - it's internal
+        continue;
       }
     }
 
-    // Add assistant response to context
+    // Add assistant response to context (store full response including tool calls)
     this.contextManager.addMessage(this.name, response.content);
 
     return {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -140,7 +140,7 @@ export class Agent {
             startedAt: Date.now(),
           });
         }
-        this._state = { status: 'waiting_for_tools', pending };
+        this._state = { status: 'waiting_for_tools', pending, completed: [] };
       } else {
         // Done, back to idle
         this._state = { status: 'idle' };
@@ -177,12 +177,11 @@ export class Agent {
     };
 
     this._state.pending.delete(callId);
+    this._state.completed.push(completed);
 
     // If all tools done, transition to ready
     if (this._state.pending.size === 0) {
-      // Gather all completed results
-      const toolResults = [completed];
-      this._state = { status: 'ready', toolResults };
+      this._state = { status: 'ready', toolResults: this._state.completed };
     }
   }
 
@@ -220,36 +219,16 @@ export class Agent {
   private async doInference(request: NormalizedRequest): Promise<InferenceResult> {
     const response = await this.membrane.complete(request);
 
-    // Use tool calls from Membrane (handles both XML and native modes)
+    // Membrane normalizes both native and XML modes to the same block structure.
+    // We receive clean content blocks: text (no XML), tool_use, thinking, etc.
     const toolCalls = response.toolCalls;
-    
-    // Extract speech content - text/thinking that should be shown to users
-    // In XML mode, we need to strip tool call XML from text blocks
-    const speechContent: ContentBlock[] = [];
-    
-    for (const block of response.content) {
-      if (block.type === 'tool_use') {
-        // Skip tool_use blocks (handled via toolCalls)
-        continue;
-      } else if (block.type === 'text') {
-        // Strip XML tool calls from text (they're handled separately)
-        let text = block.text;
-        // Remove <function_calls>...</function_calls> blocks
-        text = text.replace(/<(antml:)?function_calls>[\s\S]*?<\/(antml:)?function_calls>/g, '');
-        // Remove unclosed <function_calls> (when stopped by stop sequence)
-        text = text.replace(/<(antml:)?function_calls>[\s\S]*$/g, '');
-        // Remove *thinking* blocks (internal reasoning)
-        text = text.replace(/\*thinking\*[\s\S]*?(?=\n\n|<|$)/g, '');
-        text = text.trim();
-        
-        if (text) {
-          speechContent.push({ type: 'text', text });
-        }
-      } else if (block.type === 'thinking') {
-        // Don't include thinking in speech content - it's internal
-        continue;
-      }
-    }
+
+    // Extract speech content - text blocks that should be shown to users.
+    // Thinking blocks are internal reasoning, not speech.
+    // Tool_use blocks are handled separately via toolCalls.
+    const speechContent = response.content.filter(
+      (block): block is ContentBlock & { type: 'text' } => block.type === 'text'
+    );
 
     // Add assistant response to context (store full response including tool calls)
     this.contextManager.addMessage(this.name, response.content);

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -197,7 +197,6 @@ export class Agent {
       throw new Error(`Agent ${this.name} cannot start stream in state ${this._state.status}`);
     }
 
-    const tools = availableTools.filter((t) => this.canUseTool(t.name));
     const messages = await this.contextManager.compile(budget);
 
     const request: NormalizedRequest = {
@@ -208,7 +207,7 @@ export class Agent {
         maxTokens: this.maxTokens,
         temperature: this.temperature,
       },
-      tools: tools.length > 0 ? tools : undefined,
+      tools: availableTools.length > 0 ? availableTools : undefined,
     };
 
     const stream = this.membrane.streamYielding(request, {

--- a/src/api/mcp-server.ts
+++ b/src/api/mcp-server.ts
@@ -185,8 +185,17 @@ export class McpServer {
 
   private handleInput(line: string): void {
     try {
-      const request = JSON.parse(line) as JsonRpcRequest;
-      this.handleRequest(request);
+      const message = JSON.parse(line);
+      
+      // Check if this is a notification (no id) or a request (has id)
+      if (!('id' in message) || message.id === undefined) {
+        // This is a notification - handle silently without response
+        // Common notifications: notifications/initialized, notifications/cancelled
+        return;
+      }
+      
+      // This is a request - process and respond
+      this.handleRequest(message as JsonRpcRequest);
     } catch {
       this.sendError(null, -32700, 'Parse error');
     }

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -1,5 +1,5 @@
 import { JsStore } from 'chronicle';
-import type { Membrane, ContentBlock } from 'membrane';
+import type { Membrane, ContentBlock, YieldingStream, ToolResult as MembraneToolResult } from 'membrane';
 import { ContextManager, PassthroughStrategy } from '@connectome/context-manager';
 import type {
   MessageId,
@@ -94,6 +94,7 @@ export class AgentFramework {
   private syncTimer: ReturnType<typeof setInterval> | null = null;
   private processLoggingPersist: boolean;
   private processLoggingBroadcast: boolean;
+  private activeStreams: Map<string, Promise<void>> = new Map();
 
   private constructor(
     store: JsStore,
@@ -233,6 +234,19 @@ export class AgentFramework {
   async stop(): Promise<void> {
     this.running = false;
     this.queue.close();
+
+    // Cancel all active streams
+    for (const agent of this.agents.values()) {
+      if (agent.state.status === 'streaming' ||
+          (agent.state.status === 'waiting_for_tools' && agent.state.stream)) {
+        agent.cancelStream();
+      }
+    }
+
+    // Wait for all stream iteration handles to settle
+    if (this.activeStreams.size > 0) {
+      await Promise.allSettled(this.activeStreams.values());
+    }
 
     // Stop sync timer
     if (this.syncTimer) {
@@ -617,6 +631,7 @@ export class AgentFramework {
   async runUntilIdle(): Promise<void> {
     while (
       !this.queue.isEmpty ||
+      this.activeStreams.size > 0 ||
       Array.from(this.agents.values()).some((a) => a.state.status !== 'idle')
     ) {
       await this.processNextEvent();
@@ -659,9 +674,13 @@ export class AgentFramework {
     // Check for inference requests
     await this.processInferenceRequests();
 
-    // Small delay if nothing to do
+    // Yield to the event loop between iterations.
+    // Full 10ms sleep when truly idle; minimal yield when streams are active
+    // (needed to let stream microtasks and tool-call callbacks execute).
     if (!event && this.pendingRequests.length === 0) {
       await new Promise((resolve) => setTimeout(resolve, 10));
+    } else if (this.activeStreams.size > 0) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
     }
   }
 
@@ -693,13 +712,25 @@ export class AgentFramework {
 
         // Check if agent is now ready (state may have changed after provideToolResult)
         // Cast to AgentState to bypass TypeScript's control flow narrowing
-        if ((agent.state as AgentState).status === 'ready') {
-          this.pendingRequests.push({
-            agentName: agent.name,
-            reason: 'tool_results_ready',
-            source: 'framework',
-            timestamp: Date.now(),
-          });
+        const currentState = agent.state as AgentState;
+        if (currentState.status === 'ready') {
+          if (currentState.stream) {
+            // Streaming path: convert results and resume the stream
+            const membraneResults = currentState.toolResults.map(tc =>
+              this.toMembraneToolResult(tc.id, tc.result)
+            );
+            currentState.stream.provideToolResults(membraneResults);
+            agent.setStreaming(currentState.stream);
+            this.emitTrace({ type: 'inference:stream_resumed', agentName: agent.name });
+          } else {
+            // Non-streaming fallback: schedule re-inference
+            this.pendingRequests.push({
+              agentName: agent.name,
+              reason: 'tool_results_ready',
+              source: 'framework',
+              timestamp: Date.now(),
+            });
+          }
         }
       }
     }
@@ -792,8 +823,8 @@ export class AgentFramework {
       const agent = this.agents.get(agentName);
       if (!agent) continue;
 
-      // Skip if agent is busy
-      if (agent.state.status === 'inferring' || agent.state.status === 'waiting_for_tools') {
+      // Skip if agent is busy (inferring, streaming, or waiting for tools)
+      if (agent.state.status === 'inferring' || agent.state.status === 'streaming' || agent.state.status === 'waiting_for_tools') {
         // Re-queue requests
         this.pendingRequests.push(...requests);
         continue;
@@ -804,9 +835,9 @@ export class AgentFramework {
         continue;
       }
 
-      // Run inference with the first request as trigger context
+      // Start streaming inference (non-blocking — driveStream runs in background)
       const trigger = requests[0];
-      await this.runAgentInference(agent, 0, trigger);
+      await this.startAgentStream(agent, trigger);
     }
   }
 
@@ -891,6 +922,192 @@ export class AgentFramework {
         this.pushEvent(action.emit);
       }
     }
+  }
+
+  private async startAgentStream(agent: Agent, trigger?: InferenceRequest): Promise<void> {
+    this.emitTrace({ type: 'inference:started', agentName: agent.name });
+
+    try {
+      const tools = this.moduleRegistry.getAllTools().filter((t) => agent.canUseTool(t.name));
+      const stream = await agent.startStream(tools);
+
+      const handle = this.driveStream(agent, stream, trigger);
+      this.activeStreams.set(agent.name, handle);
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      this.emitTrace({
+        type: 'inference:failed',
+        agentName: agent.name,
+        error: err.message,
+        stack: err.stack,
+      });
+      agent.reset();
+
+      const action = this.errorPolicy.onInferenceError(err, agent.name, 0);
+      if (action.retry) {
+        await new Promise((resolve) => setTimeout(resolve, action.delayMs));
+        await this.startAgentStream(agent, trigger);
+      } else if (action.emit) {
+        this.pushEvent(action.emit);
+      }
+    }
+  }
+
+  private async driveStream(
+    agent: Agent,
+    stream: YieldingStream,
+    trigger?: InferenceRequest
+  ): Promise<void> {
+    const startTime = Date.now();
+    const requestId = `${agent.name}-${startTime}-${Math.random().toString(36).slice(2, 8)}`;
+
+    try {
+      for await (const event of stream) {
+        switch (event.type) {
+          case 'tokens':
+            this.emitTrace({
+              type: 'inference:tokens',
+              agentName: agent.name,
+              content: event.content,
+            });
+            break;
+
+          case 'tool-calls':
+            this.emitTrace({
+              type: 'inference:tool_calls_yielded',
+              agentName: agent.name,
+              calls: event.calls.map((c) => ({ id: c.id, name: c.name })),
+            });
+            agent.enterWaitingForTools(event.calls, stream);
+            // Dispatch each tool call (async, results come back via ToolResultEvent)
+            for (const call of event.calls) {
+              this.dispatchToolCall(agent.name, call);
+            }
+            // Loop naturally pauses here — stream is waiting for provideToolResults()
+            break;
+
+          case 'complete': {
+            const durationMs = Date.now() - startTime;
+            const response = event.response;
+
+            // Add assistant response to context
+            agent.addAssistantResponse(response.content);
+
+            // Extract speech content
+            const speechContent = response.content.filter(
+              (block: ContentBlock): block is ContentBlock & { type: 'text' } =>
+                block.type === 'text'
+            );
+
+            const tokenUsage = response.usage
+              ? { input: response.usage.inputTokens, output: response.usage.outputTokens }
+              : undefined;
+            this.emitTrace({
+              type: 'inference:completed',
+              agentName: agent.name,
+              durationMs,
+              tokenUsage,
+            });
+
+            // Log inference
+            this.logInference({
+              timestamp: startTime,
+              agentName: agent.name,
+              requestId,
+              success: true,
+              request: { note: 'streaming request' },
+              response: response.raw ?? { note: 'streaming response' },
+              durationMs,
+              tokenUsage,
+              stopReason: response.stopReason,
+            });
+
+            // Dispatch speech
+            if (speechContent.length > 0) {
+              const speechContext = {
+                turnComplete: response.toolCalls.length === 0,
+                trigger: trigger ?? {
+                  reason: 'unknown',
+                  source: 'unknown',
+                  timestamp: Date.now(),
+                },
+              };
+              await this.moduleRegistry.dispatchSpeech(
+                agent.name,
+                speechContent,
+                speechContext
+              );
+            }
+
+            // Done — reset to idle
+            agent.reset();
+            break;
+          }
+
+          case 'error': {
+            const err = event.error;
+            const durationMs = Date.now() - startTime;
+            this.emitTrace({
+              type: 'inference:failed',
+              agentName: agent.name,
+              error: err.message,
+              stack: err.stack,
+            });
+
+            this.logInference({
+              timestamp: startTime,
+              agentName: agent.name,
+              requestId,
+              success: false,
+              error: err.message,
+              request: { note: 'streaming request failed' },
+              durationMs,
+            });
+
+            agent.reset();
+
+            const action = this.errorPolicy.onInferenceError(err, agent.name, 0);
+            if (action.retry) {
+              await new Promise((resolve) => setTimeout(resolve, action.delayMs));
+              await this.startAgentStream(agent, trigger);
+            } else if (action.emit) {
+              this.pushEvent(action.emit);
+            }
+            break;
+          }
+
+          case 'aborted':
+            agent.reset();
+            break;
+
+          case 'usage':
+            // Token count updates — could emit trace for UI
+            break;
+        }
+      }
+    } catch (error) {
+      // Stream itself threw (unexpected)
+      const err = error instanceof Error ? error : new Error(String(error));
+      this.emitTrace({
+        type: 'inference:failed',
+        agentName: agent.name,
+        error: err.message,
+        stack: err.stack,
+      });
+      agent.reset();
+    } finally {
+      this.activeStreams.delete(agent.name);
+    }
+  }
+
+  private toMembraneToolResult(callId: string, afResult: ToolResult): MembraneToolResult {
+    return {
+      toolUseId: callId,
+      content: afResult.isError
+        ? (afResult.error ?? 'Unknown error')
+        : JSON.stringify(afResult.data),
+      isError: afResult.isError,
+    };
   }
 
   private logInference(entry: InferenceLogEntry): void {

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -1,7 +1,13 @@
 import { JsStore } from 'chronicle';
 import type { Membrane, ContentBlock } from 'membrane';
 import { ContextManager, PassthroughStrategy } from '@connectome/context-manager';
-import type { MessageId, MessageMetadata } from '@connectome/context-manager';
+import type {
+  MessageId,
+  MessageMetadata,
+  MessageQuery,
+  MessageQueryResult,
+  StoredMessage,
+} from '@connectome/context-manager';
 import type {
   FrameworkConfig,
   InferencePolicy,
@@ -115,6 +121,8 @@ export class AgentFramework {
       addMessage: (p, c, m) => this.addMessage(p, c, m),
       editMessage: (id, c) => this.editMessage(id, c),
       removeMessage: (id) => this.removeMessage(id),
+      getMessage: (id) => this.getMessage(id),
+      queryMessages: (filter) => this.queryMessages(filter),
     });
   }
 
@@ -1027,6 +1035,22 @@ export class AgentFramework {
       throw new Error('No agents configured');
     }
     agent.getContextManager().removeMessage(id);
+  }
+
+  private getMessage(id: MessageId): StoredMessage | null {
+    const agent = this.agents.values().next().value;
+    if (!agent) {
+      return null;
+    }
+    return agent.getContextManager().getMessage(id);
+  }
+
+  private queryMessages(filter: MessageQuery): MessageQueryResult {
+    const agent = this.agents.values().next().value;
+    if (!agent) {
+      return { messages: [], totalCount: 0 };
+    }
+    return agent.getContextManager().queryMessages(filter);
   }
 
   private createFrameworkState(): FrameworkState {

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -124,6 +124,7 @@ export class AgentFramework {
       removeMessage: (id) => this.removeMessage(id),
       getMessage: (id) => this.getMessage(id),
       queryMessages: (filter) => this.queryMessages(filter),
+      pushEvent: (event) => this.pushEvent(event),
     });
   }
 

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -841,97 +841,14 @@ export class AgentFramework {
     }
   }
 
-  private async runAgentInference(agent: Agent, attempt = 0, trigger?: InferenceRequest): Promise<void> {
-    this.emitTrace({ type: 'inference:started', agentName: agent.name });
-    const startTime = Date.now();
-    const requestId = `${agent.name}-${startTime}-${Math.random().toString(36).slice(2, 8)}`;
-
-    try {
-      const tools = this.moduleRegistry.getAllTools().filter((t) => agent.canUseTool(t.name));
-      const result = await agent.runInference(tools);
-
-      const durationMs = Date.now() - startTime;
-      const tokenUsage = result.usage
-        ? { input: result.usage.inputTokens, output: result.usage.outputTokens }
-        : undefined;
-      this.emitTrace({ type: 'inference:completed', agentName: agent.name, durationMs, tokenUsage });
-
-      // Log successful inference
-      this.logInference({
-        timestamp: startTime,
-        agentName: agent.name,
-        requestId,
-        success: true,
-        request: result.raw?.request ?? { note: 'request not captured' },
-        response: result.raw?.response ?? { note: 'response not captured' },
-        durationMs,
-        tokenUsage: result.usage
-          ? { input: result.usage.inputTokens, output: result.usage.outputTokens }
-          : undefined,
-        stopReason: result.stopReason,
-      });
-
-      // Dispatch speech to handlers
-      if (result.speechContent.length > 0) {
-        const speechContext = {
-          turnComplete: result.toolCalls.length === 0,
-          trigger: trigger ?? {
-            reason: 'unknown',
-            source: 'unknown',
-            timestamp: Date.now(),
-          },
-        };
-        await this.moduleRegistry.dispatchSpeech(
-          agent.name,
-          result.speechContent,
-          speechContext
-        );
-      }
-
-      // Dispatch tool calls
-      for (const call of result.toolCalls) {
-        this.dispatchToolCall(agent.name, call);
-      }
-    } catch (error) {
-      const err = error instanceof Error ? error : new Error(String(error));
-      const durationMs = Date.now() - startTime;
-      this.emitTrace({
-        type: 'inference:failed',
-        agentName: agent.name,
-        error: err.message,
-        stack: err.stack,
-      });
-
-      // Log failed inference
-      this.logInference({
-        timestamp: startTime,
-        agentName: agent.name,
-        requestId,
-        success: false,
-        error: err.message,
-        request: { note: 'request may have failed before capture' },
-        durationMs,
-      });
-
-      // Handle error with policy
-      const action = this.errorPolicy.onInferenceError(err, agent.name, attempt);
-      if (action.retry) {
-        await new Promise((resolve) => setTimeout(resolve, action.delayMs));
-        await this.runAgentInference(agent, attempt + 1, trigger);
-      } else if (action.emit) {
-        this.pushEvent(action.emit);
-      }
-    }
-  }
-
-  private async startAgentStream(agent: Agent, trigger?: InferenceRequest): Promise<void> {
+  private async startAgentStream(agent: Agent, trigger?: InferenceRequest, attempt = 0): Promise<void> {
     this.emitTrace({ type: 'inference:started', agentName: agent.name });
 
     try {
       const tools = this.moduleRegistry.getAllTools().filter((t) => agent.canUseTool(t.name));
       const stream = await agent.startStream(tools);
 
-      const handle = this.driveStream(agent, stream, trigger);
+      const handle = this.driveStream(agent, stream, trigger, attempt);
       this.activeStreams.set(agent.name, handle);
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
@@ -943,10 +860,10 @@ export class AgentFramework {
       });
       agent.reset();
 
-      const action = this.errorPolicy.onInferenceError(err, agent.name, 0);
+      const action = this.errorPolicy.onInferenceError(err, agent.name, attempt);
       if (action.retry) {
         await new Promise((resolve) => setTimeout(resolve, action.delayMs));
-        await this.startAgentStream(agent, trigger);
+        await this.startAgentStream(agent, trigger, attempt + 1);
       } else if (action.emit) {
         this.pushEvent(action.emit);
       }
@@ -956,7 +873,8 @@ export class AgentFramework {
   private async driveStream(
     agent: Agent,
     stream: YieldingStream,
-    trigger?: InferenceRequest
+    trigger?: InferenceRequest,
+    attempt = 0
   ): Promise<void> {
     const startTime = Date.now();
     const requestId = `${agent.name}-${startTime}-${Math.random().toString(36).slice(2, 8)}`;
@@ -983,7 +901,7 @@ export class AgentFramework {
             for (const call of event.calls) {
               this.dispatchToolCall(agent.name, call);
             }
-            // Loop naturally pauses here — stream is waiting for provideToolResults()
+            // Stream's async iterator blocks on next() until provideToolResults() is called
             break;
 
           case 'complete': {
@@ -1025,7 +943,7 @@ export class AgentFramework {
             // Dispatch speech
             if (speechContent.length > 0) {
               const speechContext = {
-                turnComplete: response.toolCalls.length === 0,
+                turnComplete: true,
                 trigger: trigger ?? {
                   reason: 'unknown',
                   source: 'unknown',
@@ -1066,10 +984,10 @@ export class AgentFramework {
 
             agent.reset();
 
-            const action = this.errorPolicy.onInferenceError(err, agent.name, 0);
+            const action = this.errorPolicy.onInferenceError(err, agent.name, attempt);
             if (action.retry) {
               await new Promise((resolve) => setTimeout(resolve, action.delayMs));
-              await this.startAgentStream(agent, trigger);
+              await this.startAgentStream(agent, trigger, attempt + 1);
             } else if (action.emit) {
               this.pushEvent(action.emit);
             }

--- a/src/module-registry.ts
+++ b/src/module-registry.ts
@@ -1,6 +1,12 @@
 import type { JsStore } from 'chronicle';
 import type { ContentBlock } from 'membrane';
-import type { MessageId, MessageMetadata } from '@connectome/context-manager';
+import type {
+  MessageId,
+  MessageMetadata,
+  MessageQuery,
+  MessageQueryResult,
+  StoredMessage,
+} from '@connectome/context-manager';
 import type {
   Module,
   ModuleContext,
@@ -41,6 +47,8 @@ export class ModuleRegistry {
   private addMessageFn: (participant: string, content: ContentBlock[], metadata?: MessageMetadata) => MessageId;
   private editMessageFn: (id: MessageId, content: ContentBlock[]) => void;
   private removeMessageFn: (id: MessageId) => void;
+  private getMessageFn: (id: MessageId) => StoredMessage | null;
+  private queryMessagesFn: (filter: MessageQuery) => MessageQueryResult;
 
   constructor(
     store: JsStore,
@@ -50,6 +58,8 @@ export class ModuleRegistry {
       addMessage: (participant: string, content: ContentBlock[], metadata?: MessageMetadata) => MessageId;
       editMessage: (id: MessageId, content: ContentBlock[]) => void;
       removeMessage: (id: MessageId) => void;
+      getMessage: (id: MessageId) => StoredMessage | null;
+      queryMessages: (filter: MessageQuery) => MessageQueryResult;
     }
   ) {
     this.store = store;
@@ -58,6 +68,8 @@ export class ModuleRegistry {
     this.addMessageFn = options.addMessage;
     this.editMessageFn = options.editMessage;
     this.removeMessageFn = options.removeMessage;
+    this.getMessageFn = options.getMessage;
+    this.queryMessagesFn = options.queryMessages;
   }
 
   /**
@@ -94,7 +106,9 @@ export class ModuleRegistry {
       this.getAgents,
       this.addMessageFn,
       this.editMessageFn,
-      this.removeMessageFn
+      this.removeMessageFn,
+      this.getMessageFn,
+      this.queryMessagesFn
     );
 
     this.modules.set(module.name, module);
@@ -316,6 +330,8 @@ class ModuleContextImpl implements ModuleContext {
   private addMessageFn: (participant: string, content: ContentBlock[], metadata?: MessageMetadata) => MessageId;
   private editMessageFn: (id: MessageId, content: ContentBlock[]) => void;
   private removeMessageFn: (id: MessageId) => void;
+  private getMessageFn: (id: MessageId) => StoredMessage | null;
+  private queryMessagesFn: (filter: MessageQuery) => MessageQueryResult;
 
   // External ID mapping stored in module state
   private externalIdMap: Map<string, MessageId> = new Map();
@@ -330,7 +346,9 @@ class ModuleContextImpl implements ModuleContext {
     getAgents: () => Agent[],
     addMessage: (participant: string, content: ContentBlock[], metadata?: MessageMetadata) => MessageId,
     editMessage: (id: MessageId, content: ContentBlock[]) => void,
-    removeMessage: (id: MessageId) => void
+    removeMessage: (id: MessageId) => void,
+    getMessage: (id: MessageId) => StoredMessage | null,
+    queryMessages: (filter: MessageQuery) => MessageQueryResult
   ) {
     this.moduleName = moduleName;
     this.store = store;
@@ -342,6 +360,8 @@ class ModuleContextImpl implements ModuleContext {
     this.addMessageFn = addMessage;
     this.editMessageFn = editMessage;
     this.removeMessageFn = removeMessage;
+    this.getMessageFn = getMessage;
+    this.queryMessagesFn = queryMessages;
 
     // Load external ID map from state if exists
     const state = this.getState<{ externalIdMap?: Record<string, string> }>();
@@ -405,6 +425,14 @@ class ModuleContextImpl implements ModuleContext {
   findMessageByExternalId(source: string, externalId: string): MessageId | null {
     const key = `${source}:${externalId}`;
     return this.externalIdMap.get(key) ?? null;
+  }
+
+  getMessage(id: MessageId): StoredMessage | null {
+    return this.getMessageFn(id);
+  }
+
+  queryMessages(filter: MessageQuery): MessageQueryResult {
+    return this.queryMessagesFn(filter);
   }
 
   getAgents(): AgentInfo[] {

--- a/src/module-registry.ts
+++ b/src/module-registry.ts
@@ -19,6 +19,7 @@ import type {
   ExternalIdRef,
   SpeechContext,
   SpeechHandlerOptions,
+  ProcessEvent,
 } from './types/index.js';
 import type { Agent } from './agent.js';
 
@@ -50,6 +51,8 @@ export class ModuleRegistry {
   private getMessageFn: (id: MessageId) => StoredMessage | null;
   private queryMessagesFn: (filter: MessageQuery) => MessageQueryResult;
 
+  private pushEventFn: (event: ProcessEvent) => void;
+
   constructor(
     store: JsStore,
     queue: ProcessQueue,
@@ -60,6 +63,7 @@ export class ModuleRegistry {
       removeMessage: (id: MessageId) => void;
       getMessage: (id: MessageId) => StoredMessage | null;
       queryMessages: (filter: MessageQuery) => MessageQueryResult;
+      pushEvent: (event: ProcessEvent) => void;
     }
   ) {
     this.store = store;
@@ -70,6 +74,7 @@ export class ModuleRegistry {
     this.removeMessageFn = options.removeMessage;
     this.getMessageFn = options.getMessage;
     this.queryMessagesFn = options.queryMessages;
+    this.pushEventFn = options.pushEvent;
   }
 
   /**
@@ -108,7 +113,8 @@ export class ModuleRegistry {
       this.editMessageFn,
       this.removeMessageFn,
       this.getMessageFn,
-      this.queryMessagesFn
+      this.queryMessagesFn,
+      this.pushEventFn
     );
 
     this.modules.set(module.name, module);
@@ -332,6 +338,7 @@ class ModuleContextImpl implements ModuleContext {
   private removeMessageFn: (id: MessageId) => void;
   private getMessageFn: (id: MessageId) => StoredMessage | null;
   private queryMessagesFn: (filter: MessageQuery) => MessageQueryResult;
+  private pushEventFn: (event: ProcessEvent) => void;
 
   // External ID mapping stored in module state
   private externalIdMap: Map<string, MessageId> = new Map();
@@ -348,7 +355,8 @@ class ModuleContextImpl implements ModuleContext {
     editMessage: (id: MessageId, content: ContentBlock[]) => void,
     removeMessage: (id: MessageId) => void,
     getMessage: (id: MessageId) => StoredMessage | null,
-    queryMessages: (filter: MessageQuery) => MessageQueryResult
+    queryMessages: (filter: MessageQuery) => MessageQueryResult,
+    pushEvent: (event: ProcessEvent) => void
   ) {
     this.moduleName = moduleName;
     this.store = store;
@@ -362,6 +370,7 @@ class ModuleContextImpl implements ModuleContext {
     this.removeMessageFn = removeMessage;
     this.getMessageFn = getMessage;
     this.queryMessagesFn = queryMessages;
+    this.pushEventFn = pushEvent;
 
     // Load external ID map from state if exists
     const state = this.getState<{ externalIdMap?: Record<string, string> }>();
@@ -454,6 +463,10 @@ class ModuleContextImpl implements ModuleContext {
     this.registry.unregisterSpeechHandler(this.moduleName);
   }
 
+  pushEvent(event: ProcessEvent): void {
+    this.pushEventFn(event);
+  }
+
   private persistExternalIdMap(): void {
     const currentState = this.getState<object>() ?? {};
     this.setState({
@@ -499,5 +512,9 @@ class ProcessStateImpl implements ProcessState {
 
   get queue(): ProcessQueue {
     return this.ctx.queue;
+  }
+
+  pushEvent(event: ProcessEvent): void {
+    this.ctx.pushEvent(event);
   }
 }

--- a/src/modules/discord/discord-js-client.ts
+++ b/src/modules/discord/discord-js-client.ts
@@ -9,8 +9,19 @@ import {
   TextChannel,
   DMChannel,
   type Message,
+  type Attachment,
+  type User,
+  type Guild,
+  type GuildBasedChannel,
 } from 'discord.js';
-import type { DiscordClientInterface, DiscordMessageData, DiscordAttachment } from './types.js';
+import type {
+  DiscordClientInterface,
+  DiscordMessageData,
+  DiscordAttachment,
+  DiscordGuild,
+  DiscordChannel,
+  HistoryMessage,
+} from './types.js';
 
 export interface DiscordJsClientConfig {
   token: string;
@@ -27,6 +38,7 @@ export class DiscordJsClient implements DiscordClientInterface {
   private messageHandler?: (message: DiscordMessageData) => void;
   private editHandler?: (messageId: string, newContent: string) => void;
   private deleteHandler?: (messageId: string) => void;
+  private readyHandler?: () => void;
 
   constructor(config: DiscordJsClientConfig) {
     this.token = config.token;
@@ -48,7 +60,7 @@ export class DiscordJsClient implements DiscordClientInterface {
   }
 
   private setupEventHandlers(): void {
-    this.client.on('messageCreate', (message) => {
+    this.client.on('messageCreate', (message: Message) => {
       if (!this.shouldHandleMessage(message)) return;
       if (this.messageHandler) {
         this.messageHandler(this.convertMessage(message));
@@ -68,9 +80,12 @@ export class DiscordJsClient implements DiscordClientInterface {
 
     this.client.on('ready', () => {
       console.log(`[Discord] Logged in as ${this.client.user?.tag}`);
+      if (this.readyHandler) {
+        this.readyHandler();
+      }
     });
 
-    this.client.on('error', (error) => {
+    this.client.on('error', (error: Error) => {
       console.error('[Discord] Client error:', error);
     });
   }
@@ -99,7 +114,7 @@ export class DiscordJsClient implements DiscordClientInterface {
   }
 
   private convertMessage(message: Message): DiscordMessageData {
-    const attachments: DiscordAttachment[] = message.attachments.map((a) => ({
+    const attachments: DiscordAttachment[] = message.attachments.map((a: Attachment) => ({
       id: a.id,
       filename: a.name ?? 'unknown',
       url: a.url,
@@ -107,15 +122,23 @@ export class DiscordJsClient implements DiscordClientInterface {
       size: a.size,
     }));
 
+    // Extract mentioned user IDs
+    const mentionedUserIds = message.mentions.users.map((u: User) => u.id);
+
     return {
       id: message.id,
       content: message.content,
       authorId: message.author.id,
       authorName: message.author.username,
+      isBot: message.author.bot,
       channelId: message.channelId,
       guildId: message.guildId ?? null,
       isReply: message.reference !== null,
       replyToId: message.reference?.messageId ?? undefined,
+      // Note: replyToAuthorId requires fetching the referenced message
+      // We'll leave it undefined for now - can be enhanced later if needed
+      replyToAuthorId: undefined,
+      mentionedUserIds,
       attachments,
       timestamp: message.createdAt,
     };
@@ -217,5 +240,105 @@ export class DiscordJsClient implements DiscordClientInterface {
 
   onMessageDelete(handler: (messageId: string) => void): void {
     this.deleteHandler = handler;
+  }
+
+  onReady(handler: () => void): void {
+    this.readyHandler = handler;
+  }
+
+  getBotUserId(): string | null {
+    return this.client.user?.id ?? null;
+  }
+
+  async sendTyping(channelId: string): Promise<void> {
+    const channel = await this.client.channels.fetch(channelId);
+    if (!channel || !('sendTyping' in channel)) {
+      throw new Error(`Channel ${channelId} not found or not a text channel`);
+    }
+    await (channel as TextChannel).sendTyping();
+  }
+
+  async listGuilds(): Promise<DiscordGuild[]> {
+    const guilds = this.client.guilds.cache;
+    return guilds.map((g: Guild) => ({
+      id: g.id,
+      name: g.name,
+      iconUrl: g.iconURL() ?? undefined,
+      memberCount: g.memberCount,
+    }));
+  }
+
+  async listChannels(guildId: string): Promise<DiscordChannel[]> {
+    const guild = await this.client.guilds.fetch(guildId);
+    if (!guild) {
+      throw new Error(`Guild ${guildId} not found`);
+    }
+
+    // guild.channels might be undefined if the guild was fetched without full data
+    if (!guild.channels) {
+      throw new Error(`Guild ${guildId} channels not available - may need to re-fetch with force`);
+    }
+
+    const channels = await guild.channels.fetch();
+    const result: DiscordChannel[] = [];
+    
+    channels.forEach((c: GuildBasedChannel | null) => {
+      if (c) {
+        result.push({
+          id: c.id,
+          name: c.name,
+          type: this.mapChannelType(c.type),
+          parentId: c.parentId ?? undefined,
+          position: 'position' in c ? (c as { position?: number }).position : undefined,
+        });
+      }
+    });
+    
+    return result;
+  }
+
+  private mapChannelType(type: number | undefined): DiscordChannel['type'] {
+    if (type === undefined) return 'unknown';
+    // Discord.js channel types: 0=text, 2=voice, 4=category, 11=thread, 15=forum
+    switch (type) {
+      case 0: return 'text';
+      case 2: return 'voice';
+      case 4: return 'category';
+      case 11:
+      case 12: return 'thread';
+      case 15: return 'forum';
+      default: return 'unknown';
+    }
+  }
+
+  async fetchHistory(
+    channelId: string,
+    options?: { limit?: number; before?: string }
+  ): Promise<HistoryMessage[]> {
+    const channel = await this.client.channels.fetch(channelId);
+    if (!channel || !('messages' in channel)) {
+      throw new Error(`Channel ${channelId} not found or not a text channel`);
+    }
+
+    const textChannel = channel as TextChannel;
+    const messages = await textChannel.messages.fetch({
+      limit: options?.limit ?? 50,
+      before: options?.before,
+    });
+
+    return messages.map((m: Message) => ({
+      id: m.id,
+      authorId: m.author.id,
+      authorName: m.author.username,
+      isBot: m.author.bot,
+      content: m.content,
+      timestamp: m.createdAt,
+      replyTo: m.reference
+        ? {
+            messageId: m.reference.messageId ?? '',
+            authorId: '', // Would need additional fetch to get this
+          }
+        : undefined,
+    }));
   }
 }

--- a/src/modules/discord/index.ts
+++ b/src/modules/discord/index.ts
@@ -36,6 +36,9 @@ import type {
   DeleteMessageInput,
   CreateThreadInput,
   SetReplyContextInput,
+  ListGuildsInput,
+  ListChannelsInput,
+  FetchHistoryInput,
 } from './types.js';
 
 // Re-export event types for consumers who want to handle them
@@ -48,7 +51,25 @@ const DEFAULT_CONFIG: Partial<DiscordModuleConfig> = {
   handleDMs: true,
   ignoreBots: true,
   rateLimitPerMinute: 30,
+  triggerOn: 'mention_or_reply',
+  autoTyping: true,
+  historyScrollback: 50,
 };
+
+// Image MIME types that Claude can process
+const SUPPORTED_IMAGE_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+];
+
+// Text file extensions for inline reading
+const TEXT_FILE_EXTENSIONS = [
+  '.txt', '.md', '.json', '.yaml', '.yml', '.toml',
+  '.js', '.ts', '.jsx', '.tsx', '.py', '.rb', '.go', '.rs',
+  '.html', '.css', '.xml', '.csv', '.log', '.sh', '.bash',
+];
 
 const CONVERSATION_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
 
@@ -65,6 +86,7 @@ export class DiscordModule implements Module {
     connectedGuilds: [],
     conversations: {},
     rateLimits: {},
+    lastReadMessageId: {},
   };
 
   // Track current reply context per agent
@@ -94,9 +116,24 @@ export class DiscordModule implements Module {
     this.client.onMessageEdit((id, content) => this.handleDiscordMessageEdit(id, content));
     this.client.onMessageDelete((id) => this.handleDiscordMessageDelete(id));
 
+    // Set up ready handler for history sync on (re)connect
+    if (this.client.onReady) {
+      this.client.onReady(() => this.handleReady());
+    }
+
     // Connect to Discord
     if (!ctx.isRestart || !this.client.isConnected()) {
       await this.client.connect();
+    } else {
+      // Already connected (restart) - sync history now
+      await this.syncAllChannelHistory();
+    }
+
+    // Get bot user ID after connect
+    const botUserId = this.client.getBotUserId();
+    if (botUserId) {
+      this.state.botUserId = botUserId;
+      ctx.setState(this.state);
     }
   }
 
@@ -246,6 +283,39 @@ export class DiscordModule implements Module {
           properties: {},
         },
       },
+      // ========== Discovery & Utility Tools ==========
+      {
+        name: 'list_guilds',
+        description: 'List all Discord servers (guilds) the bot is in',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+        },
+      },
+      {
+        name: 'list_channels',
+        description: 'List all channels in a Discord server',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            guildId: { type: 'string', description: 'Guild/Server ID' },
+          },
+          required: ['guildId'],
+        },
+      },
+      {
+        name: 'fetch_history',
+        description: 'Fetch recent message history from a channel',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            channelId: { type: 'string', description: 'Channel ID' },
+            limit: { type: 'number', description: 'Number of messages to fetch (default: 50, max: 100)' },
+            before: { type: 'string', description: 'Fetch messages before this message ID' },
+          },
+          required: ['channelId'],
+        },
+      },
     ];
   }
 
@@ -272,6 +342,12 @@ export class DiscordModule implements Module {
           return await this.handleActivate(call.input as { additive?: boolean });
         case 'deactivate':
           return await this.handleDeactivate();
+        case 'list_guilds':
+          return await this.handleListGuilds();
+        case 'list_channels':
+          return await this.handleListChannels(call.input as ListChannelsInput);
+        case 'fetch_history':
+          return await this.handleFetchHistory(call.input as FetchHistoryInput);
         default:
           return { success: false, error: `Unknown tool: ${call.name}`, isError: true };
       }
@@ -292,6 +368,7 @@ export class DiscordModule implements Module {
         connectedGuilds: [],
         conversations: {},
         rateLimits: {},
+        lastReadMessageId: {},
       };
 
       // Build conversation state update
@@ -314,25 +391,41 @@ export class DiscordModule implements Module {
           ...currentState.conversations,
           [convKey]: conversation,
         },
+        lastReadMessageId: {
+          ...currentState.lastReadMessageId,
+          [msg.channelId]: msg.discordMessageId,
+        },
       };
 
       // Update local state reference for tool handlers
       this.state = newState;
+
+      // Auto-send typing indicator if configured
+      if (this.config.autoTyping) {
+        // Fire and forget - don't await
+        this.client.sendTyping(msg.channelId).catch((err) => {
+          console.warn('Discord: Failed to send typing indicator:', err);
+        });
+      }
+
+      // Build content blocks from message and attachments
+      const contentBlocks = msg.contentBlocks ?? [{ type: 'text' as const, text: msg.content }];
 
       // Return declarative response - framework applies all writes atomically
       return {
         addMessages: [
           {
             participant: msg.authorName,
-            content: [{ type: 'text', text: msg.content }],
+            content: contentBlocks,
             metadata: {
               external: { source: 'discord', id: msg.discordMessageId },
+              channelId: msg.channelId,
               timestamp: msg.timestamp,
             },
           },
         ],
         stateUpdate: newState,
-        requestInference: true,
+        requestInference: msg.shouldTriggerInference ?? true,
       };
     }
 
@@ -411,11 +504,205 @@ export class DiscordModule implements Module {
   // Discord Event Handlers
   // ==========================================================================
 
-  private handleDiscordMessage(message: DiscordMessageData): void {
+  /**
+   * Handle Discord ready event - sync history for all tracked channels.
+   */
+  private async handleReady(): Promise<void> {
+    console.log('[Discord] Ready - syncing history for tracked channels');
+    
+    // Get bot user ID
+    const botUserId = this.client.getBotUserId();
+    if (botUserId) {
+      this.state.botUserId = botUserId;
+    }
+
+    await this.syncAllChannelHistory();
+  }
+
+  /**
+   * Sync history for all channels we have conversations in.
+   */
+  private async syncAllChannelHistory(): Promise<void> {
     if (!this.ctx) return;
 
-    // Ignore bots if configured
-    if (this.config.ignoreBots && message.authorId === 'bot') {
+    // Get unique channel IDs from conversations
+    const channelIds = new Set<string>();
+    for (const conv of Object.values(this.state.conversations)) {
+      channelIds.add(conv.channelId);
+    }
+
+    if (channelIds.size === 0) {
+      console.log('[Discord] No channels to sync');
+      return;
+    }
+
+    console.log(`[Discord] Syncing history for ${channelIds.size} channel(s)`);
+
+    const syncResults: Array<{
+      channelId: string;
+      newMessages: number;
+      editedMessages: number;
+      deletedMessages: number;
+    }> = [];
+
+    for (const channelId of channelIds) {
+      try {
+        const result = await this.syncChannelHistory(channelId);
+        if (result.newMessages > 0 || result.editedMessages > 0 || result.deletedMessages > 0) {
+          syncResults.push({ channelId, ...result });
+        }
+      } catch (error) {
+        console.error(`[Discord] Failed to sync channel ${channelId}:`, error);
+      }
+    }
+
+    // Emit sync complete event if there were any changes
+    if (syncResults.length > 0 && this.ctx) {
+      const totalNew = syncResults.reduce((sum, r) => sum + r.newMessages, 0);
+      const totalEdited = syncResults.reduce((sum, r) => sum + r.editedMessages, 0);
+      const totalDeleted = syncResults.reduce((sum, r) => sum + r.deletedMessages, 0);
+
+      console.log(`[Discord] History sync complete: ${totalNew} new, ${totalEdited} edited, ${totalDeleted} deleted`);
+
+      // Push a notification event (doesn't trigger inference, just informs)
+      this.ctx.queue.push({
+        type: 'module-event',
+        source: 'discord',
+        eventType: 'history-sync-complete',
+        payload: {
+          channels: syncResults.length,
+          newMessages: totalNew,
+          editedMessages: totalEdited,
+          deletedMessages: totalDeleted,
+        },
+      });
+    }
+
+    this.ctx?.setState(this.state);
+  }
+
+  /**
+   * Sync history for a specific channel - compare with Context Manager and update.
+   * Uses queryMessages() to enumerate stored messages for proper edit/delete detection.
+   */
+  private async syncChannelHistory(channelId: string): Promise<{
+    newMessages: number;
+    editedMessages: number;
+    deletedMessages: number;
+  }> {
+    if (!this.ctx) {
+      return { newMessages: 0, editedMessages: 0, deletedMessages: 0 };
+    }
+
+    const scrollback = this.config.historyScrollback ?? 50;
+    
+    // Fetch recent history from Discord
+    const discordMessages = await this.client.fetchHistory(channelId, { limit: scrollback });
+    
+    // Build a map of Discord message ID -> content for comparison
+    const discordMessageMap = new Map<string, { content: string; authorName: string; timestamp: Date }>();
+    for (const msg of discordMessages) {
+      discordMessageMap.set(msg.id, {
+        content: msg.content,
+        authorName: msg.authorName,
+        timestamp: msg.timestamp,
+      });
+    }
+
+    // Query Context Manager for all Discord messages from this channel
+    const { messages: storedMessages } = this.ctx.queryMessages({
+      source: 'discord',
+      metadata: { channelId },
+    });
+
+    // Build a map of stored message external IDs -> internal data
+    const storedMessageMap = new Map<string, { internalId: string; content: string }>();
+    for (const msg of storedMessages) {
+      const external = msg.metadata?.external as { id?: string } | undefined;
+      if (external?.id) {
+        // Extract text content for comparison
+        const textContent = msg.content
+          .filter((block): block is { type: 'text'; text: string } => block.type === 'text')
+          .map((block) => block.text)
+          .join('\n');
+        storedMessageMap.set(external.id, {
+          internalId: msg.id,
+          content: textContent,
+        });
+      }
+    }
+
+    let newMessages = 0;
+    let editedMessages = 0;
+    let deletedMessages = 0;
+
+    // Process Discord messages - check for new/edited
+    for (const discordMsg of discordMessages) {
+      const stored = storedMessageMap.get(discordMsg.id);
+      
+      if (!stored) {
+        // New message we haven't seen
+        // For bot's own messages (from previous sessions), use the agent name
+        // This ensures continuity of conversation history
+        const isBotMessage = discordMsg.authorId === this.state.botUserId;
+        const agentName = this.ctx.getAgents()[0]?.name;
+        const participantName = isBotMessage 
+          ? (agentName ?? discordMsg.authorName)
+          : discordMsg.authorName;
+        
+        this.ctx.addMessage(
+          participantName,
+          [{ type: 'text', text: discordMsg.content }],
+          {
+            external: { source: 'discord', id: discordMsg.id },
+            channelId,
+            timestamp: discordMsg.timestamp.getTime(),
+            isOwnMessage: isBotMessage, // Mark as our own for reference
+          }
+        );
+        newMessages++;
+      } else {
+        // We have this message - check if content changed (offline edit detection)
+        if (stored.content !== discordMsg.content) {
+          this.ctx.editMessage(stored.internalId, [
+            { type: 'text', text: discordMsg.content },
+          ]);
+          editedMessages++;
+        }
+      }
+    }
+
+    // Check for deletes - messages we have that Discord doesn't
+    // Only consider messages within the scrollback window (recent ones)
+    for (const [externalId, stored] of storedMessageMap) {
+      if (!discordMessageMap.has(externalId)) {
+        // Message exists in our store but not in Discord - it was deleted
+        // Note: This only catches deletes within the scrollback window
+        this.ctx.removeMessage(stored.internalId);
+        deletedMessages++;
+      }
+    }
+
+    // Update last read
+    if (discordMessages.length > 0) {
+      // Messages are typically newest first
+      const newestId = discordMessages[0].id;
+      this.state.lastReadMessageId[channelId] = newestId;
+    }
+
+    return { newMessages, editedMessages, deletedMessages };
+  }
+
+  private async handleDiscordMessage(message: DiscordMessageData): Promise<void> {
+    if (!this.ctx) return;
+
+    // ALWAYS ignore our own messages to prevent feedback loops
+    if (this.state.botUserId && message.authorId === this.state.botUserId) {
+      return;
+    }
+
+    // Optionally ignore other bots
+    if (this.config.ignoreBots && message.isBot) {
       return;
     }
 
@@ -434,9 +721,16 @@ export class DiscordModule implements Module {
     }
 
     // Check if we should handle DMs
-    if (!message.guildId && !this.config.handleDMs) {
+    const isDM = !message.guildId;
+    if (isDM && !this.config.handleDMs) {
       return;
     }
+
+    // Determine if this message should trigger inference
+    const shouldTrigger = this.shouldTriggerInference(message, isDM);
+
+    // Convert message content including attachments
+    const contentBlocks = await this.convertMessageToContent(message);
 
     // Only queue the event - all state writes happen in onProcess()
     this.ctx.queue.push({
@@ -447,9 +741,117 @@ export class DiscordModule implements Module {
       authorId: message.authorId,
       authorName: message.authorName,
       content: message.content,
-      timestamp: message.timestamp,
+      contentBlocks,
+      timestamp: message.timestamp.getTime(),
       attachments: message.attachments,
-    });
+      shouldTriggerInference: shouldTrigger,
+    } as DiscordMessageEvent);
+  }
+
+  /**
+   * Convert Discord message to ContentBlock array.
+   * Includes text content and any supported attachments (images, text files).
+   */
+  private async convertMessageToContent(message: DiscordMessageData): Promise<ContentBlock[]> {
+    const blocks: ContentBlock[] = [];
+
+    // Add text content if present
+    if (message.content.trim()) {
+      blocks.push({ type: 'text', text: message.content });
+    }
+
+    // Process attachments
+    for (const attachment of message.attachments) {
+      const contentType = attachment.contentType?.toLowerCase() ?? '';
+      const filename = attachment.filename.toLowerCase();
+
+      // Check for supported image types
+      if (SUPPORTED_IMAGE_TYPES.some(type => contentType.startsWith(type))) {
+        blocks.push({
+          type: 'image',
+          source: {
+            type: 'url',
+            url: attachment.url,
+          },
+        } as ContentBlock);
+        continue;
+      }
+
+      // Check for text files - fetch and include content
+      const isTextFile = TEXT_FILE_EXTENSIONS.some(ext => filename.endsWith(ext));
+      if (isTextFile && attachment.size && attachment.size < 100_000) { // < 100KB
+        try {
+          const response = await fetch(attachment.url);
+          if (response.ok) {
+            const textContent = await response.text();
+            blocks.push({
+              type: 'text',
+              text: `\n--- File: ${attachment.filename} ---\n${textContent}\n--- End of ${attachment.filename} ---\n`,
+            });
+          }
+        } catch (error) {
+          // If fetch fails, just note the attachment
+          blocks.push({
+            type: 'text',
+            text: `[Attachment: ${attachment.filename} (failed to fetch)]`,
+          });
+        }
+        continue;
+      }
+
+      // For unsupported attachments, add a note
+      blocks.push({
+        type: 'text',
+        text: `[Attachment: ${attachment.filename} (${contentType || 'unknown type'})]`,
+      });
+    }
+
+    // Ensure we have at least empty text if nothing else
+    if (blocks.length === 0) {
+      blocks.push({ type: 'text', text: '[Empty message]' });
+    }
+
+    return blocks;
+  }
+
+  /**
+   * Determine if a message should trigger agent inference based on config.
+   */
+  private shouldTriggerInference(message: DiscordMessageData, isDM: boolean): boolean {
+    const triggerMode = this.config.triggerOn ?? 'mention_or_reply';
+    const botUserId = this.state.botUserId;
+
+    // Check if bot is mentioned
+    const isMentioned = botUserId
+      ? message.mentionedUserIds.includes(botUserId)
+      : false;
+
+    // Check if this is a reply to bot's message
+    const isReplyToBot = botUserId
+      ? message.replyToAuthorId === botUserId
+      : false;
+
+    switch (triggerMode) {
+      case 'all':
+        // Always trigger (use with caution!)
+        return true;
+
+      case 'mention':
+        // Only trigger on direct @mention
+        return isMentioned;
+
+      case 'mention_or_reply':
+        // Trigger on @mention OR when replying to bot
+        return isMentioned || isReplyToBot;
+
+      case 'dm_or_mention':
+        // DMs always trigger, channels require mention
+        return isDM || isMentioned;
+
+      default:
+        // Fallback: mention_or_reply behavior
+        return isMentioned || isReplyToBot;
+    }
   }
 
   private handleDiscordMessageEdit(messageId: string, newContent: string): void {
@@ -590,6 +992,68 @@ export class DiscordModule implements Module {
 
     this.ctx.unregisterSpeechHandler();
     return { success: true, data: { message: 'Discord is no longer handling speech' } };
+  }
+
+  private async handleListGuilds(): Promise<ToolResult> {
+    const guilds = await this.client.listGuilds();
+    return {
+      success: true,
+      data: {
+        guilds: guilds.map((g) => ({
+          id: g.id,
+          name: g.name,
+          memberCount: g.memberCount,
+        })),
+      },
+    };
+  }
+
+  private async handleListChannels(input: ListChannelsInput): Promise<ToolResult> {
+    const channels = await this.client.listChannels(input.guildId);
+    return {
+      success: true,
+      data: {
+        guildId: input.guildId,
+        channels: channels.map((c) => ({
+          id: c.id,
+          name: c.name,
+          type: c.type,
+          parentId: c.parentId,
+        })),
+      },
+    };
+  }
+
+  private async handleFetchHistory(input: FetchHistoryInput): Promise<ToolResult> {
+    const limit = Math.min(input.limit ?? 50, 100); // Cap at 100
+    const messages = await this.client.fetchHistory(input.channelId, {
+      limit,
+      before: input.before,
+    });
+
+    // Update last read if we got messages
+    if (messages.length > 0) {
+      const latestId = messages[0].id; // Assuming sorted newest first
+      this.state.lastReadMessageId[input.channelId] = latestId;
+      this.ctx?.setState(this.state);
+    }
+
+    return {
+      success: true,
+      data: {
+        channelId: input.channelId,
+        messageCount: messages.length,
+        messages: messages.map((m) => ({
+          id: m.id,
+          author: m.authorName,
+          authorId: m.authorId,
+          isBot: m.isBot,
+          content: m.content,
+          timestamp: m.timestamp.toISOString(),
+          replyTo: m.replyTo,
+        })),
+      },
+    };
   }
 
   // ==========================================================================

--- a/src/modules/discord/types.ts
+++ b/src/modules/discord/types.ts
@@ -2,6 +2,8 @@
  * Types for the Discord module
  */
 
+import type { ContentBlock } from 'membrane';
+
 // ============================================================================
 // Module Configuration
 // ============================================================================
@@ -27,6 +29,25 @@ export interface DiscordModuleConfig {
 
   /** Rate limit: max messages per minute per channel (default: 30) */
   rateLimitPerMinute?: number;
+
+  /**
+   * When to trigger agent inference (default: 'mention')
+   * - 'all': Every message triggers inference (use with caution!)
+   * - 'mention': Only when bot is @mentioned
+   * - 'mention_or_reply': When mentioned OR when replying to bot's message
+   * - 'dm_or_mention': DMs always trigger, channels require mention
+   */
+  triggerOn?: 'all' | 'mention' | 'mention_or_reply' | 'dm_or_mention';
+
+  /** 
+   * Auto-send typing indicator when agent is activated (default: true)
+   */
+  autoTyping?: boolean;
+
+  /**
+   * Number of messages to fetch on history sync (default: 50)
+   */
+  historyScrollback?: number;
 }
 
 // ============================================================================
@@ -42,6 +63,12 @@ export interface DiscordModuleState {
 
   /** Rate limit tracking */
   rateLimits: Record<string, RateLimitInfo>;
+
+  /** Bot user ID (set after connect) */
+  botUserId?: string;
+
+  /** Last read message ID per channel (for history sync) */
+  lastReadMessageId: Record<string, string>;
 }
 
 export interface ConversationContext {
@@ -163,6 +190,87 @@ export interface SetReplyContextInput {
   replyToMessageId?: string;
 }
 
+export interface ListGuildsInput {
+  // No parameters needed
+}
+
+export interface ListChannelsInput {
+  /** Guild ID to list channels for */
+  guildId: string;
+}
+
+export interface FetchHistoryInput {
+  /** Channel ID to fetch history from */
+  channelId: string;
+
+  /** Number of messages to fetch (default: 50) */
+  limit?: number;
+
+  /** Fetch messages before this message ID */
+  before?: string;
+}
+
+// ============================================================================
+// Discord Data Types (returned by tools)
+// ============================================================================
+
+export interface DiscordGuild {
+  /** Guild ID */
+  id: string;
+
+  /** Guild name */
+  name: string;
+
+  /** Guild icon URL (optional) */
+  iconUrl?: string;
+
+  /** Number of members */
+  memberCount?: number;
+}
+
+export interface DiscordChannel {
+  /** Channel ID */
+  id: string;
+
+  /** Channel name */
+  name: string;
+
+  /** Channel type */
+  type: 'text' | 'voice' | 'category' | 'thread' | 'forum' | 'unknown';
+
+  /** Parent category ID (if applicable) */
+  parentId?: string;
+
+  /** Position in channel list */
+  position?: number;
+}
+
+export interface HistoryMessage {
+  /** Message ID */
+  id: string;
+
+  /** Author user ID */
+  authorId: string;
+
+  /** Author username */
+  authorName: string;
+
+  /** Whether author is a bot */
+  isBot: boolean;
+
+  /** Message content */
+  content: string;
+
+  /** Timestamp */
+  timestamp: Date;
+
+  /** Reply info (if this is a reply) */
+  replyTo?: {
+    messageId: string;
+    authorId: string;
+  };
+}
+
 // ============================================================================
 // Discord Events (internal)
 // ============================================================================
@@ -183,6 +291,9 @@ export interface DiscordMessageData {
   /** Author username */
   authorName: string;
 
+  /** Whether the author is a bot */
+  isBot: boolean;
+
   /** Message content */
   content: string;
 
@@ -191,6 +302,12 @@ export interface DiscordMessageData {
 
   /** ID of message being replied to */
   replyToId?: string;
+
+  /** Author ID of the message being replied to */
+  replyToAuthorId?: string;
+
+  /** User IDs mentioned in this message */
+  mentionedUserIds: string[];
 
   /** Attachments */
   attachments: DiscordAttachment[];
@@ -232,8 +349,12 @@ export interface DiscordMessageEvent {
   authorId: string;
   authorName: string;
   content: string;
-  timestamp: Date;
+  /** Pre-converted content blocks (includes attachments) */
+  contentBlocks?: ContentBlock[];
+  timestamp: number;
   attachments: DiscordAttachment[];
+  /** Whether this message should trigger agent inference */
+  shouldTriggerInference?: boolean;
   [key: string]: unknown; // Required for CustomEvent compatibility
 }
 
@@ -276,6 +397,9 @@ export interface DiscordClientInterface {
   /** Disconnect from Discord */
   disconnect(): Promise<void>;
 
+  /** Get the bot's user ID (available after connect) */
+  getBotUserId(): string | null;
+
   /** Send a message to a channel */
   sendMessage(
     channelId: string,
@@ -306,6 +430,21 @@ export interface DiscordClientInterface {
     autoArchiveDuration?: number
   ): Promise<{ threadId: string }>;
 
+  /** Send typing indicator to a channel */
+  sendTyping(channelId: string): Promise<void>;
+
+  /** List guilds the bot is in */
+  listGuilds(): Promise<DiscordGuild[]>;
+
+  /** List channels in a guild */
+  listChannels(guildId: string): Promise<DiscordChannel[]>;
+
+  /** Fetch message history from a channel */
+  fetchHistory(
+    channelId: string,
+    options?: { limit?: number; before?: string }
+  ): Promise<HistoryMessage[]>;
+
   /** Register message handler */
   onMessage(handler: (message: DiscordMessageData) => void): void;
 
@@ -314,6 +453,9 @@ export interface DiscordClientInterface {
 
   /** Register message delete handler */
   onMessageDelete(handler: (messageId: string) => void): void;
+
+  /** Register ready handler (called when connected and ready) */
+  onReady?(handler: () => void): void;
 
   /** Check if connected */
   isConnected(): boolean;

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -1,4 +1,4 @@
-import type { ContentBlock } from 'membrane';
+import type { ContentBlock, YieldingStream } from 'membrane';
 import type { ContextStrategy } from '@connectome/context-manager';
 import type { ToolCallId, ToolResult, ToolCall } from './events.js';
 
@@ -67,8 +67,9 @@ export interface InferenceResult {
 export type AgentState =
   | { status: 'idle' }
   | { status: 'inferring'; promise: Promise<InferenceResult> }
-  | { status: 'waiting_for_tools'; pending: Map<ToolCallId, PendingToolCall>; completed: CompletedToolCall[] }
-  | { status: 'ready'; toolResults: CompletedToolCall[] };
+  | { status: 'streaming'; stream: YieldingStream }
+  | { status: 'waiting_for_tools'; pending: Map<ToolCallId, PendingToolCall>; completed: CompletedToolCall[]; stream?: YieldingStream }
+  | { status: 'ready'; toolResults: CompletedToolCall[]; stream?: YieldingStream };
 
 /**
  * A tool call that's in progress.

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -67,7 +67,7 @@ export interface InferenceResult {
 export type AgentState =
   | { status: 'idle' }
   | { status: 'inferring'; promise: Promise<InferenceResult> }
-  | { status: 'waiting_for_tools'; pending: Map<ToolCallId, PendingToolCall> }
+  | { status: 'waiting_for_tools'; pending: Map<ToolCallId, PendingToolCall>; completed: CompletedToolCall[] }
   | { status: 'ready'; toolResults: CompletedToolCall[] };
 
 /**

--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -216,7 +216,7 @@ export interface AgentInfo {
 /**
  * Agent execution status.
  */
-export type AgentStatus = 'idle' | 'inferring' | 'waiting_for_tools' | 'ready';
+export type AgentStatus = 'idle' | 'inferring' | 'streaming' | 'waiting_for_tools' | 'ready';
 
 /**
  * Response from a module's event handler.

--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -1,5 +1,11 @@
 import type { ContentBlock } from 'membrane';
-import type { MessageId, MessageMetadata } from '@connectome/context-manager';
+import type {
+  MessageId,
+  MessageMetadata,
+  MessageQuery,
+  MessageQueryResult,
+  StoredMessage,
+} from '@connectome/context-manager';
 import type { ProcessEvent, ToolDefinition, ToolCall, ToolResult } from './events.js';
 
 /**
@@ -101,6 +107,17 @@ export interface ModuleContext {
    * Find a message by external ID.
    */
   findMessageByExternalId(source: string, externalId: string): MessageId | null;
+
+  /**
+   * Get a message by ID.
+   */
+  getMessage(id: MessageId): StoredMessage | null;
+
+  /**
+   * Query messages by filter criteria.
+   * Useful for finding messages from external sources, by participant, etc.
+   */
+  queryMessages(filter: MessageQuery): MessageQueryResult;
 
   /**
    * Get info about all agents.

--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -76,8 +76,15 @@ export interface ModuleContext {
 
   /**
    * Process queue for pushing events from external listeners.
+   * @deprecated Use pushEvent() instead — it also emits process:received traces.
    */
   readonly queue: ProcessQueue;
+
+  /**
+   * Push a process event to the queue and emit a process:received trace.
+   * Preferred over direct queue.push() for proper observability.
+   */
+  pushEvent(event: ProcessEvent): void;
 
   /**
    * Get another module by name.
@@ -182,8 +189,15 @@ export interface ProcessState {
 
   /**
    * Queue for emitting follow-up events.
+   * @deprecated Use pushEvent() instead — it also emits process:received traces.
    */
   readonly queue: ProcessQueue;
+
+  /**
+   * Push a process event to the queue and emit a process:received trace.
+   * Preferred over direct queue.push() for proper observability.
+   */
+  pushEvent(event: ProcessEvent): void;
 }
 
 /**

--- a/src/types/trace.ts
+++ b/src/types/trace.ts
@@ -50,6 +50,22 @@ export type TraceEvent =
       stack?: string;
     })
 
+  // Streaming inference lifecycle
+  | (TraceEventBase & {
+      type: 'inference:tokens';
+      agentName: string;
+      content: string;
+    })
+  | (TraceEventBase & {
+      type: 'inference:tool_calls_yielded';
+      agentName: string;
+      calls: Array<{ id: string; name: string }>;
+    })
+  | (TraceEventBase & {
+      type: 'inference:stream_resumed';
+      agentName: string;
+    })
+
   // Tool lifecycle
   | (TraceEventBase & {
       type: 'tool:started';

--- a/test/framework.test.ts
+++ b/test/framework.test.ts
@@ -37,11 +37,15 @@ function createMockResponse(
     .map((b) => b.text)
     .join('');
 
+  const toolCalls = content
+    .filter((b): b is ContentBlock & { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> } => b.type === 'tool_use')
+    .map((b) => ({ id: b.id, name: b.name, input: b.input }));
+
   return {
     content,
     stopReason,
     rawAssistantText: rawText,
-    toolCalls: [],
+    toolCalls,
     toolResults: [],
     usage: { inputTokens: 10, outputTokens: 5 },
     details: {

--- a/test/framework.test.ts
+++ b/test/framework.test.ts
@@ -7,7 +7,7 @@ import assert from 'node:assert';
 import { tmpdir } from 'node:os';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
-import type { NormalizedRequest, NormalizedResponse, ContentBlock } from 'membrane';
+import type { NormalizedRequest, NormalizedResponse, ContentBlock, YieldingStream, StreamEvent } from 'membrane';
 import type {
   Module,
   ModuleContext,
@@ -26,6 +26,114 @@ import { AgentFramework, ProcessQueueImpl } from '../src/index.js';
 
 interface MinimalMembrane {
   complete(request: NormalizedRequest): Promise<NormalizedResponse>;
+  streamYielding(request: NormalizedRequest, options?: unknown): YieldingStream;
+}
+
+/**
+ * Mock yielding stream for testing the streaming inference path.
+ * Takes a sequence of responses: first response starts the stream,
+ * subsequent responses resume after each tool round.
+ */
+class MockYieldingStream implements YieldingStream {
+  private events: StreamEvent[] = [];
+  private _done = false;
+  private _isWaitingForTools = false;
+  private _pendingToolCallIds: string[] = [];
+  private _toolDepth = 0;
+  private pendingResolve: (() => void) | null = null;
+
+  constructor(private responses: NormalizedResponse[]) {
+    this.processResponse(0);
+  }
+
+  private processResponse(index: number): void {
+    const response = this.responses[index];
+    if (!response) {
+      this._done = true;
+      return;
+    }
+
+    // Emit tokens
+    const text = response.rawAssistantText;
+    if (text) {
+      this.events.push({
+        type: 'tokens',
+        content: text,
+        meta: { type: 'text', visible: true, blockIndex: 0 },
+      } as StreamEvent);
+    }
+
+    // Emit usage
+    if (response.usage) {
+      this.events.push({ type: 'usage', usage: response.usage } as StreamEvent);
+    }
+
+    // Tool calls or complete
+    if (response.toolCalls.length > 0) {
+      this._isWaitingForTools = true;
+      this._pendingToolCallIds = response.toolCalls.map((c) => c.id);
+      this.events.push({
+        type: 'tool-calls',
+        calls: response.toolCalls.map((tc) => ({
+          id: tc.id,
+          name: tc.name,
+          input: tc.input as Record<string, unknown>,
+        })),
+        context: {
+          rawText: '',
+          preamble: '',
+          depth: this._toolDepth,
+          previousResults: [],
+          accumulated: '',
+        },
+      } as StreamEvent);
+    } else {
+      this.events.push({ type: 'complete', response } as StreamEvent);
+      this._done = true;
+    }
+  }
+
+  provideToolResults(_results: unknown[]): void {
+    if (!this._isWaitingForTools) throw new Error('Not waiting for tools');
+    this._isWaitingForTools = false;
+    this._pendingToolCallIds = [];
+    this._toolDepth++;
+    this.processResponse(this._toolDepth);
+    // Wake up the iterator
+    if (this.pendingResolve) {
+      const resolve = this.pendingResolve;
+      this.pendingResolve = null;
+      resolve();
+    }
+  }
+
+  cancel(): void {
+    this._done = true;
+    this.events.push({ type: 'aborted', reason: 'user' } as StreamEvent);
+    if (this.pendingResolve) {
+      const resolve = this.pendingResolve;
+      this.pendingResolve = null;
+      resolve();
+    }
+  }
+
+  get isWaitingForTools() { return this._isWaitingForTools; }
+  get pendingToolCallIds() { return [...this._pendingToolCallIds]; }
+  get toolDepth() { return this._toolDepth; }
+
+  async *[Symbol.asyncIterator](): AsyncIterator<StreamEvent> {
+    while (true) {
+      while (this.events.length > 0) {
+        const event = this.events.shift()!;
+        yield event;
+        if (event.type === 'complete' || event.type === 'error' || event.type === 'aborted') {
+          return;
+        }
+      }
+      if (this._done) return;
+      await new Promise<void>((resolve) => { this.pendingResolve = resolve; });
+    }
+  }
 }
 
 function createMockResponse(
@@ -75,6 +183,14 @@ class MockMembrane implements MinimalMembrane {
       return createMockResponse([{ type: 'text', text: 'Default response' }]);
     }
     return this.responses[this.responseIndex++];
+  }
+
+  streamYielding(request: NormalizedRequest, _options?: unknown): YieldingStream {
+    this.calls.push(request);
+    // All remaining queued responses feed the stream
+    const remaining = this.responses.slice(this.responseIndex);
+    this.responseIndex = this.responses.length;
+    return new MockYieldingStream(remaining);
   }
 
   // Cast helper - use this when passing to framework
@@ -328,8 +444,8 @@ describe('AgentFramework', () => {
     assert.strictEqual(testModule.toolCalls[0].name, 'echo');
     assert.deepStrictEqual(testModule.toolCalls[0].input, { message: 'test message' });
 
-    // Check membrane was called twice (initial + after tool result)
-    assert.strictEqual(membrane.calls.length, 2);
+    // With streaming, membrane is called once (streamYielding handles tool rounds internally)
+    assert.strictEqual(membrane.calls.length, 1);
 
     await framework.stop();
     rmSync(tempDir, { recursive: true });
@@ -465,6 +581,177 @@ describe('AgentFramework', () => {
     // We can close it ourselves
     store.close();
 
+    rmSync(tempDir, { recursive: true });
+  });
+});
+
+describe('Streaming lifecycle', () => {
+  let tempDir: string;
+  let membrane: MockMembrane;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'agent-framework-stream-'));
+    membrane = new MockMembrane();
+  });
+
+  it('should complete a simple stream without tool calls', async () => {
+    const testModule = new TestModule();
+    const events: string[] = [];
+
+    membrane.pushResponse(createMockResponse([{ type: 'text', text: 'Hello from stream' }]));
+
+    const framework = await AgentFramework.create({
+      storePath: join(tempDir, 'test.chronicle'),
+      membrane: membrane.asMembrane(),
+      agents: [{ name: 'assistant', model: 'test-model', systemPrompt: 'Test' }],
+      modules: [testModule],
+    });
+
+    framework.onTrace((event) => events.push(event.type));
+
+    framework.pushEvent({
+      type: 'external-message',
+      source: 'test',
+      content: 'Hello',
+      metadata: {},
+    });
+
+    await framework.runUntilIdle();
+
+    assert.ok(events.includes('inference:started'));
+    assert.ok(events.includes('inference:tokens'));
+    assert.ok(events.includes('inference:completed'));
+
+    // Agent should be idle after completion
+    const agent = framework.getAgent('assistant')!;
+    assert.strictEqual(agent.state.status, 'idle');
+
+    await framework.stop();
+    rmSync(tempDir, { recursive: true });
+  });
+
+  it('should handle multi-round tool calls in a single stream', async () => {
+    const testModule = new TestModule();
+
+    // Round 1: tool call
+    membrane.pushResponse(createMockResponse([
+      { type: 'text', text: 'First echo.' },
+      { type: 'tool_use', id: 'call_1', name: 'test:echo', input: { message: 'round1' } },
+    ], 'tool_use'));
+
+    // Round 2: another tool call
+    membrane.pushResponse(createMockResponse([
+      { type: 'text', text: 'Second echo.' },
+      { type: 'tool_use', id: 'call_2', name: 'test:echo', input: { message: 'round2' } },
+    ], 'tool_use'));
+
+    // Round 3: final response
+    membrane.pushResponse(createMockResponse([
+      { type: 'text', text: 'Done with both echoes.' },
+    ]));
+
+    const framework = await AgentFramework.create({
+      storePath: join(tempDir, 'test.chronicle'),
+      membrane: membrane.asMembrane(),
+      agents: [{ name: 'assistant', model: 'test-model', systemPrompt: 'Test' }],
+      modules: [testModule],
+    });
+
+    framework.pushEvent({
+      type: 'external-message',
+      source: 'test',
+      content: 'Do two echoes',
+      metadata: {},
+    });
+
+    await framework.runUntilIdle();
+
+    // Both tools were called
+    assert.strictEqual(testModule.toolCalls.length, 2);
+    assert.deepStrictEqual(testModule.toolCalls[0].input, { message: 'round1' });
+    assert.deepStrictEqual(testModule.toolCalls[1].input, { message: 'round2' });
+
+    // Still only one membrane call (one stream)
+    assert.strictEqual(membrane.calls.length, 1);
+
+    // Agent is idle
+    assert.strictEqual(framework.getAgent('assistant')!.state.status, 'idle');
+
+    await framework.stop();
+    rmSync(tempDir, { recursive: true });
+  });
+
+  it('should cancel active streams on stop', async () => {
+    const testModule = new TestModule();
+
+    // Response with a tool call but no follow-up (stream will wait forever)
+    membrane.pushResponse(createMockResponse([
+      { type: 'tool_use', id: 'call_hang', name: 'test:echo', input: { message: 'hang' } },
+    ], 'tool_use'));
+
+    const framework = await AgentFramework.create({
+      storePath: join(tempDir, 'test.chronicle'),
+      membrane: membrane.asMembrane(),
+      agents: [{ name: 'assistant', model: 'test-model', systemPrompt: 'Test' }],
+      modules: [testModule],
+    });
+
+    framework.pushEvent({
+      type: 'external-message',
+      source: 'test',
+      content: 'Hang',
+      metadata: {},
+    });
+
+    // Process the event and start streaming (but don't wait for idle — it won't happen)
+    // Let the stream start and dispatch the tool call
+    for (let i = 0; i < 10; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+
+    // stop() should cancel active streams and not hang
+    await framework.stop();
+
+    // Agent should be idle after cancellation
+    assert.strictEqual(framework.getAgent('assistant')!.state.status, 'idle');
+
+    rmSync(tempDir, { recursive: true });
+  });
+
+  it('should emit tool_calls_yielded and stream_resumed traces', async () => {
+    const testModule = new TestModule();
+    const events: string[] = [];
+
+    membrane.pushResponse(createMockResponse([
+      { type: 'tool_use', id: 'call_t', name: 'test:echo', input: { message: 'trace' } },
+    ], 'tool_use'));
+    membrane.pushResponse(createMockResponse([
+      { type: 'text', text: 'Done' },
+    ]));
+
+    const framework = await AgentFramework.create({
+      storePath: join(tempDir, 'test.chronicle'),
+      membrane: membrane.asMembrane(),
+      agents: [{ name: 'assistant', model: 'test-model', systemPrompt: 'Test' }],
+      modules: [testModule],
+    });
+
+    framework.onTrace((event) => events.push(event.type));
+
+    framework.pushEvent({
+      type: 'external-message',
+      source: 'test',
+      content: 'Trace test',
+      metadata: {},
+    });
+
+    await framework.runUntilIdle();
+
+    assert.ok(events.includes('inference:tool_calls_yielded'), 'Should emit tool_calls_yielded');
+    assert.ok(events.includes('inference:stream_resumed'), 'Should emit stream_resumed');
+    assert.ok(events.includes('inference:completed'), 'Should emit completed');
+
+    await framework.stop();
     rmSync(tempDir, { recursive: true });
   });
 });

--- a/test/framework.test.ts
+++ b/test/framework.test.ts
@@ -41,6 +41,7 @@ class MockYieldingStream implements YieldingStream {
   private _pendingToolCallIds: string[] = [];
   private _toolDepth = 0;
   private pendingResolve: (() => void) | null = null;
+  receivedToolResults: unknown[][] = [];
 
   constructor(private responses: NormalizedResponse[]) {
     this.processResponse(0);
@@ -93,8 +94,9 @@ class MockYieldingStream implements YieldingStream {
     }
   }
 
-  provideToolResults(_results: unknown[]): void {
+  provideToolResults(results: unknown[]): void {
     if (!this._isWaitingForTools) throw new Error('Not waiting for tools');
+    this.receivedToolResults.push(results);
     this._isWaitingForTools = false;
     this._pendingToolCallIds = [];
     this._toolDepth++;
@@ -170,6 +172,7 @@ function createMockResponse(
 class MockMembrane implements MinimalMembrane {
   responses: NormalizedResponse[] = [];
   calls: NormalizedRequest[] = [];
+  lastStream: MockYieldingStream | null = null;
   private responseIndex = 0;
 
   pushResponse(response: NormalizedResponse): void {
@@ -190,7 +193,9 @@ class MockMembrane implements MinimalMembrane {
     // All remaining queued responses feed the stream
     const remaining = this.responses.slice(this.responseIndex);
     this.responseIndex = this.responses.length;
-    return new MockYieldingStream(remaining);
+    const stream = new MockYieldingStream(remaining);
+    this.lastStream = stream;
+    return stream;
   }
 
   // Cast helper - use this when passing to framework
@@ -750,6 +755,45 @@ describe('Streaming lifecycle', () => {
     assert.ok(events.includes('inference:tool_calls_yielded'), 'Should emit tool_calls_yielded');
     assert.ok(events.includes('inference:stream_resumed'), 'Should emit stream_resumed');
     assert.ok(events.includes('inference:completed'), 'Should emit completed');
+
+    await framework.stop();
+    rmSync(tempDir, { recursive: true });
+  });
+
+  it('should convert AF tool results to Membrane format when resuming stream', async () => {
+    const testModule = new TestModule();
+
+    membrane.pushResponse(createMockResponse([
+      { type: 'tool_use', id: 'call_conv', name: 'test:echo', input: { message: 'convert' } },
+    ], 'tool_use'));
+    membrane.pushResponse(createMockResponse([
+      { type: 'text', text: 'Converted' },
+    ]));
+
+    const framework = await AgentFramework.create({
+      storePath: join(tempDir, 'test.chronicle'),
+      membrane: membrane.asMembrane(),
+      agents: [{ name: 'assistant', model: 'test-model', systemPrompt: 'Test' }],
+      modules: [testModule],
+    });
+
+    framework.pushEvent({
+      type: 'external-message',
+      source: 'test',
+      content: 'Convert test',
+      metadata: {},
+    });
+
+    await framework.runUntilIdle();
+
+    // Verify the mock stream received correctly converted tool results
+    const stream = membrane.lastStream!;
+    assert.strictEqual(stream.receivedToolResults.length, 1);
+    const results = stream.receivedToolResults[0] as Array<{ toolUseId: string; content: string; isError?: boolean }>;
+    assert.strictEqual(results.length, 1);
+    assert.strictEqual(results[0].toolUseId, 'call_conv');
+    assert.strictEqual(results[0].content, JSON.stringify({ echoed: 'convert' }));
+    assert.strictEqual(results[0].isError, undefined);
 
     await framework.stop();
     rmSync(tempDir, { recursive: true });


### PR DESCRIPTION
Agent-framework counterpart to: https://github.com/antra-tess/membrane/pull/6
**Incorporates AF PR** https://github.com/antra-tess/agent-framework/pull/5

Implements inference in a non-blocking way, allowing the host to process i/o and churn business logic while an inference is ongoing. 

**Opinionated**: inflicts the streaming/yielding path as the **default** for AF. This should not reasonably break any existing usage, though. 

Driveby fixes:

1. 16f23ee fix tool result aggregation — provideToolResult() was only keeping the last completed result instead of accumulating them. Added completed: CompletedToolCall[] 
  to waiting_for_tools state and accumulated results properly. (Bug existed since init, just never hit because tests only had single tool calls.)
  
  2. 752148b fix tool-call test — The "should handle tool calls" test had a broken mock that caused a spurious failure. 
  
  3. 9aac010 expose pushEvent() on ModuleContext and ProcessState — amends the module context contract to provide an unified PushEvent function instead of providing context directly. This allows trace events to fire properly, as needed for the dogfooding test with this feature (discord typing notifications as long as inference is in progress).