### PR TITLE
Fix missing durationMs in inference:aborted and broken enrichedCall refs

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -33,6 +33,7 @@ export class Agent {
   readonly temperature: number;
 
   private _state: AgentState = { status: 'idle' };
+  private _inferenceStartedAt = 0;
   private _streamId = 0;
   lastStreamInputTokens = 0;
   maxStreamTokens: number;
@@ -195,6 +196,7 @@ export class Agent {
     }
 
     // Set state to inferring
+    this._inferenceStartedAt = Date.now();
     const inferencePromise = this.doInference(request, abortController.signal);
     this._state = { status: 'inferring', promise: inferencePromise, abortController };
 
@@ -287,6 +289,7 @@ export class Agent {
     }
 
     this._streamId++;
+    this._inferenceStartedAt = Date.now();
     this.lastStreamInputTokens = 0;
 
     const { messages, systemInjections } = await this.compileWithInjections(budget, injections);
@@ -408,16 +411,18 @@ export class Agent {
     return this.systemPrompt + '\n' + injectedText.join('\n');
   }
 
-  abortInference(reason?: string): boolean {
+  abortInference(reason?: string): { aborted: true; durationMs: number } | false {
     if (this._state.status === 'inferring') {
+      const durationMs = Date.now() - this._inferenceStartedAt;
       this._state.abortController.abort(reason);
-      return true;
+      return { aborted: true, durationMs };
     }
 
     if (this._state.status === 'streaming' ||
         (this._state.status === 'waiting_for_tools' && this._state.stream)) {
+      const durationMs = Date.now() - this._inferenceStartedAt;
       this.cancelStream();
-      return true;
+      return { aborted: true, durationMs };
     }
 
     return false;

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -438,11 +438,11 @@ export class AgentFramework {
     if (!agent) {
       return false;
     }
-    const aborted = agent.abortInference(reason);
-    if (aborted) {
-      this.emitTrace({ type: 'inference:aborted', agentName, reason });
+    const result = agent.abortInference(reason);
+    if (result) {
+      this.emitTrace({ type: 'inference:aborted', agentName, reason, durationMs: result.durationMs });
     }
-    return aborted;
+    return !!result;
   }
 
   /**
@@ -1978,15 +1978,15 @@ export class AgentFramework {
     this.emitTrace({
       type: 'tool:started',
       module: moduleName,
-      tool: enrichedCall.name,
-      callId: enrichedCall.id,
-      input: enrichedCall.input,
+      tool: call.name,
+      callId: call.id,
+      input: call.input,
     });
 
     const startTime = Date.now();
 
     this.moduleRegistry
-      .handleToolCall(enrichedCall)
+      .handleToolCall(call)
       .then((result) => {
         const durationMs = Date.now() - startTime;
         this.emitTrace({


### PR DESCRIPTION
## Summary
- **inference:aborted trace missing durationMs**: The `emitTrace` call for `inference:aborted` omitted the required `durationMs` field. Added `_inferenceStartedAt` tracking on `Agent` and changed `abortInference` to return the computed duration, which the framework now passes to the trace event.
- **Undefined `enrichedCall` in `dispatchToolCallEvent`**: Four references to `enrichedCall` were left over from a rename to `call`, causing a build error. Replaced with the correct `call` variable.

## Test plan
- [ ] Verify `npx tsc --noEmit` passes cleanly (confirmed locally)
- [ ] Confirm `inference:aborted` trace events now include `durationMs`
- [ ] Confirm tool dispatch (`dispatchToolCallEvent`) works without runtime errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)