### PR TITLE
Mcpl event type

### DIFF
--- a/src/framework.ts
+++ b/src/framework.ts
@@ -1953,6 +1953,11 @@ export class AgentFramework {
       try {
         const connection = await this.mcplServerRegistry.addServer(config, hostCapabilities);
 
+        // Wire event listeners then flush any events that arrived during the
+        // handshake window (between setupMessageRouting and now).
+        this.wireMcplEvents(connection);
+        connection.ready();
+
         // Initialize feature sets if server advertises MCPL capabilities
         if (connection.capabilities) {
           const updateParams = this.featureSetManager.initializeServer(
@@ -1989,9 +1994,6 @@ export class AgentFramework {
             }
           }
         }
-
-        // Wire event listeners for this connection
-        this.wireMcplEvents(connection);
 
         this.emitTrace({ type: 'module:added', moduleName: `mcpl:${config.id}` });
       } catch (error) {

--- a/src/mcpl/channel-registry.ts
+++ b/src/mcpl/channel-registry.ts
@@ -335,7 +335,7 @@ export class ChannelRegistry {
           .join('\n');
         triggerInference = this.shouldTriggerInference(
           textContent,
-          message.metadata ?? {},
+          { ...message.metadata, eventType: 'channel:incoming' },
         );
       }
 

--- a/src/mcpl/channel-registry.ts
+++ b/src/mcpl/channel-registry.ts
@@ -238,11 +238,13 @@ export class ChannelRegistry {
       registeredIds.push(channel.id);
     }
 
-    // Auto-open all registered channels
-    await this.autoOpenChannels(serverId, params.channels);
-
+    // Respond before auto-opening — the server blocks on this response and
+    // can't process channels/open until it arrives.
     const result: ChannelsRegisterResult = { registered: registeredIds };
     responder?.respond(result);
+
+    // Auto-open all registered channels
+    await this.autoOpenChannels(serverId, params.channels);
 
     this.emitTraceFn({
       type: 'mcpl:channels-register',
@@ -557,17 +559,12 @@ export class ChannelRegistry {
   // Private: Auto-open channels
   // ==========================================================================
 
-  /**
-   * Auto-open newly registered channels by sending `channels/open` to the server.
-   */
   private async autoOpenChannels(
     serverId: string,
     channels: ChannelDescriptor[],
   ): Promise<void> {
     const server = this.serverRegistry.getServer(serverId);
-    if (!server) {
-      return;
-    }
+    if (!server) return;
 
     for (const channel of channels) {
       const key = `${serverId}:${channel.id}`;
@@ -581,7 +578,6 @@ export class ChannelRegistry {
           entry.open = true;
         }
       } catch (err) {
-        // Log but do not fail — channel may not support open
         this.emitTraceFn({
           type: 'mcpl:channel-open-failed',
           serverId,

--- a/src/mcpl/push-handler.ts
+++ b/src/mcpl/push-handler.ts
@@ -195,6 +195,7 @@ export class PushHandler {
         serverId,
         featureSet: params.featureSet,
         eventId: params.eventId,
+        eventType: 'push:event',
         ...(params.origin ?? {}),
       };
       triggerInference = this.shouldTriggerInference(textContent, metadata);

--- a/src/mcpl/server-connection.ts
+++ b/src/mcpl/server-connection.ts
@@ -84,6 +84,10 @@ export class McplServerConnection extends EventEmitter {
   private pendingRequests = new Map<string | number, PendingRequest>();
   private closed = false;
 
+  // Event buffering: events emitted before ready() are queued, not lost
+  private readyFlag = false;
+  private bufferedEvents: Array<{ event: string; args: unknown[] }> = [];
+
   // Reconnect state (adapted from Anarchid/agent-framework@mcpl-module-proto)
   private config: McplServerConfig | null = null;
   private hostCapabilities: McplHostCapabilities | null = null;
@@ -111,6 +115,36 @@ export class McplServerConnection extends EventEmitter {
       this.setupMessageRouting();
       this.setupLifecycle();
     }
+  }
+
+  // ==========================================================================
+  // Event buffering
+  // ==========================================================================
+
+  /**
+   * Mark the connection as ready — flushes any events that arrived between
+   * construction (when setupMessageRouting starts emitting) and now (when
+   * the caller has attached listeners via wireMcplEvents).
+   */
+  ready(): void {
+    this.readyFlag = true;
+    for (const { event, args } of this.bufferedEvents) {
+      super.emit(event, ...args);
+    }
+    this.bufferedEvents = [];
+  }
+
+  /**
+   * Override emit to buffer server→host events until ready() is called.
+   * Lifecycle events ('close', 'error', 'reconnect') always pass through.
+   */
+  override emit(event: string | symbol, ...args: unknown[]): boolean {
+    const name = typeof event === 'string' ? event : '';
+    if (this.readyFlag || name === 'close' || name === 'error' || name === 'reconnect') {
+      return super.emit(event, ...args);
+    }
+    this.bufferedEvents.push({ event: name, args });
+    return true;
   }
 
   // ==========================================================================
@@ -472,6 +506,7 @@ export class McplServerConnection extends EventEmitter {
       // Re-wire message routing and lifecycle on the new process
       this.setupMessageRouting();
       this.setupLifecycle();
+      this.readyFlag = true; // Listeners already attached from initial wire
 
       console.error(`MCPL server "${this.id}" reconnected successfully`);
       this.emit('reconnect');


### PR DESCRIPTION
- pass event type for mcpl-injected events (channel incoming messages and push notifs) so that AF can filter them for inference 
- defuse a possible mcpl deadlock where host and client simultaneously await each other