### PR TITLE
Prioritize user input in process queue

### DIFF
--- a/src/queue.ts
+++ b/src/queue.ts
@@ -21,6 +21,9 @@ export class ProcessQueueImpl implements ProcessQueue {
     const waiter = this.waiters.shift();
     if (waiter) {
       waiter(event);
+    } else if (event.type === 'external-message') {
+      // User input jumps to front so it's processed before queued internal events
+      this.queue.unshift(event);
     } else {
       this.queue.push(event);
     }


### PR DESCRIPTION
External messages (user input) now jump to the front of the queue so users can interrupt/redirect the agent while subagent completions and other internal events are pending.