### PR TITLE
Rename to @animalabs/agent-framework + npm deps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,61 @@
+name: Build & Publish
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Type-check
+        run: npx tsc --noEmit
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test
+
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    if: startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/examples/host-mock.ts
+++ b/examples/host-mock.ts
@@ -8,7 +8,7 @@
  *   npx tsx examples/host-mock.ts
  */
 
-import { Membrane, MockAdapter } from 'membrane';
+import { Membrane, MockAdapter } from '@animalabs/membrane';
 import { AgentFramework, ApiServer, ApiModule } from '../src/index.js';
 
 async function main() {

--- a/examples/host.ts
+++ b/examples/host.ts
@@ -5,7 +5,7 @@
  *   npx tsx examples/host.ts
  */
 
-import { Membrane, AnthropicAdapter } from 'membrane';
+import { Membrane, AnthropicAdapter } from '@animalabs/membrane';
 import { AgentFramework, ApiServer, ApiModule } from '../src/index.js';
 
 async function main() {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@connectome/agent-framework",
+  "name": "@animalabs/agent-framework",
   "version": "0.1.0",
   "description": "Multi-agent framework with pluggable modules, persistent state, and concurrent tool execution",
   "type": "module",
@@ -24,7 +24,8 @@
     "dev": "tsc --watch",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit",
-    "test": "node --test dist/test/*.test.js"
+    "test": "node --test dist/test/*.test.js",
+    "prepublishOnly": "npm run build"
   },
   "keywords": [
     "connectome",
@@ -37,11 +38,11 @@
   "author": "Anima Research",
   "license": "MIT",
   "dependencies": {
-    "@connectome/context-manager": "file:../context-manager",
+    "@animalabs/context-manager": "^0.1.0",
+    "@animalabs/chronicle": "^0.1.0",
+    "@animalabs/membrane": "^0.5.40",
     "chokidar": "^4.0.3",
-    "chronicle": "file:../chronicle",
     "discord.js": "^14.25.1",
-    "membrane": "file:../membrane",
     "ws": "^8.18.0"
   },
   "devDependencies": {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,11 +1,11 @@
-import type { Membrane, NormalizedMessage, NormalizedRequest, ContentBlock, YieldingStream } from 'membrane';
-import { isAbortedResponse } from 'membrane';
+import type { Membrane, NormalizedMessage, NormalizedRequest, ContentBlock, YieldingStream } from '@animalabs/membrane';
+import { isAbortedResponse } from '@animalabs/membrane';
 
 export interface StartStreamResult {
   stream: YieldingStream;
   request: NormalizedRequest;
 }
-import type { ContextManager, TokenBudget, ContextInjection, CompileResult } from '@connectome/context-manager';
+import type { ContextManager, TokenBudget, ContextInjection, CompileResult } from '@animalabs/context-manager';
 import type {
   AgentConfig,
   AgentState,

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -8,7 +8,7 @@
 
 import { WebSocketServer, WebSocket } from 'ws';
 import { createServer, IncomingMessage, ServerResponse } from 'node:http';
-import type { ContentBlock } from 'membrane';
+import type { ContentBlock } from '@animalabs/membrane';
 import type { AgentFramework } from '../framework.js';
 import type { TraceEvent, ProcessEvent } from '../types/index.js';
 import type {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -2,7 +2,7 @@
  * API types for WebSocket communication with the agent framework
  */
 
-import type { ContentBlock } from 'membrane';
+import type { ContentBlock } from '@animalabs/membrane';
 import type { AgentStatus, ToolCall, ToolResult } from '../types/index.js';
 
 // ============================================================================

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -1,14 +1,14 @@
 import { join } from 'node:path';
-import { JsStore } from 'chronicle';
-import type { Membrane, ContentBlock, NormalizedRequest, YieldingStream, ToolResult as MembraneToolResult } from 'membrane';
-import { ContextManager, PassthroughStrategy } from '@connectome/context-manager';
+import { JsStore } from '@animalabs/chronicle';
+import type { Membrane, ContentBlock, NormalizedRequest, YieldingStream, ToolResult as MembraneToolResult } from '@animalabs/membrane';
+import { ContextManager, PassthroughStrategy } from '@animalabs/context-manager';
 import type {
   MessageId,
   MessageMetadata,
   MessageQuery,
   MessageQueryResult,
   StoredMessage,
-} from '@connectome/context-manager';
+} from '@animalabs/context-manager';
 import type {
   FrameworkConfig,
   InferencePolicy,
@@ -67,7 +67,7 @@ import type {
   ChannelsChangedParams,
   ChannelsIncomingParams,
 } from './mcpl/types.js';
-import type { ContextInjection } from '@connectome/context-manager';
+import type { ContextInjection } from '@animalabs/context-manager';
 
 const FRAMEWORK_STATE_ID = 'framework/state';
 const INFERENCE_LOG_ID = 'framework/inference-log';

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ export { EventGate } from './gate/index.js';
 export type { GateConfig, GateOptions, GatePolicy, GatePolicyMatch, GateBehavior } from './gate/index.js';
 
 // Re-export commonly used types from dependencies
-export type { ContextManager, ContextStrategy, TokenBudget } from '@connectome/context-manager';
-export { PassthroughStrategy, AutobiographicalStrategy, KnowledgeStrategy } from '@connectome/context-manager';
-export type { KnowledgeConfig, PhaseType } from '@connectome/context-manager';
-export type { Membrane, NormalizedMessage, NormalizedRequest, ContentBlock } from 'membrane';
+export type { ContextManager, ContextStrategy, TokenBudget } from '@animalabs/context-manager';
+export { PassthroughStrategy, AutobiographicalStrategy, KnowledgeStrategy } from '@animalabs/context-manager';
+export type { KnowledgeConfig, PhaseType } from '@animalabs/context-manager';
+export type { Membrane, NormalizedMessage, NormalizedRequest, ContentBlock } from '@animalabs/membrane';

--- a/src/mcpl/channel-registry.ts
+++ b/src/mcpl/channel-registry.ts
@@ -13,7 +13,7 @@
  * - Build channel context for beforeInference params
  */
 
-import type { ContentBlock } from 'membrane';
+import type { ContentBlock } from '@animalabs/membrane';
 
 import type {
   ChannelDescriptor,

--- a/src/mcpl/checkpoint-manager.ts
+++ b/src/mcpl/checkpoint-manager.ts
@@ -12,7 +12,7 @@
  * Spec reference: Section 8 (State Management).
  */
 
-import type { JsStore } from 'chronicle';
+import type { JsStore } from '@animalabs/chronicle';
 
 import type { StateCheckpoint, JsonPatchOperation } from './types.js';
 

--- a/src/mcpl/hook-orchestrator.ts
+++ b/src/mcpl/hook-orchestrator.ts
@@ -12,8 +12,8 @@
  * - Loop prevention: rejects inference/request while inside a hook
  */
 
-import type { ContentBlock } from 'membrane';
-import type { ContextInjection } from '@connectome/context-manager';
+import type { ContentBlock } from '@animalabs/membrane';
+import type { ContextInjection } from '@animalabs/context-manager';
 
 import type {
   McplContentBlock,

--- a/src/mcpl/inference-router.ts
+++ b/src/mcpl/inference-router.ts
@@ -8,7 +8,7 @@
  * Spec reference: Section 11 (Server-Initiated Inference).
  */
 
-import type { Membrane, ContentBlock, NormalizedRequest } from 'membrane';
+import type { Membrane, ContentBlock, NormalizedRequest } from '@animalabs/membrane';
 
 import type {
   McplInferenceRequestParams,

--- a/src/mcpl/push-handler.ts
+++ b/src/mcpl/push-handler.ts
@@ -7,7 +7,7 @@
  * Spec reference: Section 9 (Push Events).
  */
 
-import type { ContentBlock } from 'membrane';
+import type { ContentBlock } from '@animalabs/membrane';
 
 import type {
   McplContentBlock,

--- a/src/module-registry.ts
+++ b/src/module-registry.ts
@@ -1,5 +1,5 @@
-import type { JsStore } from 'chronicle';
-import type { ContentBlock } from 'membrane';
+import type { JsStore } from '@animalabs/chronicle';
+import type { ContentBlock } from '@animalabs/membrane';
 import type {
   MessageId,
   MessageMetadata,
@@ -7,7 +7,7 @@ import type {
   MessageQueryResult,
   StoredMessage,
   ContextInjection,
-} from '@connectome/context-manager';
+} from '@animalabs/context-manager';
 import type {
   Module,
   ModuleContext,

--- a/src/modules/discord/index.ts
+++ b/src/modules/discord/index.ts
@@ -7,7 +7,7 @@
  * - Tools for explicit Discord operations (send, DM, react, etc.)
  */
 
-import type { ContentBlock } from 'membrane';
+import type { ContentBlock } from '@animalabs/membrane';
 import type {
   Module,
   ModuleContext,

--- a/src/modules/discord/types.ts
+++ b/src/modules/discord/types.ts
@@ -2,7 +2,7 @@
  * Types for the Discord module
  */
 
-import type { ContentBlock } from 'membrane';
+import type { ContentBlock } from '@animalabs/membrane';
 
 // ============================================================================
 // Module Configuration

--- a/src/modules/workspace/index.ts
+++ b/src/modules/workspace/index.ts
@@ -7,7 +7,7 @@
 
 import { readFile, stat, access } from 'node:fs/promises';
 import { join, resolve, relative } from 'node:path';
-import type { JsStore } from 'chronicle';
+import type { JsStore } from '@animalabs/chronicle';
 import type { Module, ModuleContext, ProcessState, EventResponse } from '../../types/module.js';
 import type { ProcessEvent, ToolDefinition, ToolCall, ToolResult } from '../../types/events.js';
 import type {

--- a/src/modules/workspace/sync.ts
+++ b/src/modules/workspace/sync.ts
@@ -9,7 +9,7 @@
 import { createHash } from 'node:crypto';
 import { readFile, writeFile, mkdir, readdir, stat, access } from 'node:fs/promises';
 import { join, dirname, relative, resolve } from 'node:path';
-import type { JsStore, JsTreeEntry } from 'chronicle';
+import type { JsStore, JsTreeEntry } from '@animalabs/chronicle';
 import type { MountState } from './types.js';
 
 export const DEFAULT_MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -1,5 +1,5 @@
-import type { ContentBlock, YieldingStream } from 'membrane';
-import type { ContextStrategy } from '@connectome/context-manager';
+import type { ContentBlock, YieldingStream } from '@animalabs/membrane';
+import type { ContextStrategy } from '@animalabs/context-manager';
 import type { ToolCallId, ToolResult, ToolCall } from './events.js';
 
 /**

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -1,5 +1,5 @@
-import type { ContentBlock, ToolDefinition as MembraneToolDefinition } from 'membrane';
-import type { MessageId } from '@connectome/context-manager';
+import type { ContentBlock, ToolDefinition as MembraneToolDefinition } from '@animalabs/membrane';
+import type { MessageId } from '@animalabs/context-manager';
 
 /**
  * Unique identifier for a tool call.

--- a/src/types/framework.ts
+++ b/src/types/framework.ts
@@ -1,5 +1,5 @@
-import type { JsStore } from 'chronicle';
-import type { Membrane } from 'membrane';
+import type { JsStore } from '@animalabs/chronicle';
+import type { Membrane } from '@animalabs/membrane';
 import type { Module, EventResponse } from './module.js';
 import type { AgentConfig, InferenceRequest } from './agent.js';
 import type { ProcessEvent } from './events.js';

--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -1,10 +1,10 @@
-import type { ContentBlock } from 'membrane';
+import type { ContentBlock } from '@animalabs/membrane';
 import type {
   MessageId,
   MessageMetadata,
   StoredMessage,
   ContextInjection,
-} from '@connectome/context-manager';
+} from '@animalabs/context-manager';
 import type { ProcessEvent, ToolDefinition, ToolCall, ToolResult } from './events.js';
 
 /**

--- a/test-event-persistence.mjs
+++ b/test-event-persistence.mjs
@@ -2,8 +2,8 @@
  * Test script for event persistence
  */
 
-import { JsStore } from 'chronicle';
-import { Membrane, AnthropicAdapter } from 'membrane';
+import { JsStore } from '@animalabs/chronicle';
+import { Membrane, AnthropicAdapter } from '@animalabs/membrane';
 import { AgentFramework, ApiModule } from './dist/index.js';
 import { rm } from 'fs/promises';
 

--- a/test/framework.test.ts
+++ b/test/framework.test.ts
@@ -7,7 +7,7 @@ import assert from 'node:assert';
 import { tmpdir } from 'node:os';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
-import type { NormalizedRequest, NormalizedResponse, ContentBlock, YieldingStream, StreamEvent } from 'membrane';
+import type { NormalizedRequest, NormalizedResponse, ContentBlock, YieldingStream, StreamEvent } from '@animalabs/membrane';
 import type {
   Module,
   ModuleContext,

--- a/test/framework.test.ts
+++ b/test/framework.test.ts
@@ -199,8 +199,8 @@ class MockMembrane implements MinimalMembrane {
   }
 
   // Cast helper - use this when passing to framework
-  asMembrane(): import('membrane').Membrane {
-    return this as unknown as import('membrane').Membrane;
+  asMembrane(): import('@animalabs/membrane').Membrane {
+    return this as unknown as import('@animalabs/membrane').Membrane;
   }
 }
 
@@ -561,7 +561,7 @@ describe('AgentFramework', () => {
 
   it('should share store when provided', async () => {
     // This test verifies that app-owned stores work
-    const { JsStore } = await import('chronicle');
+    const { JsStore } = await import('@animalabs/chronicle');
     const store = JsStore.openOrCreate({ path: join(tempDir, 'shared.chronicle') });
 
     const framework = await AgentFramework.create({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,12 @@
     "declarationMap": true,
     "sourceMap": true,
     "resolveJsonModule": true,
-    "composite": true
+    "composite": true,
+    "paths": {
+      "@animalabs/chronicle": ["../chronicle/index.d.ts"],
+      "@animalabs/membrane": ["../membrane/dist/index.d.ts"],
+      "@animalabs/context-manager": ["../context-manager/dist/src/index.d.ts"]
+    }
   },
   "include": ["src/**/*", "test/**/*"],
   "exclude": ["node_modules", "dist"],


### PR DESCRIPTION
## Summary
- Renames package from `@connectome/agent-framework` to `@animalabs/agent-framework`
- Updates `chronicle`, `membrane`, and `context-manager` deps from `file:` refs to `@animalabs/*` npm packages
- Renames all imports across src/, test/, and examples/ (~25 files)
- Adds tsconfig `paths` for local development against sibling packages
- Adds `prepublishOnly` script

## Part of
npm publishing initiative — depends on `@animalabs/chronicle`, `@animalabs/membrane`, and `@animalabs/context-manager` being published first.

## Test plan
- [ ] `npx tsc --noEmit` passes ✅ (verified locally)
- [ ] Existing tests pass after `npm install` with published deps
- [ ] `npm publish --access public` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)