### PR TITLE
    fix: align MCPL event scopes with canonical 'mcpl:' prefix; add gate:decision trace

### DIFF
--- a/src/gate/event-gate.ts
+++ b/src/gate/event-gate.ts
@@ -394,9 +394,24 @@ export class EventGate {
     this.reloadIfChanged();
 
     const policy = this.matchPolicy(info);
+    const decision = this.computeDecision(policy, info);
 
+    this.emitTrace({
+      type: 'gate:decision',
+      eventType: info.eventType,
+      serverId: info.serverId || undefined,
+      channelId: info.channelId || undefined,
+      matchedPolicy: decision.policyName,
+      trigger: decision.trigger,
+      behavior: typeof decision.behavior === 'object' ? `debounce:${decision.behavior.debounce}` : decision.behavior,
+      timestamp: Date.now(),
+    });
+
+    return decision;
+  }
+
+  private computeDecision(policy: GatePolicy | null, info: GateEventInfo): GateDecision {
     if (!policy) {
-      // No policy matched — use default
       const trigger = (this.config.default ?? 'always') === 'always';
       return { trigger, policyName: null, behavior: this.config.default ?? 'always' };
     }
@@ -407,7 +422,7 @@ export class EventGate {
     policyStats.lastMatchTimestamp = Date.now();
     this.stats.set(policy.name, policyStats);
 
-    // Emit trace
+    // Legacy trace kept for backward compatibility with existing consumers.
     this.emitTrace({
       type: 'gate:policy-matched',
       policyName: policy.name,

--- a/src/mcpl/channel-registry.ts
+++ b/src/mcpl/channel-registry.ts
@@ -339,7 +339,7 @@ export class ChannelRegistry {
           textContent,
           {
             ...message.metadata,
-            eventType: 'channel:incoming',
+            eventType: 'mcpl:channel-incoming',
             serverId,
             channelId: message.channelId,
             messageId: message.messageId,

--- a/src/mcpl/push-handler.ts
+++ b/src/mcpl/push-handler.ts
@@ -195,7 +195,7 @@ export class PushHandler {
         serverId,
         featureSet: params.featureSet,
         eventId: params.eventId,
-        eventType: 'push:event',
+        eventType: 'mcpl:push-event',
         ...(params.origin ?? {}),
       };
       triggerInference = this.shouldTriggerInference(textContent, metadata);

--- a/src/types/trace.ts
+++ b/src/types/trace.ts
@@ -175,6 +175,15 @@ export type TraceEvent =
       configPath: string;
       policyCount: number;
     })
+  | (TraceEventBase & {
+      type: 'gate:decision';
+      eventType: string;
+      serverId?: string;
+      channelId?: string;
+      matchedPolicy: string | null;
+      trigger: boolean;
+      behavior: string;
+    })
 
   // Usage lifecycle
   | (TraceEventBase & {

--- a/test/event-gate.test.ts
+++ b/test/event-gate.test.ts
@@ -47,7 +47,7 @@ function makeGate(configPath: string, opts?: { initialConfig?: GateConfig }) {
 function event(overrides?: Partial<GateEventInfo>): GateEventInfo {
   return {
     content: 'test message',
-    eventType: 'push:event',
+    eventType: 'mcpl:push-event',
     serverId: '',
     channelId: '',
     ...overrides,
@@ -99,13 +99,13 @@ describe('policy matching', () => {
   it('scope match — matching event type', () => {
     const path = writeConfig('scope.json', {
       policies: [
-        { name: 'channels', match: { scope: ['channel:incoming'] }, behavior: 'always' },
+        { name: 'channels', match: { scope: ['mcpl:channel-incoming'] }, behavior: 'always' },
       ],
       default: 'skip',
     });
     const { gate } = makeGate(path);
-    assert.strictEqual(gate.evaluate(event({ eventType: 'channel:incoming' })).trigger, true);
-    assert.strictEqual(gate.evaluate(event({ eventType: 'push:event' })).trigger, false);
+    assert.strictEqual(gate.evaluate(event({ eventType: 'mcpl:channel-incoming' })).trigger, true);
+    assert.strictEqual(gate.evaluate(event({ eventType: 'mcpl:push-event' })).trigger, false);
   });
 
   it('source match — exact serverId', () => {
@@ -176,7 +176,7 @@ describe('policy matching', () => {
         {
           name: 'zulip-errors',
           match: {
-            scope: ['channel:incoming'],
+            scope: ['mcpl:channel-incoming'],
             source: 'zulip',
             filter: { type: 'text', pattern: 'error' },
           },
@@ -189,25 +189,25 @@ describe('policy matching', () => {
     // All conditions met
     assert.strictEqual(gate.evaluate(event({
       content: 'An error occurred',
-      eventType: 'channel:incoming',
+      eventType: 'mcpl:channel-incoming',
       serverId: 'zulip',
     })).trigger, true);
     // Wrong scope
     assert.strictEqual(gate.evaluate(event({
       content: 'An error occurred',
-      eventType: 'push:event',
+      eventType: 'mcpl:push-event',
       serverId: 'zulip',
     })).trigger, false);
     // Wrong source
     assert.strictEqual(gate.evaluate(event({
       content: 'An error occurred',
-      eventType: 'channel:incoming',
+      eventType: 'mcpl:channel-incoming',
       serverId: 'discord',
     })).trigger, false);
     // No error keyword
     assert.strictEqual(gate.evaluate(event({
       content: 'All good',
-      eventType: 'channel:incoming',
+      eventType: 'mcpl:channel-incoming',
       serverId: 'zulip',
     })).trigger, false);
   });
@@ -274,7 +274,7 @@ describe('debounce', () => {
   it('returns false immediately', () => {
     const path = writeConfig('debounce.json', {
       policies: [
-        { name: 'editor', match: { scope: ['push:event'] }, behavior: { debounce: 100 } },
+        { name: 'editor', match: { scope: ['mcpl:push-event'] }, behavior: { debounce: 100 } },
       ],
       default: 'skip',
     });
@@ -287,7 +287,7 @@ describe('debounce', () => {
   it('batches events and fires after delay', async () => {
     const path = writeConfig('debounce-fire.json', {
       policies: [
-        { name: 'editor', match: { scope: ['push:event'] }, behavior: { debounce: 150 } },
+        { name: 'editor', match: { scope: ['mcpl:push-event'] }, behavior: { debounce: 150 } },
       ],
       default: 'skip',
     });
@@ -529,15 +529,15 @@ describe('gate:status tool', () => {
     const path = writeConfig('status.json', {
       policies: [
         { name: 'always-policy', match: {}, behavior: 'always' },
-        { name: 'debounce-policy', match: { scope: ['push:event'] }, behavior: { debounce: 1000 } },
+        { name: 'debounce-policy', match: { scope: ['mcpl:push-event'] }, behavior: { debounce: 1000 } },
       ],
       default: 'skip',
     });
     const { gate } = makeGate(path);
 
     // Trigger some matches
-    gate.evaluate(event({ eventType: 'channel:incoming' }));
-    gate.evaluate(event({ eventType: 'channel:incoming' }));
+    gate.evaluate(event({ eventType: 'mcpl:channel-incoming' }));
+    gate.evaluate(event({ eventType: 'mcpl:channel-incoming' }));
 
     const result = await gate.handleToolCall();
     assert.strictEqual(result.success, true);
@@ -568,8 +568,8 @@ describe('asShouldTriggerCallback', () => {
     const cb = gate.asShouldTriggerCallback();
 
     assert.strictEqual(typeof cb, 'function');
-    assert.strictEqual(cb('hello', { eventType: 'push:event', serverId: 'zulip' }), true);
-    assert.strictEqual(cb('hello', { eventType: 'push:event', serverId: 'discord' }), false);
+    assert.strictEqual(cb('hello', { eventType: 'mcpl:push-event', serverId: 'zulip' }), true);
+    assert.strictEqual(cb('hello', { eventType: 'mcpl:push-event', serverId: 'discord' }), false);
   });
 });
 

--- a/test/mcpl-gate-roundtrip.test.ts
+++ b/test/mcpl-gate-roundtrip.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { existsSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { EventGate } from '../src/gate/event-gate.js';
+import { ChannelRegistry } from '../src/mcpl/channel-registry.js';
+import type { GateConfig } from '../src/gate/types.js';
+import type { ChannelsIncomingParams } from '../src/mcpl/types.js';
+import type { ProcessEvent } from '../src/types/index.js';
+
+const TMP_DIR = join(import.meta.dirname, '../.test-tmp-roundtrip');
+
+beforeEach(() => {
+  mkdirSync(TMP_DIR, { recursive: true });
+});
+
+afterEach(() => {
+  if (existsSync(TMP_DIR)) rmSync(TMP_DIR, { recursive: true, force: true });
+});
+
+function makeGate(config: GateConfig) {
+  const configPath = join(TMP_DIR, 'gate.json');
+  writeFileSync(configPath, JSON.stringify(config));
+  return new EventGate({
+    configPath,
+    emitTrace: () => {},
+    addMessage: () => '',
+    requestInference: () => {},
+    getAgentNames: () => ['agent'],
+  });
+}
+
+function makeRegistry(shouldTriggerInference?: (c: string, m: Record<string, unknown>) => boolean) {
+  const pushed: ProcessEvent[] = [];
+  const registry = new ChannelRegistry(
+    {} as never,
+    {} as never,
+    (ev) => pushed.push(ev),
+    () => {},
+    shouldTriggerInference ? { shouldTriggerInference } : undefined,
+  );
+  return { registry, pushed };
+}
+
+function incomingParams(channelId: string, text: string): ChannelsIncomingParams {
+  return {
+    messages: [{
+      channelId,
+      messageId: 'msg-1',
+      author: { id: '42', name: 'Alice' },
+      timestamp: new Date().toISOString(),
+      content: [{ type: 'text', text }],
+    }],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Contract: ChannelRegistry emits eventType='mcpl:channel-incoming' to the gate
+// ---------------------------------------------------------------------------
+
+describe('ChannelRegistry → shouldTriggerInference contract', () => {
+  it('emits eventType="mcpl:channel-incoming" in callback metadata', () => {
+    const seen: Array<Record<string, unknown>> = [];
+    const { registry } = makeRegistry((_content, metadata) => {
+      seen.push(metadata);
+      return true;
+    });
+
+    registry.handleIncoming('zulip', incomingParams('zulip:tracker-miner-f', 'hi'));
+
+    assert.strictEqual(seen.length, 1);
+    assert.strictEqual(seen[0].eventType, 'mcpl:channel-incoming');
+    assert.strictEqual(seen[0].serverId, 'zulip');
+    assert.strictEqual(seen[0].channelId, 'zulip:tracker-miner-f');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Roundtrip: a recipe-shaped channel policy fires for a channel-incoming event
+// ---------------------------------------------------------------------------
+
+describe('ChannelRegistry + EventGate roundtrip', () => {
+  it('channel-scoped policy triggers inference on matching channel-incoming', () => {
+    const gate = makeGate({
+      default: 'skip',
+      policies: [
+        {
+          name: 'tracker-channel',
+          match: { scope: ['mcpl:channel-incoming'], channel: 'zulip:tracker-miner-f' },
+          behavior: 'always',
+        },
+      ],
+    });
+
+    const { registry, pushed } = makeRegistry(gate.asShouldTriggerCallback());
+
+    registry.handleIncoming('zulip', incomingParams('zulip:tracker-miner-f', 'question in channel'));
+
+    assert.strictEqual(pushed.length, 1);
+    const event = pushed[0] as { type: string; triggerInference?: boolean };
+    assert.strictEqual(event.type, 'mcpl:channel-incoming');
+    assert.strictEqual(event.triggerInference, true);
+  });
+
+  it('default:skip wins when no policy matches the channel', () => {
+    const gate = makeGate({
+      default: 'skip',
+      policies: [
+        {
+          name: 'tracker-channel',
+          match: { scope: ['mcpl:channel-incoming'], channel: 'zulip:tracker-miner-f' },
+          behavior: 'always',
+        },
+      ],
+    });
+
+    const { registry, pushed } = makeRegistry(gate.asShouldTriggerCallback());
+
+    registry.handleIncoming('zulip', incomingParams('zulip:other-channel', 'noise'));
+
+    assert.strictEqual(pushed.length, 1);
+    const event = pushed[0] as { type: string; triggerInference?: boolean };
+    assert.strictEqual(event.triggerInference, false);
+  });
+});


### PR DESCRIPTION
ChannelRegistry and PushHandler were injecting 'channel:incoming' and 'push:event'
    into the shouldTriggerInference metadata, while event.type (and every recipe
    author) used 'mcpl:channel-incoming' and 'mcpl:push-event'. Recipes matching on
    the canonical strings never fired and fell through to default:skip, silently
    dropping channel-scoped wake intent.
    
    Aligns channel-registry.ts:342 and push-handler.ts:198 with the canonical
    strings. Adds a gate:decision trace emitted on every EventGate.evaluate so
    future scope mismatches (or any other silent-drop path) are self-diagnosing
    from Chronicle. gate:policy-matched kept for backward compatibility with
    existing consumers.
