### PR TITLE
Enrich shouldTriggerInference metadata for channel messages

### DIFF
--- a/src/mcpl/channel-registry.ts
+++ b/src/mcpl/channel-registry.ts
@@ -337,7 +337,15 @@ export class ChannelRegistry {
           .join('\n');
         triggerInference = this.shouldTriggerInference(
           textContent,
-          { ...message.metadata, eventType: 'channel:incoming' },
+          {
+            ...message.metadata,
+            eventType: 'channel:incoming',
+            serverId,
+            channelId: message.channelId,
+            messageId: message.messageId,
+            threadId: message.threadId,
+            author: message.author,
+          },
         );
       }
 


### PR DESCRIPTION
## Summary

- Pass `serverId`, `channelId`, `messageId`, `threadId`, and `author` into the metadata object passed to `shouldTriggerInference` for channel incoming messages
- Previously only `message.metadata` (server-provided) and `eventType` were passed, making it impossible to filter by channel structure

This enables downstream wake/filter logic (like connectome-host's file-based wake policies) to match on which channel or server a message came from, not just its text content.

## Test plan

- [ ] Verify `shouldTriggerInference` callback receives enriched metadata for `channels/incoming` events
- [ ] Existing push event metadata unchanged (already had `serverId`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)