### PR TITLE
MCPL v0.5: state management, branches, and WebSocket transport

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -450,6 +450,11 @@ export class ApiServer {
       parent: this.currentBranch,
     });
 
+    this.framework.notifyBranchChanged('created', params.name, {
+      parent: this.currentBranch,
+      source: 'api',
+    });
+
     if (params.switchTo) {
       await this.cmdBranchSwitch({ name: params.name });
     }
@@ -471,6 +476,11 @@ export class ApiServer {
     this.broadcast('branch:switched', {
       from: previousBranch,
       to: params.name,
+    });
+
+    this.framework.notifyBranchChanged('switched', params.name, {
+      previous: previousBranch,
+      source: 'api',
     });
 
     return { switched: true };
@@ -497,6 +507,8 @@ export class ApiServer {
     store.deleteBranch(params.name);
 
     this.broadcast('branch:deleted', { name: params.name });
+
+    this.framework.notifyBranchChanged('deleted', params.name, { source: 'api' });
 
     return { deleted: true };
   }

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -62,6 +62,21 @@ import type {
   ChannelsRegisterParams,
   ChannelsChangedParams,
   ChannelsIncomingParams,
+  StateUpdateParams,
+  StateUpdateResult,
+  StateGetParams,
+  StateGetResult,
+  BranchesListParams,
+  BranchesListResult,
+  BranchesCurrentParams,
+  BranchesCurrentResult,
+  BranchesCreateParams,
+  BranchesCreateResult,
+  BranchesSwitchParams,
+  BranchesSwitchResult,
+  BranchesDeleteParams,
+  BranchesDeleteResult,
+  BranchInfo,
 } from './mcpl/types.js';
 import type { ContextInjection } from '@connectome/context-manager';
 
@@ -1417,6 +1432,303 @@ export class AgentFramework {
     }
   }
 
