### PR TITLE
Detect and recover from zombie ephemeral agents

### DIFF
--- a/src/framework.ts
+++ b/src/framework.ts
@@ -504,13 +504,31 @@ export class AgentFramework {
       let speech = '';
       let toolCallsCount = 0;
       let settled = false;
+      let inferenceStarted = false;
+
+      const STARTUP_TIMEOUT_MS = 30_000;
 
       const cleanup = () => {
         if (settled) return;
         settled = true;
+        clearTimeout(startupWatchdog);
         this.offTrace(traceListener);
         this.agents.delete(agent.name);
       };
+
+      // Watchdog: if inference never starts within 30s, the agent is a zombie.
+      // This catches cases where the event loop stalled, the agent was
+      // deregistered, or processInferenceRequests() skipped the request.
+      const startupWatchdog = setTimeout(() => {
+        if (!inferenceStarted && !settled) {
+          cleanup();
+          reject(new Error(
+            `Ephemeral agent "${agent.name}" failed to start inference within ` +
+            `${STARTUP_TIMEOUT_MS}ms — zombie detected. The event loop may have ` +
+            `stalled or the inference request was dropped.`
+          ));
+        }
+      }, STARTUP_TIMEOUT_MS);
 
       const traceListener = (event: TraceEvent) => {
         if (settled) return;
@@ -519,7 +537,11 @@ export class AgentFramework {
         if (agentName !== agent.name) return;
 
         switch (event.type) {
+          case 'inference:started':
+            inferenceStarted = true;
+            break;
           case 'inference:tokens': {
+            inferenceStarted = true;
             const content = (event as { content?: string }).content;
             if (content) speech += content;
             break;
@@ -1178,6 +1200,8 @@ export class AgentFramework {
       return;
     }
 
+    const STALE_REQUEST_MS = 30_000;
+    const now = Date.now();
     const state = this.createFrameworkState();
 
     // Group requests by agent
@@ -1194,11 +1218,32 @@ export class AgentFramework {
     // Check each agent
     for (const [agentName, requests] of requestsByAgent) {
       const agent = this.agents.get(agentName);
-      if (!agent) continue;
+      if (!agent) {
+        // Agent not found — request is orphaned. Emit warning and drop.
+        const oldest = Math.min(...requests.map(r => r.timestamp));
+        this.emitTrace({
+          type: 'inference:request_dropped',
+          agentName,
+          reason: 'agent_not_found',
+          requestCount: requests.length,
+          oldestRequestAge: now - oldest,
+        });
+        continue;
+      }
 
       // Skip if agent is busy (inferring, streaming, or waiting for tools)
       if (agent.state.status === 'inferring' || agent.state.status === 'streaming' || agent.state.status === 'waiting_for_tools') {
-        // Re-queue requests
+        // Re-queue requests, but warn if they've been pending too long
+        const oldest = Math.min(...requests.map(r => r.timestamp));
+        if (now - oldest > STALE_REQUEST_MS) {
+          this.emitTrace({
+            type: 'inference:request_stale',
+            agentName,
+            agentStatus: agent.state.status,
+            requestCount: requests.length,
+            oldestRequestAge: now - oldest,
+          });
+        }
         this.pendingRequests.push(...requests);
         continue;
       }

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -1714,35 +1714,38 @@ export class AgentFramework {
   }
 
   private dispatchToolCall(agentName: string, call: ToolCall): void {
+    // Enrich call with caller identity so modules can resolve the calling agent
+    const enrichedCall: ToolCall = { ...call, callerAgentName: agentName };
+
     // Route MCPL tool calls to the appropriate server via prefix map
-    const mcplMatch = this.resolveMcplTool(call.name);
+    const mcplMatch = this.resolveMcplTool(enrichedCall.name);
     if (mcplMatch && this.mcplServerRegistry) {
-      this.dispatchMcplToolCall(agentName, call, mcplMatch[0], mcplMatch[1]);
+      this.dispatchMcplToolCall(agentName, enrichedCall, mcplMatch[0], mcplMatch[1]);
       return;
     }
 
     // Route synthesized channel tools
-    if (call.name.startsWith('channel_') && this.channelRegistry) {
-      this.dispatchChannelToolCall(agentName, call);
+    if (enrichedCall.name.startsWith('channel_') && this.channelRegistry) {
+      this.dispatchChannelToolCall(agentName, enrichedCall);
       return;
     }
 
-    const colonIndex = call.name.indexOf(':');
-    const moduleName = colonIndex >= 0 ? call.name.substring(0, colonIndex) : 'unknown';
+    const colonIndex = enrichedCall.name.indexOf(':');
+    const moduleName = colonIndex >= 0 ? enrichedCall.name.substring(0, colonIndex) : 'unknown';
 
     this.emitTrace({
       type: 'tool:started',
       module: moduleName,
-      tool: call.name,
-      callId: call.id,
-      input: call.input,
+      tool: enrichedCall.name,
+      callId: enrichedCall.id,
+      input: enrichedCall.input,
     });
 
     const startTime = Date.now();
 
     // Execute tool asynchronously
     this.moduleRegistry
-      .handleToolCall(call)
+      .handleToolCall(enrichedCall)
       .then((result) => {
         const durationMs = Date.now() - startTime;
         this.emitTrace({

--- a/src/module-registry.ts
+++ b/src/module-registry.ts
@@ -228,11 +228,12 @@ export class ModuleRegistry {
       };
     }
 
-    // Create a call with the un-prefixed name
+    // Create a call with the un-prefixed name (preserving caller identity)
     const moduleCall: ToolCall = {
       id: call.id,
       name: toolName,
       input: call.input,
+      callerAgentName: call.callerAgentName,
     };
 
     try {

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -189,6 +189,8 @@ export interface ToolCall {
   name: string;
   /** Tool input */
   input: unknown;
+  /** The agent that made this tool call. Set by the framework dispatch layer. */
+  callerAgentName?: string;
 }
 
 // ============================================================================

--- a/src/types/trace.ts
+++ b/src/types/trace.ts
@@ -115,6 +115,22 @@ export type TraceEvent =
   | (TraceEventBase & { type: 'module:added'; moduleName: string })
   | (TraceEventBase & { type: 'module:removed'; moduleName: string })
 
+  // Inference request health
+  | (TraceEventBase & {
+      type: 'inference:request_dropped';
+      agentName: string;
+      reason: string;
+      requestCount: number;
+      oldestRequestAge: number;
+    })
+  | (TraceEventBase & {
+      type: 'inference:request_stale';
+      agentName: string;
+      agentStatus: string;
+      requestCount: number;
+      oldestRequestAge: number;
+    })
+
   // Message lifecycle
   | (TraceEventBase & {
       type: 'message:added';


### PR DESCRIPTION
## Summary
- Adds a 30s startup watchdog to `runEphemeralToCompletion` — if inference never starts, the promise rejects with a "zombie detected" error instead of silently holding a concurrency slot
- Adds `inference:request_dropped` and `inference:request_stale` trace events to surface cases where inference requests are silently swallowed or re-queued indefinitely

## Context
Postmortem from a zulip-app session where a zombie fork (`lead-ssr-route`) held 1 of 3 concurrency slots for ~2 hours, blocking all subsequent sub-forks. The fork was created and acknowledged but never started inference — no watchdog existed to detect this.

## Test plan
- [x] All 19 existing tests pass
- [x] Type-checks clean
- [ ] Run a zulip-app session with intentional fork load to verify watchdog fires correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)