### PR TITLE
Re-export KnowledgeStrategy from context-manager

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,5 +52,6 @@ export type {
 
 // Re-export commonly used types from dependencies
 export type { ContextManager, ContextStrategy, TokenBudget } from '@connectome/context-manager';
-export { PassthroughStrategy, AutobiographicalStrategy } from '@connectome/context-manager';
+export { PassthroughStrategy, AutobiographicalStrategy, KnowledgeStrategy } from '@connectome/context-manager';
+export type { KnowledgeConfig, PhaseType } from '@connectome/context-manager';
 export type { Membrane, NormalizedMessage, NormalizedRequest, ContentBlock } from 'membrane';


### PR DESCRIPTION
## Summary

- Re-exports `KnowledgeStrategy`, `KnowledgeConfig`, and `PhaseType` from `@connectome/context-manager`
- Companion to [context-manager PR #7](https://github.com/anima-research/context-manager/pull/7)
- Allows FKM and other apps to import `KnowledgeStrategy` from `@connectome/agent-framework`

## Test plan

- [x] `npx tsc --noEmit` passes
- [ ] FKM integration (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)