### PR TITLE
Triumvirate fixes

### DIFF
--- a/src/framework.ts
+++ b/src/framework.ts
@@ -1463,13 +1463,20 @@ export class AgentFramework {
 
       // Gate non-MCPL events (MCPL events are already gated in PushHandler/ChannelRegistry)
       if (this.eventGate && event.type !== 'mcpl:push-event' && event.type !== 'mcpl:channel-incoming') {
-        const content = 'content' in event ? String((event as { content: unknown }).content) : '';
+        const evAny = event as unknown as Record<string, unknown>;
+        const content = 'content' in event ? String(evAny.content) : '';
+        const mount = typeof evAny.mount === 'string' ? evAny.mount : undefined;
+        const paths = Array.isArray(evAny.paths)
+          ? (evAny.paths as unknown[]).filter((p): p is string => typeof p === 'string')
+          : undefined;
         const decision = this.eventGate.evaluate({
           content,
           eventType: event.type,
           serverId: source,
           channelId: '',
           metadata: 'metadata' in event ? (event as { metadata: Record<string, unknown> }).metadata : {},
+          mount,
+          paths,
         });
         if (!decision.trigger) return;
       }

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -2451,6 +2451,12 @@ export class AgentFramework {
 
     for (const config of serverConfigs) {
       try {
+        // Record per-server channel subscription policy before the server
+        // registers channels — handleRegister fires during the handshake.
+        if (config.channelSubscription !== undefined && this.channelRegistry) {
+          this.channelRegistry.setSubscriptionPolicy(config.id, config.channelSubscription);
+        }
+
         const connection = await this.mcplServerRegistry.addServer(config, hostCapabilities);
 
         // Wire event listeners then flush any events that arrived during the

--- a/src/gate/event-gate.ts
+++ b/src/gate/event-gate.ts
@@ -76,6 +76,8 @@ interface CompiledPolicy {
   filterRegex?: RegExp;
   sourceRegex?: RegExp;
   channelRegex?: RegExp;
+  mountRegex?: RegExp;
+  pathRegex?: RegExp;
 }
 
 interface PolicyStats {
@@ -170,6 +172,8 @@ function validatePolicy(raw: unknown): GatePolicy {
     if (Array.isArray(m.scope)) match.scope = m.scope.filter(s => typeof s === 'string');
     if (typeof m.source === 'string') match.source = m.source;
     if (typeof m.channel === 'string') match.channel = m.channel;
+    if (typeof m.mount === 'string') match.mount = m.mount;
+    if (typeof m.pathGlob === 'string') match.pathGlob = m.pathGlob;
     if (m.filter && typeof m.filter === 'object') {
       const f = m.filter as Record<string, unknown>;
       if ((f.type === 'text' || f.type === 'regex') && typeof f.pattern === 'string') {
@@ -286,6 +290,12 @@ export class EventGate {
       if (policy.match.channel) {
         compiled.channelRegex = compileGlob(policy.match.channel);
       }
+      if (policy.match.mount) {
+        compiled.mountRegex = compileGlob(policy.match.mount);
+      }
+      if (policy.match.pathGlob) {
+        compiled.pathRegex = compileGlob(policy.match.pathGlob);
+      }
       return compiled;
     });
   }
@@ -366,6 +376,21 @@ export class EventGate {
     // Channel check
     if (compiled.channelRegex && !compiled.channelRegex.test(info.channelId)) {
       return false;
+    }
+
+    // Mount check (workspace fs events)
+    if (compiled.mountRegex) {
+      if (!info.mount || !compiled.mountRegex.test(info.mount)) {
+        return false;
+      }
+    }
+
+    // Path glob check — matches if ANY path matches
+    if (compiled.pathRegex) {
+      const paths = info.paths;
+      if (!paths || paths.length === 0) return false;
+      const anyMatch = paths.some(p => compiled.pathRegex!.test(p));
+      if (!anyMatch) return false;
     }
 
     // Content filter check

--- a/src/gate/event-gate.ts
+++ b/src/gate/event-gate.ts
@@ -214,6 +214,12 @@ export class EventGate {
   // Per-policy stats
   private stats = new Map<string, PolicyStats>();
 
+  // Observability counters for events that didn't match any policy
+  private totalEvaluations = 0;
+  private defaultTriggered = 0;
+  private defaultSkipped = 0;
+  private defaultByEventType = new Map<string, { triggered: number; skipped: number }>();
+
   // Dependency-injected callbacks
   private emitTrace: (event: TraceEventLike) => void;
   private addMessageFn: (participant: string, content: Array<{ type: 'text'; text: string }>, metadata?: Record<string, unknown>) => unknown;
@@ -234,13 +240,43 @@ export class EventGate {
     this.requestInferenceFn = opts.requestInference;
     this.getAgentNamesFn = opts.getAgentNames;
 
-    // Seed config file if it doesn't exist
-    if (opts.initialConfig && !existsSync(this.configPath)) {
+    // Seed or reconcile the on-disk config.
+    //
+    // First start: write `initialConfig` verbatim.
+    // Subsequent starts: if the recipe/config source declares policies that
+    // aren't yet in gate.json (e.g. the user edited the recipe between
+    // sessions), append them by name. Existing policies are left alone so
+    // user edits via `workspace--edit _config/gate.json` survive.
+    // The `default` field is not reconciled — it's an explicit operator
+    // choice and a recipe change shouldn't silently flip live wake
+    // behavior for a session that's already been running.
+    if (opts.initialConfig) {
       try {
         mkdirSync(dirname(this.configPath), { recursive: true });
-        writeFileSync(this.configPath, JSON.stringify(opts.initialConfig, null, 2) + '\n');
+        if (!existsSync(this.configPath)) {
+          writeFileSync(this.configPath, JSON.stringify(opts.initialConfig, null, 2) + '\n');
+        } else {
+          const existing = this.loadConfig();
+          if (existing) {
+            const existingNames = new Set(existing.policies.map(p => p.name));
+            const missing = opts.initialConfig.policies.filter(p => !existingNames.has(p.name));
+            if (missing.length > 0) {
+              const reconciled: GateConfig = {
+                ...existing,
+                policies: [...existing.policies, ...missing],
+              };
+              writeFileSync(this.configPath, JSON.stringify(reconciled, null, 2) + '\n');
+              opts.emitTrace({
+                type: 'gate:config-reconciled',
+                configPath: this.configPath,
+                addedPolicies: missing.map(p => p.name),
+                timestamp: Date.now(),
+              });
+            }
+          }
+        }
       } catch (err) {
-        this.configErrors.push(`Failed to seed gate.json: ${err}`);
+        this.configErrors.push(`Failed to seed/reconcile gate.json: ${err}`);
       }
     }
 
@@ -420,6 +456,20 @@ export class EventGate {
 
     const policy = this.matchPolicy(info);
     const decision = this.computeDecision(policy, info);
+
+    this.totalEvaluations++;
+    if (!policy) {
+      const bucket = this.defaultByEventType.get(info.eventType)
+        ?? { triggered: 0, skipped: 0 };
+      if (decision.trigger) {
+        this.defaultTriggered++;
+        bucket.triggered++;
+      } else {
+        this.defaultSkipped++;
+        bucket.skipped++;
+      }
+      this.defaultByEventType.set(info.eventType, bucket);
+    }
 
     this.emitTrace({
       type: 'gate:decision',
@@ -639,6 +689,9 @@ export class EventGate {
       return result;
     });
 
+    const byEventType: Record<string, { triggered: number; skipped: number }> = {};
+    for (const [k, v] of this.defaultByEventType) byEventType[k] = { ...v };
+
     return {
       configPath: this.configPath,
       configSource: this.configSource,
@@ -646,6 +699,12 @@ export class EventGate {
       default: this.config.default ?? 'always',
       policies,
       errors: [...this.configErrors],
+      totalEvaluations: this.totalEvaluations,
+      defaultDecisions: {
+        triggered: this.defaultTriggered,
+        skipped: this.defaultSkipped,
+        byEventType,
+      },
     };
   }
 

--- a/src/gate/types.ts
+++ b/src/gate/types.ts
@@ -30,6 +30,16 @@ export interface GatePolicyMatch {
   channel?: string;
   /** Content text filter. */
   filter?: { type: 'text' | 'regex'; pattern: string };
+  /**
+   * Mount name to match (exact or glob with *). Populated for workspace
+   * filesystem events (workspace:created/modified/deleted).
+   */
+  mount?: string;
+  /**
+   * Glob applied against each path in the event. Matches if ANY path matches.
+   * Supports `*` wildcard; not full gitignore syntax.
+   */
+  pathGlob?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -87,6 +97,10 @@ export interface GateEventInfo {
   serverId: string;
   channelId: string;
   metadata?: Record<string, unknown>;
+  /** Workspace mount name (for workspace:* events). */
+  mount?: string;
+  /** Mount-prefixed paths touched (for workspace:* events). */
+  paths?: string[];
 }
 
 /** Per-policy runtime statistics (for gate:status). */

--- a/src/gate/types.ts
+++ b/src/gate/types.ts
@@ -123,4 +123,18 @@ export interface GateStatus {
   default: 'always' | 'skip';
   policies: GatePolicyStats[];
   errors: string[];
+  /** Total events the gate has evaluated since startup. */
+  totalEvaluations: number;
+  /**
+   * Count of events that fell through to `default` (no policy matched),
+   * broken down by whether they triggered or were skipped. Useful for
+   * spotting events that are arriving but silently dropped — if a policy
+   * appears to never fire (matchCount 0) and this count is growing for the
+   * same eventType, the event is reaching the gate but being dropped.
+   */
+  defaultDecisions: {
+    triggered: number;
+    skipped: number;
+    byEventType: Record<string, { triggered: number; skipped: number }>;
+  };
 }

--- a/src/mcpl/channel-registry.ts
+++ b/src/mcpl/channel-registry.ts
@@ -195,6 +195,13 @@ export class ChannelRegistry {
   /** Per-channel typing indicator timers. */
   private typingIntervals = new Map<string, ReturnType<typeof setInterval>>();
 
+  /**
+   * Per-server channel auto-open policy. Populated by the framework from
+   * each McplServerConfig at connect time; default ('auto') applies when
+   * unset.
+   */
+  private subscriptionPolicies = new Map<string, 'auto' | 'manual' | string[]>();
+
   constructor(
     serverRegistry: McplServerRegistry,
     featureSetManager: FeatureSetManager,
@@ -210,6 +217,14 @@ export class ChannelRegistry {
     this.emitTraceFn = emitTraceFn;
     this.sendTypingFn = options?.sendTypingFn;
     this.shouldTriggerInference = options?.shouldTriggerInference;
+  }
+
+  /**
+   * Set the channel auto-open policy for a server. Called by the framework
+   * when each MCPL server is registered.
+   */
+  setSubscriptionPolicy(serverId: string, policy: 'auto' | 'manual' | string[]): void {
+    this.subscriptionPolicies.set(serverId, policy);
   }
 
   // ==========================================================================
@@ -574,7 +589,22 @@ export class ChannelRegistry {
     const server = this.serverRegistry.getServer(serverId);
     if (!server) return;
 
+    const policy = this.subscriptionPolicies.get(serverId) ?? 'auto';
+    if (policy === 'manual') {
+      this.emitTraceFn({
+        type: 'mcpl:channels-auto-open-skipped',
+        serverId,
+        reason: 'manual',
+        count: channels.length,
+      });
+      return;
+    }
+
+    const allowList = Array.isArray(policy) ? new Set(policy) : null;
+
     for (const channel of channels) {
+      if (allowList && !allowList.has(channel.id)) continue;
+
       const key = `${serverId}:${channel.id}`;
       try {
         await server.sendChannelsOpen({

--- a/src/mcpl/types.ts
+++ b/src/mcpl/types.ts
@@ -222,6 +222,22 @@ export interface McplServerConfig {
    * Must not collide with any module name or another server's prefix.
    */
   toolPrefix?: string;
+
+  /**
+   * How channels registered by this server are opened.
+   * - `'auto'` (default) — every registered channel is auto-opened; the host
+   *   receives all traffic. Matches prior behavior. Right for agents that
+   *   should listen passively (e.g. a frontdesk clerk).
+   * - `'manual'` — registered channels are listed but not opened. The agent
+   *   must call the `channel_open` tool to start receiving messages. Right
+   *   for focused agents that should not be flooded with chatter from
+   *   servers that advertise many public channels (e.g. Zulip's full stream
+   *   list).
+   * - `string[]` — allow-list of channel ids; only matching channels are
+   *   auto-opened. Ids are server-scoped (the raw id the server registers,
+   *   e.g. `"zulip:tracker-miner-f"`).
+   */
+  channelSubscription?: 'auto' | 'manual' | string[];
 }
 
 // ============================================================================

--- a/src/modules/workspace/index.ts
+++ b/src/modules/workspace/index.ts
@@ -5,8 +5,8 @@
  * auto-sync between real filesystem and Chronicle, and manual materialization.
  */
 
-import { readFile, stat, access } from 'node:fs/promises';
-import { join, resolve, relative } from 'node:path';
+import { readFile, stat, access, writeFile, unlink, mkdir } from 'node:fs/promises';
+import { join, resolve, relative, dirname } from 'node:path';
 import type { JsStore } from '@animalabs/chronicle';
 import type { Module, ModuleContext, ProcessState, EventResponse } from '../../types/module.js';
 import type { ProcessEvent, ToolDefinition, ToolCall, ToolResult } from '../../types/events.js';
@@ -407,6 +407,44 @@ export class WorkspaceModule implements Module {
     return this.store;
   }
 
+  /**
+   * Persist a single write/edit/delete to disk when the mount opts in via
+   * `autoMaterialize`. Required for cross-agent pipelines — another agent's
+   * chokidar watcher on the same directory only sees real filesystem events.
+   * The local watcher's `suppress()` absorbs the echo so we don't self-wake.
+   */
+  private async autoMaterialize(
+    mount: MountState,
+    relativePath: string,
+    op: 'write' | 'delete',
+    content?: Buffer,
+  ): Promise<void> {
+    if (!mount.config.autoMaterialize) return;
+    if (mount.config.mode === 'read-only') return;
+
+    const absolutePath = join(mount.config.path, relativePath);
+    const watcher = this.watchers.get(mount.config.name);
+    watcher?.suppress(relativePath);
+
+    try {
+      if (op === 'write' && content) {
+        await mkdir(dirname(absolutePath), { recursive: true });
+        await writeFile(absolutePath, content);
+        mount.materializedHashes.set(relativePath, hashContent(content));
+      } else if (op === 'delete') {
+        try {
+          await unlink(absolutePath);
+        } catch (err) {
+          // File may already be gone on disk; swallow ENOENT, surface the rest.
+          if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+        }
+        mount.materializedHashes.delete(relativePath);
+      }
+    } catch (err) {
+      console.warn(`[workspace] autoMaterialize failed for ${mount.config.name}/${relativePath}:`, err);
+    }
+  }
+
   // ==========================================================================
   // Lazy Sync
   // ==========================================================================
@@ -497,12 +535,14 @@ export class WorkspaceModule implements Module {
       return { success: false, error: `Content exceeds max file size (${maxSize} bytes)`, isError: true };
     }
 
-    const blobHash = store.storeBlob(Buffer.from(input.content, 'utf-8'), 'text/plain');
+    const buffer = Buffer.from(input.content, 'utf-8');
+    const blobHash = store.storeBlob(buffer, 'text/plain');
     store.treeSet(mount.treeStateId, relativePath, {
       blobHash,
       size: Buffer.byteLength(input.content),
       mode: 0o644,
     });
+    await this.autoMaterialize(mount, relativePath, 'write', buffer);
 
     return {
       success: true,
@@ -554,12 +594,14 @@ export class WorkspaceModule implements Module {
       ? content.replaceAll(input.oldString, input.newString)
       : content.replace(input.oldString, input.newString);
 
-    const newBlobHash = store.storeBlob(Buffer.from(content, 'utf-8'), 'text/plain');
+    const newBuffer = Buffer.from(content, 'utf-8');
+    const newBlobHash = store.storeBlob(newBuffer, 'text/plain');
     store.treeSet(mount.treeStateId, relativePath, {
       blobHash: newBlobHash,
       size: Buffer.byteLength(content),
       mode: entry.mode,
     });
+    await this.autoMaterialize(mount, relativePath, 'write', newBuffer);
 
     return {
       success: true,
@@ -583,6 +625,7 @@ export class WorkspaceModule implements Module {
     }
 
     store.treeRemove(mount.treeStateId, relativePath);
+    await this.autoMaterialize(mount, relativePath, 'delete');
 
     return { success: true, data: { path: input.path, deleted: true } };
   }

--- a/src/modules/workspace/index.ts
+++ b/src/modules/workspace/index.ts
@@ -25,9 +25,13 @@ import type {
   StatusInput,
   MaterializeInput,
   SyncInput,
-  WorkspaceChangedEvent,
+  WorkspaceCreatedEvent,
+  WorkspaceModifiedEvent,
+  WorkspaceDeletedEvent,
+  WorkspaceFsOp,
 } from './types.js';
-import { MountWatcher } from './watcher.js';
+import { WORKSPACE_FS_EVENT_TYPES, opToEventType } from './types.js';
+import { MountWatcher, type FsChange } from './watcher.js';
 import { syncFromFs, materializeToFs, hashContent, DEFAULT_MAX_FILE_SIZE, type ConflictInfo } from './sync.js';
 
 export type {
@@ -137,8 +141,8 @@ export class WorkspaceModule implements Module {
     for (const [name, mount] of this.mounts) {
       const watchMode = mount.config.watch ?? 'always';
       if (watchMode === 'always') {
-        const watcher = new MountWatcher(mount.config, (paths) => {
-          this.handleFsChanges(name, paths);
+        const watcher = new MountWatcher(mount.config, (changes) => {
+          this.handleFsChanges(name, changes);
         });
         watcher.start();
         this.watchers.set(name, watcher);
@@ -330,8 +334,26 @@ export class WorkspaceModule implements Module {
     }
   }
 
-  async onProcess(_event: ProcessEvent, _state: ProcessState): Promise<EventResponse> {
-    return {};
+  async onProcess(event: ProcessEvent, _state: ProcessState): Promise<EventResponse> {
+    // Wake agents on filesystem events when the originating mount opted in.
+    // The EventGate still has final say — gate policies can further filter by
+    // mount name, path glob, or op type without requiring a recipe change.
+    if (!(WORKSPACE_FS_EVENT_TYPES as readonly string[]).includes(event.type)) {
+      return {};
+    }
+    const mountName = (event as { mount?: string }).mount;
+    if (!mountName) return {};
+    const mount = this.mounts.get(mountName);
+    if (!mount) return {};
+
+    const flag = mount.config.wakeOnChange;
+    if (!flag) return {};
+
+    const op = event.type.slice('workspace:'.length) as WorkspaceFsOp;
+    const opAllowed = flag === true || (Array.isArray(flag) && flag.includes(op));
+    if (!opAllowed) return {};
+
+    return { requestInference: true };
   }
 
   // ==========================================================================
@@ -869,20 +891,12 @@ export class WorkspaceModule implements Module {
       mount.initialSyncDone = true;
 
       if (result.synced.length > 0 || result.conflicts.length > 0) {
-        allResults.push({ mount: name, synced: result.synced, conflicts: result.conflicts });
-
-        // Emit workspace:changed event
-        if (this.ctx) {
-          const event: WorkspaceChangedEvent = {
-            type: 'workspace:changed',
-            paths: result.synced.map(p => `${name}/${p}`),
-            mount: name,
-            conflicts: result.conflicts.length > 0
-              ? result.conflicts.map(c => `${name}/${c.path}`)
-              : undefined,
-          };
-          this.ctx.pushEvent(event as ProcessEvent);
-        }
+        allResults.push({
+          mount: name,
+          synced: result.synced.map(s => s.path),
+          conflicts: result.conflicts,
+        });
+        this.emitFsEvents(name, result.synced, result.conflicts);
       }
     }
 
@@ -902,23 +916,67 @@ export class WorkspaceModule implements Module {
 
   /**
    * Handle filesystem changes detected by watcher (watch: 'always' mode).
+   *
+   * The watcher carries the op per path. For created/modified we call
+   * syncFromFs to pull content into the tree; for deleted we strip the tree
+   * entry directly (the file is gone, nothing to read). We emit one event per
+   * op type.
    */
-  private async handleFsChanges(mountName: string, paths: string[]): Promise<void> {
+  private async handleFsChanges(mountName: string, changes: FsChange[]): Promise<void> {
     const store = this.store;
     const mount = this.mounts.get(mountName);
     if (!store || !mount) return;
 
-    const result = await syncFromFs(store, mount, paths);
+    const touchedPaths = changes.filter(c => c.op !== 'deleted').map(c => c.path);
+    const deletedPaths = changes.filter(c => c.op === 'deleted').map(c => c.path);
 
-    if ((result.synced.length > 0 || result.conflicts.length > 0) && this.ctx) {
-      const event: WorkspaceChangedEvent = {
-        type: 'workspace:changed',
-        paths: result.synced.map(p => `${mountName}/${p}`),
+    const syncResult = touchedPaths.length > 0
+      ? await syncFromFs(store, mount, touchedPaths)
+      : { synced: [], conflicts: [], skipped: [] };
+
+    // Strip deleted entries from the tree so downstream consumers see a
+    // coherent state. syncFromFs would also do this if we passed the paths in,
+    // but the op from the watcher is authoritative — skip the access() probe.
+    for (const p of deletedPaths) {
+      const existing = store.treeGet(mount.treeStateId, p);
+      if (existing) {
+        store.treeRemove(mount.treeStateId, p);
+        syncResult.synced.push({ path: p, op: 'deleted' });
+      }
+    }
+
+    this.emitFsEvents(mountName, syncResult.synced, syncResult.conflicts);
+  }
+
+  /**
+   * Group synced paths by op and push one ProcessEvent per non-empty op.
+   */
+  private emitFsEvents(
+    mountName: string,
+    synced: Array<{ path: string; op: WorkspaceFsOp }>,
+    conflicts: ConflictInfo[],
+  ): void {
+    if (!this.ctx || synced.length === 0) return;
+
+    const byOp = new Map<WorkspaceFsOp, string[]>();
+    for (const { path, op } of synced) {
+      const list = byOp.get(op) ?? [];
+      list.push(`${mountName}/${path}`);
+      byOp.set(op, list);
+    }
+
+    const conflictPaths = conflicts.length > 0
+      ? conflicts.map(c => `${mountName}/${c.path}`)
+      : undefined;
+
+    for (const [op, paths] of byOp) {
+      const type = opToEventType(op);
+      const event = {
+        type,
+        paths,
         mount: mountName,
-        conflicts: result.conflicts.length > 0
-          ? result.conflicts.map(c => `${mountName}/${c.path}`)
-          : undefined,
-      };
+        ...(op !== 'deleted' && conflictPaths ? { conflicts: conflictPaths } : {}),
+      } as WorkspaceCreatedEvent | WorkspaceModifiedEvent | WorkspaceDeletedEvent;
       this.ctx.pushEvent(event as ProcessEvent);
     }
   }

--- a/src/modules/workspace/index.ts
+++ b/src/modules/workspace/index.ts
@@ -89,6 +89,12 @@ export class WorkspaceModule implements Module {
 
   /**
    * Inject the Chronicle store. Must be called after framework creation.
+   *
+   * Host ordering is: `AgentFramework.create()` calls `module.start(ctx)`
+   * before the framework is fully returned, and the host (e.g. conhost) wires
+   * the store via `initStore(store)` afterwards. Neither half has everything
+   * it needs on its own, so watcher setup runs in whichever callback fires
+   * second. `ensureRunning()` gates on `ctx && mounts-populated`.
    */
   initStore(store: JsStore): void {
     this.store = store;
@@ -118,6 +124,8 @@ export class WorkspaceModule implements Module {
       };
       this.mounts.set(mount.name, mountState);
     }
+
+    this.ensureRunning();
   }
 
   async start(ctx: ModuleContext): Promise<void> {
@@ -137,8 +145,20 @@ export class WorkspaceModule implements Module {
       }
     }
 
-    // Start watchers for 'always' mode mounts
+    this.ensureRunning();
+  }
+
+  /**
+   * Start chokidar watchers and emit workspace:mounted events.
+   * Idempotent: safe to call from both start() and initStore(), fires once
+   * per mount regardless of which runs second.
+   */
+  private ensureRunning(): void {
+    if (!this.ctx || this.mounts.size === 0) return;
+
     for (const [name, mount] of this.mounts) {
+      if (this.watchers.has(name)) continue;
+
       const watchMode = mount.config.watch ?? 'always';
       if (watchMode === 'always') {
         const watcher = new MountWatcher(mount.config, (changes) => {
@@ -148,8 +168,7 @@ export class WorkspaceModule implements Module {
         this.watchers.set(name, watcher);
       }
 
-      // Emit mounted event
-      this.ctx?.pushEvent({
+      this.ctx.pushEvent({
         type: 'workspace:mounted',
         mount: name,
         path: mount.config.path,

--- a/src/modules/workspace/index.ts
+++ b/src/modules/workspace/index.ts
@@ -166,6 +166,14 @@ export class WorkspaceModule implements Module {
         });
         watcher.start();
         this.watchers.set(name, watcher);
+
+        // Chokidar is started with ignoreInitial:true, so files already on
+        // disk at session start would be invisible. Trigger one syncFromFs
+        // pass — syncFromFs diffs disk against the tree state, so only files
+        // new-to-this-session's-tree fire workspace:created events. Fresh
+        // sessions see the existing catalog; restarts only see what appeared
+        // while the session was down.
+        void this.initialScan(name);
       }
 
       this.ctx.pushEvent({
@@ -173,6 +181,20 @@ export class WorkspaceModule implements Module {
         mount: name,
         path: mount.config.path,
       } as ProcessEvent);
+    }
+  }
+
+  private async initialScan(mountName: string): Promise<void> {
+    const store = this.store;
+    const mount = this.mounts.get(mountName);
+    if (!store || !mount) return;
+
+    try {
+      const result = await syncFromFs(store, mount);
+      mount.initialSyncDone = true;
+      this.emitFsEvents(mountName, result.synced, result.conflicts);
+    } catch (err) {
+      console.warn(`[workspace] initial scan failed for ${mountName}:`, err);
     }
   }
 

--- a/src/modules/workspace/sync.ts
+++ b/src/modules/workspace/sync.ts
@@ -56,9 +56,16 @@ export interface ConflictInfo {
   agentBlobHash: string;
 }
 
+export type SyncOp = 'created' | 'modified' | 'deleted';
+
+export interface SyncedPath {
+  path: string;
+  op: SyncOp;
+}
+
 export interface SyncResult {
-  /** Paths that were synced */
-  synced: string[];
+  /** Paths that were synced, tagged with the op detected against tree state */
+  synced: SyncedPath[];
   /** Paths that conflicted (both agent and user modified) — filesystem wins */
   conflicts: ConflictInfo[];
   /** Paths that were skipped (binary, too large, etc.) */
@@ -97,7 +104,7 @@ export async function syncFromFs(
       const existing = store.treeGet(mount.treeStateId, relativePath);
       if (existing) {
         store.treeRemove(mount.treeStateId, relativePath);
-        result.synced.push(relativePath);
+        result.synced.push({ path: relativePath, op: 'deleted' });
       }
       continue;
     }
@@ -151,7 +158,7 @@ export async function syncFromFs(
       }
 
       store.treeSet(mount.treeStateId, relativePath, entry);
-      result.synced.push(relativePath);
+      result.synced.push({ path: relativePath, op: existing ? 'modified' : 'created' });
     } catch {
       result.skipped.push(relativePath);
     }

--- a/src/modules/workspace/types.ts
+++ b/src/modules/workspace/types.ts
@@ -36,6 +36,17 @@ export interface MountConfig {
   followSymlinks?: boolean;
   /** Maximum file size in bytes (default: 5MB) */
   maxFileSize?: number;
+  /**
+   * If set, filesystem changes on this mount request inference.
+   * - `true` — wake on any op (created | modified | deleted)
+   * - array — wake only for the listed ops
+   *
+   * Self-writes through the module's own tools are already suppressed by the
+   * watcher, so a mount shared between agents only wakes on external writes.
+   * The EventGate still has final say — use gate policies for path-glob
+   * filtering or to disable wake temporarily via hot-reload.
+   */
+  wakeOnChange?: boolean | Array<'created' | 'modified' | 'deleted'>;
 }
 
 /**
@@ -175,11 +186,33 @@ export interface SyncInput {
 // Events
 // ============================================================================
 
-export interface WorkspaceChangedEvent {
-  type: 'workspace:changed';
+export type WorkspaceFsOp = 'created' | 'modified' | 'deleted';
+
+/**
+ * Fired when files in a mount are created. `paths` are mount-prefixed
+ * (e.g. "tickets/2026-04-20-foo.md"). Conflicts are reported when Chronicle
+ * sync detected divergence between the filesystem and the tree state.
+ */
+export interface WorkspaceCreatedEvent {
+  type: 'workspace:created';
   paths: string[];
   mount: string;
   conflicts?: string[];
+  [key: string]: unknown;
+}
+
+export interface WorkspaceModifiedEvent {
+  type: 'workspace:modified';
+  paths: string[];
+  mount: string;
+  conflicts?: string[];
+  [key: string]: unknown;
+}
+
+export interface WorkspaceDeletedEvent {
+  type: 'workspace:deleted';
+  paths: string[];
+  mount: string;
   [key: string]: unknown;
 }
 
@@ -197,6 +230,20 @@ export interface WorkspaceUnmountedEvent {
 }
 
 export type WorkspaceEvent =
-  | WorkspaceChangedEvent
+  | WorkspaceCreatedEvent
+  | WorkspaceModifiedEvent
+  | WorkspaceDeletedEvent
   | WorkspaceMountedEvent
   | WorkspaceUnmountedEvent;
+
+export const WORKSPACE_FS_EVENT_TYPES = [
+  'workspace:created',
+  'workspace:modified',
+  'workspace:deleted',
+] as const;
+
+export type WorkspaceFsEventType = typeof WORKSPACE_FS_EVENT_TYPES[number];
+
+export function opToEventType(op: WorkspaceFsOp): WorkspaceFsEventType {
+  return `workspace:${op}` as WorkspaceFsEventType;
+}

--- a/src/modules/workspace/types.ts
+++ b/src/modules/workspace/types.ts
@@ -47,6 +47,15 @@ export interface MountConfig {
    * filtering or to disable wake temporarily via hot-reload.
    */
   wakeOnChange?: boolean | Array<'created' | 'modified' | 'deleted'>;
+
+  /**
+   * If true, writes/edits/deletes via the module's tools materialize to the
+   * filesystem immediately (not just into Chronicle tree state). Required for
+   * any mount shared across agents as a communication channel — without it,
+   * another agent's watcher on the same directory sees nothing. The watcher
+   * suppresses its own echoes, so this doesn't cause self-wake loops.
+   */
+  autoMaterialize?: boolean;
 }
 
 /**

--- a/src/modules/workspace/watcher.ts
+++ b/src/modules/workspace/watcher.ts
@@ -1,12 +1,22 @@
 /**
  * Filesystem watcher with debounce, ignore patterns, and suppression.
+ *
+ * Events are carried through with their op type (created/modified/deleted) so
+ * downstream wake policies can key on creation vs. modification vs. deletion.
  */
 
 import { watch, type FSWatcher } from 'chokidar';
 import { type MountConfig } from './types.js';
 
+export type FsOp = 'created' | 'modified' | 'deleted';
+
+export interface FsChange {
+  path: string;
+  op: FsOp;
+}
+
 export interface WatcherEvents {
-  onChange(paths: string[]): void;
+  onChange(changes: FsChange[]): void;
 }
 
 /**
@@ -15,17 +25,19 @@ export interface WatcherEvents {
  */
 export class MountWatcher {
   private watcher: FSWatcher | null = null;
-  private pendingChanges = new Set<string>();
+  // Most recent op seen per path within the current debounce window.
+  // create -> modify collapses to 'created' (single batch); delete always wins.
+  private pendingChanges = new Map<string, FsOp>();
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private suppressedPaths = new Set<string>();
   private suppressionTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private readonly debounceMs: number;
   private readonly config: MountConfig;
-  private readonly onChangeCallback: (paths: string[]) => void;
+  private readonly onChangeCallback: (changes: FsChange[]) => void;
 
   constructor(
     config: MountConfig,
-    onChange: (paths: string[]) => void,
+    onChange: (changes: FsChange[]) => void,
   ) {
     this.config = config;
     this.debounceMs = config.watchDebounceMs ?? 300;
@@ -51,21 +63,22 @@ export class MountWatcher {
       },
     });
 
-    const handleEvent = (filePath: string) => {
-      // Convert absolute path to mount-relative
+    const handleEvent = (op: FsOp) => (filePath: string) => {
       const relative = this.toRelative(filePath);
       if (!relative) return;
 
-      // Skip if this path is suppressed (we just wrote it)
+      // Skip if this path is suppressed (we just wrote it).
+      // Suppression covers all ops — a materialize-then-delete by the module
+      // should not echo either the add or the unlink.
       if (this.suppressedPaths.has(relative)) return;
 
-      this.pendingChanges.add(relative);
+      this.mergeOp(relative, op);
       this.scheduleFire();
     };
 
-    this.watcher.on('add', handleEvent);
-    this.watcher.on('change', handleEvent);
-    this.watcher.on('unlink', handleEvent);
+    this.watcher.on('add', handleEvent('created'));
+    this.watcher.on('change', handleEvent('modified'));
+    this.watcher.on('unlink', handleEvent('deleted'));
   }
 
   /**
@@ -92,12 +105,10 @@ export class MountWatcher {
   /**
    * Suppress watcher events for a path temporarily.
    * Used after materializing to avoid echo events.
-   * After the cooldown, the path is re-checked via the recheckCallback.
    */
   suppress(relativePath: string, cooldownMs = 500): void {
     this.suppressedPaths.add(relativePath);
 
-    // Clear existing timer for this path
     const existing = this.suppressionTimers.get(relativePath);
     if (existing) clearTimeout(existing);
 
@@ -116,6 +127,31 @@ export class MountWatcher {
     return this.suppressedPaths.has(relativePath);
   }
 
+  /**
+   * Merge a new op for a path into the pending batch. Chokidar can fire
+   * multiple events per path inside one debounce window (e.g. add+change when
+   * a new file is written in two phases); collapse them to the most meaningful
+   * single op.
+   */
+  private mergeOp(path: string, op: FsOp): void {
+    const prev = this.pendingChanges.get(path);
+    if (!prev) {
+      this.pendingChanges.set(path, op);
+      return;
+    }
+    // delete wins — a file that ended the window deleted was deleted
+    if (op === 'deleted' || prev === 'deleted') {
+      this.pendingChanges.set(path, 'deleted');
+      return;
+    }
+    // created + modified → created (net effect: new file)
+    if (prev === 'created' || op === 'created') {
+      this.pendingChanges.set(path, 'created');
+      return;
+    }
+    this.pendingChanges.set(path, 'modified');
+  }
+
   private scheduleFire(): void {
     if (this.debounceTimer) {
       clearTimeout(this.debounceTimer);
@@ -123,9 +159,9 @@ export class MountWatcher {
     this.debounceTimer = setTimeout(() => {
       this.debounceTimer = null;
       if (this.pendingChanges.size > 0) {
-        const paths = [...this.pendingChanges];
+        const changes: FsChange[] = [...this.pendingChanges].map(([path, op]) => ({ path, op }));
         this.pendingChanges.clear();
-        this.onChangeCallback(paths);
+        this.onChangeCallback(changes);
       }
     }, this.debounceMs);
   }

--- a/test/event-gate.test.ts
+++ b/test/event-gate.test.ts
@@ -145,6 +145,65 @@ describe('policy matching', () => {
     assert.strictEqual(gate.evaluate(event({ channelId: 'prod-alerts' })).trigger, false);
   });
 
+  it('mount match — exact name', () => {
+    const path = writeConfig('mount-exact.json', {
+      policies: [
+        {
+          name: 'tickets',
+          match: { scope: ['workspace:created'], mount: 'knowledge-requests' },
+          behavior: 'always',
+        },
+      ],
+      default: 'skip',
+    });
+    const { gate } = makeGate(path);
+    assert.strictEqual(
+      gate.evaluate(event({ eventType: 'workspace:created', mount: 'knowledge-requests', paths: ['knowledge-requests/t1.md'] })).trigger,
+      true,
+    );
+    assert.strictEqual(
+      gate.evaluate(event({ eventType: 'workspace:created', mount: 'library-mined', paths: ['library-mined/r1.md'] })).trigger,
+      false,
+    );
+    // Event without a mount must not match a mount-scoped policy.
+    assert.strictEqual(
+      gate.evaluate(event({ eventType: 'workspace:created' })).trigger,
+      false,
+    );
+  });
+
+  it('pathGlob match — any path matches', () => {
+    const path = writeConfig('path-glob.json', {
+      policies: [
+        {
+          name: 'md-only',
+          match: { scope: ['workspace:modified'], pathGlob: '*.md' },
+          behavior: 'always',
+        },
+      ],
+      default: 'skip',
+    });
+    const { gate } = makeGate(path);
+    assert.strictEqual(
+      gate.evaluate(event({ eventType: 'workspace:modified', paths: ['tickets/a.md'] })).trigger,
+      true,
+    );
+    assert.strictEqual(
+      gate.evaluate(event({ eventType: 'workspace:modified', paths: ['logs/a.txt'] })).trigger,
+      false,
+    );
+    // ANY-match: one matching path is enough.
+    assert.strictEqual(
+      gate.evaluate(event({ eventType: 'workspace:modified', paths: ['logs/a.txt', 'tickets/b.md'] })).trigger,
+      true,
+    );
+    // Empty paths can't match a pathGlob policy.
+    assert.strictEqual(
+      gate.evaluate(event({ eventType: 'workspace:modified', paths: [] })).trigger,
+      false,
+    );
+  });
+
   it('content filter — text match (case insensitive)', () => {
     const path = writeConfig('filter-text.json', {
       policies: [

--- a/test/event-gate.test.ts
+++ b/test/event-gate.test.ts
@@ -686,3 +686,102 @@ describe('dispose', () => {
     assert.strictEqual(messages.length, 0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Policy reconciliation on restart (postmortem: clerk stuck on old policies)
+// ---------------------------------------------------------------------------
+
+describe('policy reconciliation', () => {
+  it('appends missing-by-name policies from initialConfig when gate.json already exists', () => {
+    // Simulate a prior session that seeded gate.json with 2 policies
+    const path = writeConfig('reconcile-add.json', {
+      default: 'skip',
+      policies: [
+        { name: 'user-input', match: { scope: ['external-message'] }, behavior: 'always' },
+        { name: 'subagent-completions', match: { scope: ['inference-request'] }, behavior: 'always' },
+      ],
+    });
+
+    // New session starts with a recipe that added a third policy
+    const { gate, traces } = makeGate(path, {
+      initialConfig: {
+        default: 'skip',
+        policies: [
+          { name: 'user-input', match: { scope: ['external-message'] }, behavior: 'always' },
+          { name: 'subagent-completions', match: { scope: ['inference-request'] }, behavior: 'always' },
+          { name: 'reviewed-responses', match: { scope: ['workspace:created'] }, behavior: 'always' },
+        ],
+      },
+    });
+
+    // gate.json on disk should now contain all three policies
+    const onDisk = JSON.parse(readFileSync(path, 'utf-8'));
+    assert.strictEqual(onDisk.policies.length, 3);
+    assert.ok(onDisk.policies.some((p: { name: string }) => p.name === 'reviewed-responses'));
+
+    // Reconciliation trace emitted
+    assert.ok(traces.some(t => t.type === 'gate:config-reconciled'));
+
+    // Live gate honors the new policy
+    assert.strictEqual(
+      gate.evaluate(event({ eventType: 'workspace:created' })).trigger,
+      true,
+    );
+  });
+
+  it("leaves existing policies alone — user's workspace--edit survives recipe changes", () => {
+    const path = writeConfig('reconcile-preserve.json', {
+      default: 'skip',
+      policies: [
+        {
+          name: 'user-input',
+          // User edited this policy to also filter on content
+          match: { scope: ['external-message'], filter: { type: 'text', pattern: 'urgent' } },
+          behavior: 'always',
+        },
+      ],
+    });
+
+    makeGate(path, {
+      initialConfig: {
+        default: 'skip',
+        policies: [
+          // Recipe declares it without the filter
+          { name: 'user-input', match: { scope: ['external-message'] }, behavior: 'always' },
+        ],
+      },
+    });
+
+    const onDisk = JSON.parse(readFileSync(path, 'utf-8'));
+    assert.strictEqual(onDisk.policies.length, 1);
+    assert.deepStrictEqual(onDisk.policies[0].match.filter, { type: 'text', pattern: 'urgent' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Observability: defaultDecisions counts help diagnose silent drops
+// ---------------------------------------------------------------------------
+
+describe('defaultDecisions counters', () => {
+  it('counts events that fell through to default (by eventType)', () => {
+    const path = writeConfig('default-counts.json', {
+      default: 'skip',
+      policies: [
+        { name: 'user-input', match: { scope: ['external-message'] }, behavior: 'always' },
+      ],
+    });
+    const { gate } = makeGate(path);
+
+    gate.evaluate(event({ eventType: 'external-message' })); // matches
+    gate.evaluate(event({ eventType: 'workspace:created' })); // default skip
+    gate.evaluate(event({ eventType: 'workspace:created' })); // default skip
+    gate.evaluate(event({ eventType: 'other' })); // default skip
+
+    const status = gate.getStatus();
+    assert.strictEqual(status.totalEvaluations, 4);
+    assert.strictEqual(status.defaultDecisions.skipped, 3);
+    assert.strictEqual(status.defaultDecisions.triggered, 0);
+    assert.strictEqual(status.defaultDecisions.byEventType['workspace:created'].skipped, 2);
+    assert.strictEqual(status.defaultDecisions.byEventType['other'].skipped, 1);
+  });
+});

--- a/test/mcpl-gate-roundtrip.test.ts
+++ b/test/mcpl-gate-roundtrip.test.ts
@@ -124,3 +124,56 @@ describe('ChannelRegistry + EventGate roundtrip', () => {
     assert.strictEqual(event.triggerInference, false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// ChannelRegistry: per-server channelSubscription policy gates auto-open
+// ---------------------------------------------------------------------------
+
+describe('ChannelRegistry subscriptionPolicy', () => {
+  function makeServerStub() {
+    const opens: Array<{ type: string; address: unknown }> = [];
+    const server = {
+      sendChannelsOpen: async (args: { type: string; address: unknown }) => { opens.push(args); },
+    };
+    const serverRegistry = { getServer: () => server } as unknown as ConstructorParameters<typeof ChannelRegistry>[0];
+    return { opens, serverRegistry };
+  }
+
+  const channels = [
+    { id: 'zulip:tracker-miner-f', type: 'zulip-stream' as const, address: { streamId: 1 }, name: 'tracker-miner-f' },
+    { id: 'zulip:general', type: 'zulip-stream' as const, address: { streamId: 2 }, name: 'general' },
+    { id: 'zulip:random', type: 'zulip-stream' as const, address: { streamId: 3 }, name: 'random' },
+  ];
+  const registerParams = { channels } as unknown as ChannelsIncomingParams;
+
+  it("default 'auto' opens every registered channel", async () => {
+    const { opens, serverRegistry } = makeServerStub();
+    const registry = new ChannelRegistry(serverRegistry, {} as never, () => {}, () => {});
+
+    await registry.handleRegister('zulip', registerParams as never);
+
+    assert.strictEqual(opens.length, 3);
+  });
+
+  it("'manual' opens nothing but still registers the channels", async () => {
+    const { opens, serverRegistry } = makeServerStub();
+    const registry = new ChannelRegistry(serverRegistry, {} as never, () => {}, () => {});
+    registry.setSubscriptionPolicy('zulip', 'manual');
+
+    await registry.handleRegister('zulip', registerParams as never);
+
+    assert.strictEqual(opens.length, 0);
+    assert.strictEqual(registry.getOpenChannels().length, 0);
+  });
+
+  it('string[] allow-list opens only matching channels', async () => {
+    const { opens, serverRegistry } = makeServerStub();
+    const registry = new ChannelRegistry(serverRegistry, {} as never, () => {}, () => {});
+    registry.setSubscriptionPolicy('zulip', ['zulip:tracker-miner-f']);
+
+    await registry.handleRegister('zulip', registerParams as never);
+
+    assert.strictEqual(opens.length, 1);
+    assert.deepStrictEqual(opens[0].address, { streamId: 1 });
+  });
+});


### PR DESCRIPTION
Workspace + Gate: wire up cross-agent file-event pipelines                  
                                                                              
  Five commits that together make filesystem-event-driven multi-agent         
  pipelines actually work end-to-end (motivated by connectome-host's clerk ↔  
  miner ↔ reviewer pipeline over shared tickets/ and reports/ directories). 
                                                                              
  Commits                                                                     
   
  02a4f13 feat(workspace): split fs events by op + wakeOnChange mount flag    
  (breaking)                                                                
  - Replace workspace:changed with workspace:created / :modified / :deleted;  
  MountWatcher tracks op per path and sensibly collapses multi-event windows  
  (delete wins; create+modify → created).                                   
  - SyncResult.synced becomes Array<{path, op}>; syncFromFs distinguishes     
  create vs. modify via tree state.                                         
  - New MountConfig.wakeOnChange (bool | op[]) triggers inference for matching
   ops; watcher self-suppression keeps agents from waking on their own writes.
  - GatePolicyMatch gains mount (exact/glob) and pathGlob matchers; framework 
  feeds mount+paths into GateEventInfo.                                      
                                                                              
  c293590 fix(workspace): start chokidar watchers regardless of             
  start()/initStore() order                                                   
  - start() iterated this.mounts, but mounts are populated by initStore()   
  which hosts call after AgentFramework.create() — so no watchers ever booted 
  after the wakeOnChange commit. Extract setup into idempotent ensureRunning()
   called from both entry points.                                             
                                                                            
  c0042b6 feat(mcpl): per-server channelSubscription policy
  - 'auto' (default, prior behavior) / 'manual' / string[] allow-list.
  - Motivated by a real blast: a focused Zulip miner was silently absorbing   
  chatter from 119 auto-opened public streams. Default stays 'auto'; noisy 
  recipes opt into 'manual'.                                                  
  - 3 new tests.                                                            
                                                                              
  c2d5e84 feat(workspace): autoMaterialize mount flag                       
  - workspace--write/edit/delete previously only updated Chronicle tree state;
   files never hit disk without an explicit materialize call — fine for single
   agents, broken for cross-agent pipelines where another agent's chokidar    
  watcher needs to see the write.                                             
  - When autoMaterialize: true, each op materializes that single file       
  immediately; local watcher's suppress() absorbs the echo, external watchers
  fire normally. Delete handled separately (unlink) because materializeToFs   
  doesn't propagate tree-removals.                                         
                                                                              
  d5691dd fix(gate,workspace): reconcile policies + initial scan +          
  default-drop counters                                                       
  Three fixes exposed by a reviewer→clerk wake failure:
  1. EventGate now reconciles recipe-declared policies into existing on-disk  
  gate.json at startup (previously seed-only). Additive by policy name — user 
  edits preserved. Emits gate:config-reconciled trace.                        
  2. WorkspaceModule does a one-shot syncFromFs scan when starting a          
  watch:'always' mount (chokidar's ignoreInitial:true left pre-existing files
  invisible).                                                                 
  3. EventGate.getStatus() exposes totalEvaluations + defaultDecisions
  counters — "policy never fires" used to look identical to "event never      
  arrived."                                                                   
  - 3 new tests; 69 pass total.