+  /**
+   * Handle a state/update from an MCPL server (Section 8.8).
+   * Validates the feature set, checks parent checkpoint matches, and records
+   * the checkpoint in the CheckpointManager.
+   */
+  private handleStateUpdate(
+    serverId: string,
+    params: StateUpdateParams,
+    responder?: { respond: (result: unknown) => void; respondError: (code: number, message: string, data?: unknown) => void },
+  ): void {
+    // Validate feature set
+    try {
+      this.featureSetManager?.validateInbound(serverId, params.featureSet);
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : 'Feature set validation failed';
+      const result: StateUpdateResult = { accepted: false, reason };
+      responder?.respond(result);
+      return;
+    }
+
+    // Validate payload: data and patch are mutually exclusive (both absent = opaque checkpoint)
+    if (params.data !== undefined && params.patch !== undefined) {
+      const result: StateUpdateResult = { accepted: false, reason: 'data and patch are mutually exclusive' };
+      responder?.respond(result);
+      return;
+    }
+
+    if (!this.checkpointManager) {
+      const result: StateUpdateResult = { accepted: false, reason: 'State management not available' };
+      responder?.respond(result);
+      return;
+    }
+
+    // Reject if the feature set isn't registered as stateful
+    if (!this.checkpointManager.isStateful(serverId, params.featureSet)) {
+      const result: StateUpdateResult = { accepted: false, reason: 'Feature set is not registered as stateful' };
+      responder?.respond(result);
+      return;
+    }
+
+    // Optimistic concurrency: check parent matches current checkpoint
+    const currentCheckpoint = this.checkpointManager.getCurrentCheckpoint(serverId, params.featureSet);
+    if (params.parent !== null && currentCheckpoint !== null && params.parent !== currentCheckpoint) {
+      const result: StateUpdateResult = {
+        accepted: false,
+        reason: `Parent mismatch: expected "${currentCheckpoint}", got "${params.parent}"`,
+      };
+      responder?.respond(result);
+      return;
+    }
+
+    // Record the checkpoint (same path as tool call responses)
+    this.checkpointManager.recordCheckpoint(serverId, params.featureSet, {
+      checkpoint: params.checkpoint,
+      parent: params.parent,
+      data: params.data,
+      patch: params.patch,
+    });
+
+    this.emitTrace({
+      type: 'mcpl:state_update',
+      serverId,
+      featureSet: params.featureSet,
+      checkpoint: params.checkpoint,
+      parent: params.parent,
+    });
+
+    const result: StateUpdateResult = { accepted: true };
+    responder?.respond(result);
+  }
+
+  /**
+   * Handle a state/get from an MCPL server (Section 8.10).
+   * Returns the current host-managed state for the requested feature set.
+   */
+  private handleStateGet(
+    serverId: string,
+    params: StateGetParams,
+    responder?: { respond: (result: unknown) => void; respondError: (code: number, message: string, data?: unknown) => void },
+  ): void {
+    if (!responder) return;
+
+    // Validate feature set
+    try {
+      this.featureSetManager?.validateInbound(serverId, params.featureSet);
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : 'Feature set validation failed';
+      responder.respondError(-32001, reason);
+      return;
+    }
+
+    if (!this.checkpointManager) {
+      responder.respondError(-32006, 'No host-managed state for feature set', { featureSet: params.featureSet });
+      return;
+    }
+
+    if (!this.checkpointManager.isHostManaged(serverId, params.featureSet)) {
+      responder.respondError(-32006, 'No host-managed state for feature set', { featureSet: params.featureSet });
+      return;
+    }
+
+    const checkpoint = this.checkpointManager.getCurrentCheckpoint(serverId, params.featureSet);
+    const data = this.checkpointManager.getCurrentState(serverId, params.featureSet);
+
+    const result: StateGetResult = { checkpoint, data: data ?? null };
+    responder.respond(result);
+  }
+
+  // ==========================================================================
+  // Branches (Section 15)
+  // ==========================================================================
+
+  private handleBranchesList(
+    serverId: string,
+    params: BranchesListParams,
+    responder?: { respond: (r: unknown) => void; respondError: (c: number, m: string, d?: unknown) => void },
+  ): void {
+    if (!responder) return;
+    try {
+      this.featureSetManager?.validateInbound(serverId, params.featureSet);
+    } catch (err) {
+      responder.respondError(-32001, err instanceof Error ? err.message : 'Feature set validation failed');
+      return;
+    }
+
+    const branches = this.store.listBranches();
+    const current = this.store.currentBranch();
+    const branchMap = new Map(branches.map(b => [b.id, b]));
+
+    const result: BranchesListResult = {
+      branches: branches.map(b => ({
+        name: b.name,
+        head: b.head,
+        isCurrent: b.id === current.id,
+        parent: b.parentId ? branchMap.get(b.parentId)?.name ?? null : null,
+        branchPoint: b.branchPoint ?? null,
+      })),
+    };
+    responder.respond(result);
+  }
+
+  private handleBranchesCurrent(
+    serverId: string,
+    params: BranchesCurrentParams,
+    responder?: { respond: (r: unknown) => void; respondError: (c: number, m: string, d?: unknown) => void },
+  ): void {
+    if (!responder) return;
+    try {
+      this.featureSetManager?.validateInbound(serverId, params.featureSet);
+    } catch (err) {
+      responder.respondError(-32001, err instanceof Error ? err.message : 'Feature set validation failed');
+      return;
+    }
+
+    const branch = this.store.currentBranch();
+    const result: BranchesCurrentResult = { name: branch.name, head: branch.head };
+    responder.respond(result);
+  }
+
+  private handleBranchesCreate(
+    serverId: string,
+    params: BranchesCreateParams,
+    responder?: { respond: (r: unknown) => void; respondError: (c: number, m: string, d?: unknown) => void },
+  ): void {
+    if (!responder) return;
+    try {
+      this.featureSetManager?.validateInbound(serverId, params.featureSet);
+    } catch (err) {
+      responder.respondError(-32001, err instanceof Error ? err.message : 'Feature set validation failed');
+      return;
+    }
+
+    try {
+      const from = params.from ?? undefined;
+      const branch = this.store.createBranch(params.name, from);
+
+      this.notifyBranchChanged('created', branch.name, {
+        head: branch.head,
+        parent: from ?? this.store.currentBranch().name,
+        source: 'mcpl',
+      });
+
+      const result: BranchesCreateResult = { accepted: true, name: branch.name, head: branch.head };
+      responder.respond(result);
+    } catch (err) {
+      const result: BranchesCreateResult = { accepted: false, reason: err instanceof Error ? err.message : 'Branch creation failed' };
+      responder.respond(result);
+    }
+  }
+
+  private handleBranchesSwitch(
+    serverId: string,
+    params: BranchesSwitchParams,
+    responder?: { respond: (r: unknown) => void; respondError: (c: number, m: string, d?: unknown) => void },
+  ): void {
+    if (!responder) return;
+    try {
+      this.featureSetManager?.validateInbound(serverId, params.featureSet);
+    } catch (err) {
+      responder.respondError(-32001, err instanceof Error ? err.message : 'Feature set validation failed');
+      return;
+    }
+
+    try {
+      const previous = this.store.currentBranch().name;
+      const branch = this.store.switchBranch(params.name);
+
+      this.notifyBranchChanged('switched', branch.name, {
+        head: branch.head,
+        previous,
+        source: 'mcpl',
+      });
+
+      const result: BranchesSwitchResult = { accepted: true, name: branch.name, head: branch.head, previous };
+      responder.respond(result);
+    } catch (err) {
+      const result: BranchesSwitchResult = { accepted: false, reason: err instanceof Error ? err.message : 'Branch switch failed' };
+      responder.respond(result);
+    }
+  }
+
+  private handleBranchesDelete(
+    serverId: string,
+    params: BranchesDeleteParams,
+    responder?: { respond: (r: unknown) => void; respondError: (c: number, m: string, d?: unknown) => void },
+  ): void {
+    if (!responder) return;
+    try {
+      this.featureSetManager?.validateInbound(serverId, params.featureSet);
+    } catch (err) {
+      responder.respondError(-32001, err instanceof Error ? err.message : 'Feature set validation failed');
+      return;
+    }
+
+    // Reject deletion of current branch
+    const current = this.store.currentBranch();
+    if (current.name === params.name) {
+      const result: BranchesDeleteResult = { accepted: false, reason: 'Cannot delete the current branch' };
+      responder.respond(result);
+      return;
+    }
+
+    try {
+      this.store.deleteBranch(params.name);
+
+      this.notifyBranchChanged('deleted', params.name, { source: 'mcpl' });
+
+      const result: BranchesDeleteResult = { accepted: true, name: params.name };
+      responder.respond(result);
+    } catch (err) {
+      const result: BranchesDeleteResult = { accepted: false, reason: err instanceof Error ? err.message : 'Branch deletion failed' };
+      responder.respond(result);
+    }
+  }
+
+  /**
+   * Broadcast a branches/changed notification to all connected MCPL servers.
+   */
+  private broadcastBranchesChanged(params: import('./mcpl/types.js').BranchesChangedParams): void {
+    if (!this.mcplServerRegistry) return;
+    for (const server of this.mcplServerRegistry.getAllServers()) {
+      server.sendBranchesChanged(params);
+    }
+  }
+
+  /**
+   * Notify the system that a branch operation occurred.
+   * Emits a trace event (for TUI/observers) and broadcasts to MCPL servers.
+   * Public so that ApiServer and other components can call it.
+   */
+  notifyBranchChanged(event: 'created' | 'switched' | 'deleted', branch: string, opts?: {
+    head?: number;
+    previous?: string;
+    parent?: string;
+    source?: 'mcpl' | 'api' | 'host';
+  }): void {
+    const source = opts?.source ?? 'host';
+
+    this.broadcastBranchesChanged({
+      event,
+      branch,
+      ...(opts?.head !== undefined ? { head: opts.head } : {}),
+      ...(opts?.previous ? { previous: opts.previous } : {}),
+      ...(opts?.parent ? { parent: opts.parent } : {}),
+    });
+
+    this.emitTrace({
+      type: 'branches:changed',
+      event,
+      branch,
+      ...(opts?.head !== undefined ? { head: opts.head } : {}),
+      ...(opts?.previous ? { previous: opts.previous } : {}),
+      ...(opts?.parent ? { parent: opts.parent } : {}),
+      source,
+    });
+  }
+
   private async processInferenceRequests(): Promise<void> {
     if (this.pendingRequests.length === 0) {
       return;
@@ -1978,15 +2290,15 @@ export class AgentFramework {
     this.emitTrace({
       type: 'tool:started',
       module: moduleName,
-      tool: enrichedCall.name,
-      callId: enrichedCall.id,
-      input: enrichedCall.input,
+      tool: call.name,
+      callId: call.id,
+      input: call.input,
     });
 
     const startTime = Date.now();
 
     this.moduleRegistry
-      .handleToolCall(enrichedCall)
+      .handleToolCall(call)
       .then((result) => {
         const durationMs = Date.now() - startTime;
         this.emitTrace({
@@ -2179,13 +2491,20 @@ export class AgentFramework {
 
     // Host capabilities advertised during the MCP handshake
     const hostCapabilities: McplHostCapabilities = {
-      version: '0.4',
+      version: '0.5',
       pushEvents: true,
       contextHooks: {
         beforeInference: true,
         afterInference: { blocking: true },
       },
+      stateUpdate: true,
       featureSets: true,
+      branches: {
+        list: true,
+        create: true,
+        switch: true,
+        delete: true,
+      },
     };
 
     for (const config of serverConfigs) {
@@ -2278,6 +2597,39 @@ export class AgentFramework {
       responder?: { respond: (result: unknown) => void; respondError: (code: number, message: string) => void },
     ) => {
       this.pushHandler?.handlePushEvent(connection.id, params, responder as never);
+    });
+
+    // Handle server-initiated state updates (Section 8.8)
+    connection.on('state-update', (
+      params: StateUpdateParams,
+      responder?: { respond: (result: unknown) => void; respondError: (code: number, message: string, data?: unknown) => void },
+    ) => {
+      this.handleStateUpdate(connection.id, params, responder);
+    });
+
+    // Handle server state retrieval (Section 8.10)
+    connection.on('state-get', (
+      params: StateGetParams,
+      responder?: { respond: (result: unknown) => void; respondError: (code: number, message: string, data?: unknown) => void },
+    ) => {
+      this.handleStateGet(connection.id, params, responder);
+    });
+
+    // Handle branches (Section 15)
+    connection.on('branches-list', (params: BranchesListParams, responder?: { respond: (r: unknown) => void; respondError: (c: number, m: string, d?: unknown) => void }) => {
+      this.handleBranchesList(connection.id, params, responder);
+    });
+    connection.on('branches-current', (params: BranchesCurrentParams, responder?: { respond: (r: unknown) => void; respondError: (c: number, m: string, d?: unknown) => void }) => {
+      this.handleBranchesCurrent(connection.id, params, responder);
+    });
+    connection.on('branches-create', (params: BranchesCreateParams, responder?: { respond: (r: unknown) => void; respondError: (c: number, m: string, d?: unknown) => void }) => {
+      this.handleBranchesCreate(connection.id, params, responder);
+    });
+    connection.on('branches-switch', (params: BranchesSwitchParams, responder?: { respond: (r: unknown) => void; respondError: (c: number, m: string, d?: unknown) => void }) => {
+      this.handleBranchesSwitch(connection.id, params, responder);
+    });
+    connection.on('branches-delete', (params: BranchesDeleteParams, responder?: { respond: (r: unknown) => void; respondError: (c: number, m: string, d?: unknown) => void }) => {
+      this.handleBranchesDelete(connection.id, params, responder);
     });
 
     // Handle server-initiated inference requests (Step 6)

--- a/src/mcpl/server-connection.ts
+++ b/src/mcpl/server-connection.ts
@@ -62,12 +62,19 @@ interface PendingRequest {
  *
  * Events emitted:
  * - `'push-event'`        — Server sent `push/event`
+ * - `'state-update'`      — Server sent `state/update`
+ * - `'state-get'`         — Server sent `state/get`
  * - `'inference-request'`  — Server sent `inference/request`
  * - `'scope-elevate'`      — Server sent `scope/elevate`
  * - `'channels-register'`  — Server sent `channels/register`
  * - `'channels-changed'`   — Server sent `channels/changed`
  * - `'channels-incoming'`  — Server sent `channels/incoming`
  * - `'feature-sets-changed'` — Server sent `featureSets/changed`
+ * - `'branches-list'`     — Server sent `branches/list`
+ * - `'branches-current'`  — Server sent `branches/current`
+ * - `'branches-create'`   — Server sent `branches/create`
+ * - `'branches-switch'`   — Server sent `branches/switch`
+ * - `'branches-delete'`   — Server sent `branches/delete`
  * - `'error'`              — Connection-level error
  * - `'close'`              — Connection closed
  */
@@ -400,6 +407,11 @@ export class McplServerConnection extends EventEmitter {
     this.sendNotification(McplMethod.ChannelsTyping, { channelId });
   }
 
+  /** Send `branches/changed` notification. */
+  sendBranchesChanged(params: import('./types.js').BranchesChangedParams): void {
+    this.sendNotification(McplMethod.BranchesChanged, params as unknown as Record<string, unknown>);
+  }
+
   // ==========================================================================
   // Standard MCP methods
   // ==========================================================================
@@ -564,12 +576,19 @@ export class McplServerConnection extends EventEmitter {
    */
   private static readonly METHOD_TO_EVENT: Record<string, string> = {
     [McplMethod.PushEvent]: 'push-event',
+    [McplMethod.StateUpdate]: 'state-update',
+    [McplMethod.StateGet]: 'state-get',
     [McplMethod.InferenceRequest]: 'inference-request',
     [McplMethod.ScopeElevate]: 'scope-elevate',
     [McplMethod.ChannelsRegister]: 'channels-register',
     [McplMethod.ChannelsChanged]: 'channels-changed',
     [McplMethod.ChannelsIncoming]: 'channels-incoming',
     [McplMethod.FeatureSetsChanged]: 'feature-sets-changed',
+    [McplMethod.BranchesList]: 'branches-list',
+    [McplMethod.BranchesCurrent]: 'branches-current',
+    [McplMethod.BranchesCreate]: 'branches-create',
+    [McplMethod.BranchesSwitch]: 'branches-switch',
+    [McplMethod.BranchesDelete]: 'branches-delete',
     'notifications/tools/list_changed': 'tools-list-changed',
   };
 

--- a/src/mcpl/server-connection.ts
+++ b/src/mcpl/server-connection.ts
@@ -1,14 +1,18 @@
 /**
  * McplServerConnection — manages a single JSON-RPC 2.0 connection to an MCPL server.
  *
- * Spawns a child process (stdio transport), performs the MCP initialize handshake
- * with MCPL capability negotiation, and provides typed methods for all outbound
- * MCPL messages plus EventEmitter events for inbound messages.
+ * Supports two transports:
+ * - **stdio**: Spawns a child process, communicates via newline-delimited JSON on stdin/stdout
+ * - **WebSocket**: Connects to a remote server via WebSocket, one JSON-RPC message per frame
+ *
+ * Both transports perform the MCP initialize handshake with MCPL capability negotiation,
+ * and provide the same typed methods for outbound messages and EventEmitter events for inbound.
  */
 
-import { spawn, type ChildProcess } from 'node:child_process';
-import { createInterface, type Interface as ReadlineInterface } from 'node:readline';
+import { spawn } from 'node:child_process';
+import { createInterface } from 'node:readline';
 import { EventEmitter } from 'node:events';
+import WebSocket from 'ws';
 
 import type {
   McplServerConfig,
@@ -43,6 +47,9 @@ import { McplMethod } from './types.js';
  *  Spring Boot + JDA servers can take 5-10s to boot, so 30s is safe. */
 const INITIALIZE_TIMEOUT_MS = 30_000;
 
+/** WebSocket ping interval in milliseconds (Proposal 001: 30s). */
+const WS_PING_INTERVAL_MS = 30_000;
+
 /** MCP protocol version used in the initialize handshake. */
 const MCP_PROTOCOL_VERSION = '2024-11-05';
 
@@ -56,9 +63,28 @@ interface PendingRequest {
 }
 
 /**
+ * Transport abstraction — decouples message framing from protocol logic.
+ * stdio: newline-delimited JSON on stdin/stdout
+ * WebSocket: one JSON-RPC message per text frame
+ */
+interface Transport {
+  /** Send a JSON string to the server. */
+  write(json: string): void;
+  /** Register a callback for each incoming message (already parsed line/frame). */
+  onMessage(cb: (line: string) => void): void;
+  /** Register a callback for transport-level errors. */
+  onError(cb: (err: Error) => void): void;
+  /** Register a callback for transport close. */
+  onClose(cb: (code?: number, signal?: string) => void): void;
+  /** Shut down the transport. Returns when fully closed. */
+  close(): Promise<void>;
+}
+
+/**
  * McplServerConnection manages a single JSON-RPC 2.0 connection to an
- * MCPL server over stdio. Use the static `connect()` factory to create
- * and initialize a connection.
+ * MCPL server. Supports stdio and WebSocket transports.
+ * Use `connect()` for stdio, `connectWebSocket()` for WebSocket,
+ * or `connectWithReconnect()` which auto-selects based on config.
  *
  * Events emitted:
  * - `'push-event'`        — Server sent `push/event`
@@ -85,8 +111,7 @@ export class McplServerConnection extends EventEmitter {
   /** MCPL capabilities negotiated during the initialize handshake, or null if the server does not support MCPL. */
   capabilities: McplCapabilities | null;
 
-  private process: ChildProcess;
-  private readline: ReadlineInterface;
+  private transport: Transport | null;
   private nextRequestId = 1;
   private pendingRequests = new Map<string | number, PendingRequest>();
   private closed = false;
@@ -103,22 +128,20 @@ export class McplServerConnection extends EventEmitter {
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
   /**
-   * Private constructor. Use `McplServerConnection.connect()` instead.
+   * Private constructor. Use `McplServerConnection.connect()` or `connectWebSocket()` instead.
    */
   private constructor(
     id: string,
     capabilities: McplCapabilities | null,
-    childProcess: ChildProcess,
-    readline: ReadlineInterface,
+    transport: Transport | null,
   ) {
     super();
     this.id = id;
     this.capabilities = capabilities;
-    this.process = childProcess;
-    this.readline = readline;
+    this.transport = transport;
 
-    // Skip setup for disconnected stubs (process/readline are null)
-    if (childProcess && readline) {
+    // Skip setup for disconnected stubs (transport is null)
+    if (transport) {
       this.setupMessageRouting();
       this.setupLifecycle();
     }
@@ -159,8 +182,8 @@ export class McplServerConnection extends EventEmitter {
   // ==========================================================================
 
   /**
-   * Spawn a server process, perform the MCP initialize handshake with MCPL
-   * capability negotiation, and return a ready-to-use connection.
+   * Spawn a server process (stdio transport), perform the MCP initialize
+   * handshake with MCPL capability negotiation, and return a ready-to-use connection.
    *
    * Throws if the process cannot be spawned or the handshake times out.
    */
@@ -168,6 +191,10 @@ export class McplServerConnection extends EventEmitter {
     config: McplServerConfig,
     hostCapabilities: McplHostCapabilities,
   ): Promise<McplServerConnection> {
+    if (!config.command) {
+      throw new Error(`MCPL server "${config.id}": stdio transport requires "command" in config`);
+    }
+
     const child = spawn(config.command, config.args ?? [], {
       stdio: ['pipe', 'pipe', 'pipe'],
       env: { ...process.env, ...config.env },
@@ -186,12 +213,150 @@ export class McplServerConnection extends EventEmitter {
     // Set up readline for newline-delimited JSON on stdout
     const rl = createInterface({ input: child.stdout! });
 
+    // Build the stdio transport
+    const transport: Transport = {
+      write(json: string) { child.stdin!.write(json + '\n'); },
+      onMessage(cb) { rl.on('line', cb); },
+      onError(cb) { child.on('error', (err) => cb(err)); },
+      onClose(cb) {
+        child.on('exit', (code, signal) => cb(code ?? undefined, signal ?? undefined));
+      },
+      async close() {
+        rl.close();
+        if (!child.killed) child.kill();
+        await new Promise<void>((resolve) => {
+          if (child.exitCode !== null || child.killed) resolve();
+          else child.once('exit', () => resolve());
+        });
+      },
+    };
+
     // -----------------------------------------------------------------------
     // Perform initialize handshake
     // -----------------------------------------------------------------------
 
+    const mcplCaps = await McplServerConnection.performHandshake(
+      config.id, transport, hostCapabilities, earlyExitPromise,
+    );
+
+    // Remove the early-exit listener so normal close handling takes over
+    child.removeAllListeners('exit');
+    child.removeAllListeners('error');
+
+    const connection = new McplServerConnection(config.id, mcplCaps, transport);
+
+    // Store config for reconnection
+    if (config.reconnect) {
+      connection.config = config;
+      connection.hostCapabilities = hostCapabilities;
+      connection.reconnectEnabled = true;
+      connection.reconnectIntervalMs = config.reconnectIntervalMs ?? 5000;
+    }
+
+    return connection;
+  }
+
+  /**
+   * Connect to a remote MCPL server via WebSocket, perform the MCP initialize
+   * handshake with MCPL capability negotiation, and return a ready-to-use connection.
+   *
+   * Throws if the WebSocket connection fails or the handshake times out.
+   */
+  static async connectWebSocket(
+    config: McplServerConfig,
+    hostCapabilities: McplHostCapabilities,
+  ): Promise<McplServerConnection> {
+    if (!config.url) {
+      throw new Error(`MCPL server "${config.id}": WebSocket transport requires "url" in config`);
+    }
+
+    // Append token as query parameter if provided
+    let wsUrl = config.url;
+    if (config.token) {
+      const separator = wsUrl.includes('?') ? '&' : '?';
+      wsUrl = `${wsUrl}${separator}token=${encodeURIComponent(config.token)}`;
+    }
+
+    const ws = await new Promise<WebSocket>((resolve, reject) => {
+      const socket = new WebSocket(wsUrl);
+      socket.once('open', () => {
+        socket.removeListener('error', reject);
+        resolve(socket);
+      });
+      socket.once('error', (err) => {
+        reject(new Error(`Failed to connect to MCPL server "${config.id}" at ${config.url}: ${err.message}`));
+      });
+    });
+
+    // Heartbeat: ping every 30s, close if no pong within 60s
+    let pongReceived = true;
+    const pingInterval = setInterval(() => {
+      if (!pongReceived) {
+        ws.terminate();
+        return;
+      }
+      pongReceived = false;
+      ws.ping();
+    }, WS_PING_INTERVAL_MS);
+
+    ws.on('pong', () => { pongReceived = true; });
+
+    // Build the WebSocket transport
+    const transport: Transport = {
+      write(json: string) { ws.send(json); },
+      onMessage(cb) { ws.on('message', (data: WebSocket.RawData) => cb(data.toString())); },
+      onError(cb) { ws.on('error', (err: Error) => cb(err)); },
+      onClose(cb) { ws.on('close', (code: number) => cb(code)); },
+      async close() {
+        clearInterval(pingInterval);
+        if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+          ws.close();
+          await new Promise<void>((resolve) => ws.once('close', () => resolve()));
+        }
+      },
+    };
+
+    // Fail fast if the WebSocket closes during handshake
+    const earlyClosePromise = new Promise<never>((_resolve, reject) => {
+      ws.once('close', (code) => {
+        reject(new Error(`MCPL server "${config.id}" WebSocket closed before handshake (code ${code})`));
+      });
+    });
+
+    const mcplCaps = await McplServerConnection.performHandshake(
+      config.id, transport, hostCapabilities, earlyClosePromise,
+    );
+
+    // Remove the early-close listener so normal close handling takes over
+    ws.removeAllListeners('close');
+    // Re-attach the transport's onClose since we just removed it
+    transport.onClose = (cb) => { ws.on('close', (code) => cb(code)); };
+
+    const connection = new McplServerConnection(config.id, mcplCaps, transport);
+
+    // Store config for reconnection
+    if (config.reconnect) {
+      connection.config = config;
+      connection.hostCapabilities = hostCapabilities;
+      connection.reconnectEnabled = true;
+      connection.reconnectIntervalMs = config.reconnectIntervalMs ?? 5000;
+    }
+
+    return connection;
+  }
+
+  /**
+   * Perform the MCP initialize handshake over a transport.
+   * Shared by both stdio and WebSocket factories.
+   */
+  private static async performHandshake(
+    serverId: string,
+    transport: Transport,
+    hostCapabilities: McplHostCapabilities,
+    earlyFailPromise: Promise<never>,
+  ): Promise<McplCapabilities | null> {
     // Step 1: Send `initialize` request
-    const initId = 0; // use id=0 for the handshake
+    const initId = 0;
     const initRequest: JsonRpcRequest = {
       jsonrpc: '2.0',
       method: 'initialize',
@@ -209,18 +374,19 @@ export class McplServerConnection extends EventEmitter {
         },
       },
     };
-    child.stdin!.write(JSON.stringify(initRequest) + '\n');
+    transport.write(JSON.stringify(initRequest));
 
     // Step 2: Wait for the initialize response
     const initResponse = await Promise.race([
       new Promise<JsonRpcResponse>((resolve, reject) => {
-        const onLine = (line: string) => {
+        const onMessage = (line: string) => {
           try {
             const msg = JSON.parse(line) as JsonRpcResponse;
             if (msg.id === initId) {
-              rl.off('line', onLine);
+              // Can't remove listener from transport interface, but the handler
+              // becomes a no-op after first match since we resolve/reject once
               if (msg.error) {
-                reject(new Error(`MCPL server "${config.id}" initialize error: ${msg.error.message}`));
+                reject(new Error(`MCPL server "${serverId}" initialize error: ${msg.error.message}`));
               } else {
                 resolve(msg);
               }
@@ -229,12 +395,12 @@ export class McplServerConnection extends EventEmitter {
             // Ignore non-JSON lines (e.g. logback output from Java servers)
           }
         };
-        rl.on('line', onLine);
+        transport.onMessage(onMessage);
       }),
-      earlyExitPromise,
+      earlyFailPromise,
       new Promise<never>((_resolve, reject) =>
         setTimeout(() => {
-          reject(new Error(`MCPL server "${config.id}" initialize handshake timed out`));
+          reject(new Error(`MCPL server "${serverId}" initialize handshake timed out`));
         }, INITIALIZE_TIMEOUT_MS),
       ),
     ]);
@@ -245,28 +411,27 @@ export class McplServerConnection extends EventEmitter {
     const experimental = caps?.experimental as Record<string, unknown> | undefined;
     const mcplCaps = (experimental?.mcpl as McplCapabilities) ?? null;
 
-    // Step 3: Send `initialized` notification (no id)
+    // Step 3: Send `initialized` notification
     const initializedNotification: JsonRpcRequest = {
       jsonrpc: '2.0',
       method: 'notifications/initialized',
     };
-    child.stdin!.write(JSON.stringify(initializedNotification) + '\n');
+    transport.write(JSON.stringify(initializedNotification));
 
-    // Remove the early-exit listener so normal close handling takes over
-    child.removeAllListeners('exit');
-    child.removeAllListeners('error');
+    return mcplCaps;
+  }
 
-    const connection = new McplServerConnection(config.id, mcplCaps, child, rl);
-
-    // Store config for reconnection
-    if (config.reconnect) {
-      connection.config = config;
-      connection.hostCapabilities = hostCapabilities;
-      connection.reconnectEnabled = true;
-      connection.reconnectIntervalMs = config.reconnectIntervalMs ?? 5000;
+  /**
+   * Connect with the appropriate transport based on config (stdio or WebSocket).
+   */
+  private static connectAuto(
+    config: McplServerConfig,
+    hostCapabilities: McplHostCapabilities,
+  ): Promise<McplServerConnection> {
+    if (config.url) {
+      return McplServerConnection.connectWebSocket(config, hostCapabilities);
     }
-
-    return connection;
+    return McplServerConnection.connect(config, hostCapabilities);
   }
 
   /**
@@ -280,7 +445,7 @@ export class McplServerConnection extends EventEmitter {
     hostCapabilities: McplHostCapabilities,
   ): Promise<McplServerConnection> {
     try {
-      return await McplServerConnection.connect(config, hostCapabilities);
+      return await McplServerConnection.connectAuto(config, hostCapabilities);
     } catch (error) {
       if (!config.reconnect) {
         throw error;
@@ -301,8 +466,7 @@ export class McplServerConnection extends EventEmitter {
     config: McplServerConfig,
     hostCapabilities: McplHostCapabilities,
   ): McplServerConnection {
-    // Use null! for process/readline since the connection is closed
-    const stub = new McplServerConnection(config.id, null, null! as ChildProcess, null! as ReadlineInterface);
+    const stub = new McplServerConnection(config.id, null, null);
     stub.closed = true;
     stub.config = config;
     stub.hostCapabilities = hostCapabilities;
@@ -316,13 +480,14 @@ export class McplServerConnection extends EventEmitter {
   }
 
   /**
-   * Extract internals for transfer during reconnection.
-   * Strips the source connection — caller takes ownership of the process/readline.
+   * Extract transport for transfer during reconnection.
+   * Strips the source connection — caller takes ownership of the transport.
    * @internal Used only by attemptReconnect().
    */
-  extractInternals(): { process: ChildProcess; readline: ReadlineInterface } {
-    const result = { process: this.process, readline: this.readline };
-    // Prevent the source connection from killing the transferred process
+  extractTransport(): Transport | null {
+    const result = this.transport;
+    // Prevent the source connection from closing the transferred transport
+    this.transport = null;
     this.closed = true;
     return result;
   }
@@ -437,7 +602,7 @@ export class McplServerConnection extends EventEmitter {
   // Lifecycle
   // ==========================================================================
 
-  /** Close the connection: disable reconnect, kill the child process, and clean up resources. */
+  /** Close the connection: disable reconnect, close the transport, and clean up resources. */
   async close(): Promise<void> {
     // Disable reconnect before closing — explicit close means stop retrying
     this.reconnectEnabled = false;
@@ -457,25 +622,9 @@ export class McplServerConnection extends EventEmitter {
     }
     this.pendingRequests.clear();
 
-    // Close readline
-    if (this.readline) {
-      this.readline.close();
-    }
-
-    // Kill the child process
-    if (this.process && !this.process.killed) {
-      this.process.kill();
-    }
-
-    // Wait for process to actually exit
-    if (this.process) {
-      await new Promise<void>((resolve) => {
-        if (this.process.exitCode !== null || this.process.killed) {
-          resolve();
-        } else {
-          this.process.once('exit', () => resolve());
-        }
-      });
+    // Close the transport
+    if (this.transport) {
+      await this.transport.close();
     }
 
     this.emit('close');
@@ -494,24 +643,23 @@ export class McplServerConnection extends EventEmitter {
   }
 
   /**
-   * Attempt to reconnect by spawning a new process and performing the handshake.
+   * Attempt to reconnect using the appropriate transport.
    */
   private async attemptReconnect(): Promise<void> {
     if (!this.reconnectEnabled || !this.config || !this.hostCapabilities) return;
 
     try {
-      const fresh = await McplServerConnection.connect(this.config, this.hostCapabilities);
-      const internals = fresh.extractInternals();
+      const fresh = await McplServerConnection.connectAuto(this.config, this.hostCapabilities);
+      const transport = fresh.extractTransport();
 
       // Transfer state from fresh connection to this instance
-      this.process = internals.process;
-      this.readline = internals.readline;
+      this.transport = transport;
       this.capabilities = fresh.capabilities;
       this.closed = false;
       this.nextRequestId = 1;
       this.pendingRequests.clear();
 
-      // Re-wire message routing and lifecycle on the new process
+      // Re-wire message routing and lifecycle on the new transport
       this.setupMessageRouting();
       this.setupLifecycle();
       this.readyFlag = true; // Listeners already attached from initial wire
@@ -533,7 +681,7 @@ export class McplServerConnection extends EventEmitter {
    * or rejects with a JSON-RPC error.
    */
   private sendRequest(method: string, params: Record<string, unknown>): Promise<unknown> {
-    if (this.closed) {
+    if (this.closed || !this.transport) {
       return Promise.reject(new Error(`Cannot send request: connection to "${this.id}" is closed`));
     }
 
@@ -547,7 +695,7 @@ export class McplServerConnection extends EventEmitter {
 
     return new Promise((resolve, reject) => {
       this.pendingRequests.set(id, { resolve, reject, method });
-      this.process.stdin!.write(JSON.stringify(request) + '\n');
+      this.transport!.write(JSON.stringify(request));
     });
   }
 
@@ -555,7 +703,7 @@ export class McplServerConnection extends EventEmitter {
    * Send a JSON-RPC notification (no `id`, no response expected).
    */
   private sendNotification(method: string, params: Record<string, unknown>): void {
-    if (this.closed) {
+    if (this.closed || !this.transport) {
       return;
     }
 
@@ -564,7 +712,7 @@ export class McplServerConnection extends EventEmitter {
       method,
       params,
     };
-    this.process.stdin!.write(JSON.stringify(notification) + '\n');
+    this.transport.write(JSON.stringify(notification));
   }
 
   // ==========================================================================
@@ -593,10 +741,10 @@ export class McplServerConnection extends EventEmitter {
   };
 
   /**
-   * Wire up readline to route incoming JSON-RPC messages.
+   * Wire up the transport to route incoming JSON-RPC messages.
    */
   private setupMessageRouting(): void {
-    this.readline.on('line', (line) => {
+    this.transport!.onMessage((line) => {
       let msg: JsonRpcRequest | JsonRpcResponse;
       try {
         msg = JSON.parse(line);
@@ -657,22 +805,22 @@ export class McplServerConnection extends EventEmitter {
    * Send a successful JSON-RPC response back to the server.
    */
   private sendResponse(id: string | number, result: unknown): void {
-    if (this.closed) return;
+    if (this.closed || !this.transport) return;
     const response: JsonRpcResponse = { jsonrpc: '2.0', id, result };
-    this.process.stdin!.write(JSON.stringify(response) + '\n');
+    this.transport.write(JSON.stringify(response));
   }
 
   /**
    * Send a JSON-RPC error response back to the server.
    */
   private sendErrorResponse(id: string | number, code: number, message: string, data?: unknown): void {
-    if (this.closed) return;
+    if (this.closed || !this.transport) return;
     const response: JsonRpcResponse = {
       jsonrpc: '2.0',
       id,
       error: { code, message, data },
     };
-    this.process.stdin!.write(JSON.stringify(response) + '\n');
+    this.transport.write(JSON.stringify(response));
   }
 
   // ==========================================================================
@@ -680,14 +828,14 @@ export class McplServerConnection extends EventEmitter {
   // ==========================================================================
 
   /**
-   * Set up process error/exit handlers.
+   * Set up transport error/close handlers.
    */
   private setupLifecycle(): void {
-    this.process.on('error', (err) => {
-      this.emit('error', new Error(`MCPL server "${this.id}" process error: ${err.message}`));
+    this.transport!.onError((err) => {
+      this.emit('error', new Error(`MCPL server "${this.id}" transport error: ${err.message}`));
     });
 
-    this.process.on('exit', (code, signal) => {
+    this.transport!.onClose((code, signal) => {
       if (!this.closed) {
         this.closed = true;
 
@@ -695,7 +843,7 @@ export class McplServerConnection extends EventEmitter {
         for (const [id, pending] of this.pendingRequests) {
           pending.reject(
             new Error(
-              `MCPL server "${this.id}" exited unexpectedly (code=${code}, signal=${signal}) while awaiting ${pending.method} (id=${id})`,
+              `MCPL server "${this.id}" closed unexpectedly (code=${code}, signal=${signal}) while awaiting ${pending.method} (id=${id})`,
             ),
           );
         }
@@ -703,7 +851,7 @@ export class McplServerConnection extends EventEmitter {
 
         this.emit('close', code, signal);
 
-        // Schedule reconnect if enabled (unexpected exit triggers auto-reconnect)
+        // Schedule reconnect if enabled (unexpected close triggers auto-reconnect)
         if (this.reconnectEnabled) {
           this.scheduleReconnect();
         }

--- a/src/mcpl/server-registry.ts
+++ b/src/mcpl/server-registry.ts
@@ -40,9 +40,23 @@ export class McplServerRegistry {
       throw new Error(`MCPL server "${config.id}" is already registered`);
     }
 
-    const connection = config.reconnect
-      ? await McplServerConnection.connectWithReconnect(config, hostCapabilities)
-      : await McplServerConnection.connect(config, hostCapabilities);
+    // Validate config: exactly one of command or url must be present
+    if (!config.command && !config.url) {
+      throw new Error(`MCPL server "${config.id}": either "command" (stdio) or "url" (WebSocket) must be provided`);
+    }
+    if (config.command && config.url) {
+      throw new Error(`MCPL server "${config.id}": "command" and "url" are mutually exclusive`);
+    }
+
+    // Route to the appropriate transport
+    let connection: McplServerConnection;
+    if (config.reconnect) {
+      connection = await McplServerConnection.connectWithReconnect(config, hostCapabilities);
+    } else if (config.url) {
+      connection = await McplServerConnection.connectWebSocket(config, hostCapabilities);
+    } else {
+      connection = await McplServerConnection.connect(config, hostCapabilities);
+    }
     this.servers.set(config.id, connection);
 
     // Auto-remove on unexpected close (unless reconnect will re-add)

--- a/src/mcpl/types.ts
+++ b/src/mcpl/types.ts
@@ -1,5 +1,5 @@
 /**
- * MCPL (MCP Live) Protocol Types — v0.4.0-draft
+ * MCPL (MCP Live) Protocol Types — v0.5.0-draft
  *
  * Type definitions for the host-side implementation of the MCPL protocol.
  * Organized by spec section for easy cross-referencing with mcpl/SPEC.md.
@@ -116,6 +116,9 @@ export interface McplCapabilities {
     streaming?: boolean;
   };
 
+  /** Server supports state/update (server-initiated state sync) */
+  stateUpdate?: boolean;
+
   /** Server supports model/info requests */
   modelInfo?: boolean;
 
@@ -124,6 +127,9 @@ export interface McplCapabilities {
 
   /** Channel capabilities */
   channels?: McplChannelCapabilities;
+
+  /** Branch capabilities */
+  branches?: McplBranchCapabilities;
 }
 
 /**
@@ -140,8 +146,18 @@ export interface McplHostCapabilities {
   inferenceRequest?: {
     streaming?: boolean;
   };
+  stateUpdate?: boolean;
   featureSets?: boolean;
   channels?: McplChannelCapabilities;
+  branches?: McplBranchCapabilities;
+}
+
+/** Branch-specific capability flags. */
+export interface McplBranchCapabilities {
+  list?: boolean;
+  create?: boolean;
+  switch?: boolean;
+  delete?: boolean;
 }
 
 /** Channel-specific capability flags. */
@@ -234,9 +250,11 @@ export type FeatureSetUse =
   | 'contextHooks.beforeInference'
   | 'contextHooks.afterInference'
   | 'inferenceRequest'
+  | 'stateUpdate'
   | 'tools'
   | 'channels.publish'
-  | 'channels.observe';
+  | 'channels.observe'
+  | 'branches';
 
 /**
  * A feature set declaration as advertised by a server.
@@ -380,6 +398,27 @@ export interface JsonPatchOperation {
 }
 
 /**
+ * state/get params (Server → Host, Request).
+ * Spec Section 8.10.
+ */
+export interface StateGetParams {
+  /** Feature set to retrieve state for */
+  featureSet: string;
+}
+
+/**
+ * state/get result (Host → Server).
+ * Spec Section 8.10.
+ */
+export interface StateGetResult {
+  /** Current checkpoint ID (null if no state has been recorded yet) */
+  checkpoint: string | null;
+
+  /** Current reconstructed state */
+  data: unknown;
+}
+
+/**
  * state/rollback params (Host → Server, Request).
  * Spec Section 8.5.
  */
@@ -403,6 +442,54 @@ export interface StateRollbackResult {
   success: boolean;
 
   /** Reason for failure (present if success: false) */
+  reason?: string;
+
+  /**
+   * Full state at the rolled-back checkpoint (for host-managed state).
+   * Allows servers with local state (e.g., editors) to update without
+   * an extra state/get round-trip.
+   */
+  data?: unknown;
+}
+
+/**
+ * state/update params (Server → Host, Request).
+ * Spec Section 8.8.
+ */
+export interface StateUpdateParams {
+  /** Declaring feature set */
+  featureSet: string;
+
+  /** New checkpoint identifier */
+  checkpoint: string;
+
+  /** Parent checkpoint (null for initial state) */
+  parent: string | null;
+
+  /**
+   * Full state data (mutually exclusive with `patch`).
+   * When both `data` and `patch` are absent, the checkpoint is an opaque
+   * reference and the server manages state internally.
+   */
+  data?: unknown;
+
+  /**
+   * JSON Patch (RFC 6902) delta from parent (mutually exclusive with `data`).
+   * When both `data` and `patch` are absent, the checkpoint is an opaque
+   * reference and the server manages state internally.
+   */
+  patch?: JsonPatchOperation[];
+}
+
+/**
+ * state/update result (Host → Server).
+ * Spec Section 8.8.
+ */
+export interface StateUpdateResult {
+  /** Whether the host accepted the state update */
+  accepted: boolean;
+
+  /** Present if accepted: false */
   reason?: string;
 }
 
@@ -912,6 +999,109 @@ export interface InferenceRoutingPolicy {
 }
 
 // ============================================================================
+// Section 15 — Branches
+// ============================================================================
+
+/**
+ * Branch info as returned by branches/list.
+ * Spec Section 15.2.
+ */
+export interface BranchInfo {
+  name: string;
+  head: number;
+  isCurrent: boolean;
+  parent: string | null;
+  branchPoint: number | null;
+}
+
+/**
+ * branches/list params (Server → Host, Request).
+ * Spec Section 15.2.
+ */
+export interface BranchesListParams {
+  featureSet: string;
+}
+
+export interface BranchesListResult {
+  branches: BranchInfo[];
+}
+
+/**
+ * branches/current params (Server → Host, Request).
+ * Spec Section 15.3.
+ */
+export interface BranchesCurrentParams {
+  featureSet: string;
+}
+
+export interface BranchesCurrentResult {
+  name: string;
+  head: number;
+}
+
+/**
+ * branches/create params (Server → Host, Request).
+ * Spec Section 15.4.
+ */
+export interface BranchesCreateParams {
+  featureSet: string;
+  name: string;
+  from?: string;
+  atCheckpoint?: string;
+}
+
+export interface BranchesCreateResult {
+  accepted: boolean;
+  name?: string;
+  head?: number;
+  reason?: string;
+}
+
+/**
+ * branches/switch params (Server → Host, Request).
+ * Spec Section 15.5.
+ */
+export interface BranchesSwitchParams {
+  featureSet: string;
+  name: string;
+}
+
+export interface BranchesSwitchResult {
+  accepted: boolean;
+  name?: string;
+  head?: number;
+  previous?: string;
+  reason?: string;
+}
+
+/**
+ * branches/delete params (Server → Host, Request).
+ * Spec Section 15.6.
+ */
+export interface BranchesDeleteParams {
+  featureSet: string;
+  name: string;
+}
+
+export interface BranchesDeleteResult {
+  accepted: boolean;
+  name?: string;
+  reason?: string;
+}
+
+/**
+ * branches/changed params (Host → Server, Notification).
+ * Spec Section 15.7.
+ */
+export interface BranchesChangedParams {
+  event: 'created' | 'switched' | 'deleted';
+  branch: string;
+  previous?: string;
+  head?: number;
+  parent?: string;
+}
+
+// ============================================================================
 // MCPL Method Names (string constants for routing)
 // ============================================================================
 
@@ -938,7 +1128,9 @@ export const McplMethod = {
   // Scoped access (Server → Host)
   ScopeElevate: 'scope/elevate',
 
-  // State management (Host → Server)
+  // State management
+  StateUpdate: 'state/update',
+  StateGet: 'state/get',
   StateRollback: 'state/rollback',
 
   // Channels
@@ -952,6 +1144,14 @@ export const McplMethod = {
   ChannelsPublish: 'channels/publish',
   ChannelsIncoming: 'channels/incoming',
   ChannelsTyping: 'channels/typing',
+
+  // Branches (Server → Host, except Changed which is Host → Server)
+  BranchesList: 'branches/list',
+  BranchesCurrent: 'branches/current',
+  BranchesCreate: 'branches/create',
+  BranchesSwitch: 'branches/switch',
+  BranchesDelete: 'branches/delete',
+  BranchesChanged: 'branches/changed',
 } as const;
 
 export type McplMethodName = (typeof McplMethod)[keyof typeof McplMethod];

--- a/src/mcpl/types.ts
+++ b/src/mcpl/types.ts
@@ -181,13 +181,29 @@ export interface McplServerConfig {
   /** Unique server identifier */
   id: string;
 
-  /** Command to spawn the server process (stdio transport) */
-  command: string;
+  /**
+   * Command to spawn the server process (stdio transport).
+   * Mutually exclusive with `url`. One of `command` or `url` must be provided.
+   */
+  command?: string;
 
-  /** Arguments for the command */
+  /**
+   * WebSocket URL for remote MCPL servers (e.g., "wss://example.com/mcpl").
+   * When present, connects via WebSocket instead of spawning a child process.
+   * Mutually exclusive with `command`. One of `command` or `url` must be provided.
+   */
+  url?: string;
+
+  /**
+   * Authentication token for WebSocket connections.
+   * Sent as a query parameter: `wss://example.com/mcpl?token=<token>`.
+   */
+  token?: string;
+
+  /** Arguments for the command (stdio only) */
   args?: string[];
 
-  /** Environment variables for the child process */
+  /** Environment variables for the child process (stdio only) */
   env?: Record<string, string>;
 
   /** Feature sets to enable on connect */

--- a/src/types/trace.ts
+++ b/src/types/trace.ts
@@ -157,6 +157,26 @@ export type TraceEvent =
       agentName: string;
       fromBranch: string;
       toBranch: string;
+    })
+
+  // MCPL state management
+  | (TraceEventBase & {
+      type: 'mcpl:state_update';
+      serverId: string;
+      featureSet: string;
+      checkpoint: string;
+      parent: string | null;
+    })
+
+  // Branch lifecycle
+  | (TraceEventBase & {
+      type: 'branches:changed';
+      event: 'created' | 'switched' | 'deleted';
+      branch: string;
+      head?: number;
+      previous?: string;
+      parent?: string;
+      source: 'mcpl' | 'api' | 'host';
     });
 
 /**


### PR DESCRIPTION
## Summary
- **State management**: `handleStateUpdate()` (server-initiated state sync with opaque checkpoint support), `handleStateGet()` (server pulls current state), event routing, host capabilities
- **Branches (Section 15)**: 5 inbound handlers delegating to Chronicle's branch API, `broadcastBranchesChanged()` outbound to all connected servers, event routing, host capabilities
- **WebSocket transport**: `McplServerConnection.connectWebSocket()` — connects to remote MCPL servers via WebSocket instead of spawning child processes. Transport abstraction decouples framing from protocol logic. Ping/pong heartbeat (30s), token auth via URL query param, automatic transport selection in registry.
- **Trace events**: `mcpl:state_update`, `branches:changed`
- Fixes pre-existing `enrichedCall` → `call` typo in `dispatchToolCallEvent`

## Motivation
Host-side implementation of MCPL v0.5.0 protocol additions, enabling the mcpl-editor server to push state updates, request host branching, and connect over WebSocket for remote deployment. Companion PRs: [mcpl spec](https://github.com/anima-research/mcpl/pull/1), mcpl-core-ts.

## Test plan
- [ ] `npx tsc --noEmit` passes (modulo pre-existing KnowledgeStrategy import)
- [ ] mcpl-editor E2E test exercises state/update flow end-to-end
- [ ] Branch handlers tested via mcpl-editor branch UI (pending frontend)
- [ ] WebSocket transport: connect to mcpl-editor via `url` config, verify handshake + message exchange

🤖 Generated with [Claude Code](https://claude.com/claude-code)