### PR TITLE
fix(workspace): emit context message alongside wake on file events

### DIFF
--- a/src/modules/workspace/index.ts
+++ b/src/modules/workspace/index.ts
@@ -424,7 +424,51 @@ export class WorkspaceModule implements Module {
     const opAllowed = flag === true || (Array.isArray(flag) && flag.includes(op));
     if (!opAllowed) return {};
 
-    return { requestInference: true };
+    // Inject a context message so the model actually sees the event.
+    // The wake signal alone (requestInference) only starts an inference; the
+    // model needs textual evidence in its context to act on it. Symmetric with
+    // how the framework converts mcpl:channel-incoming / mcpl:push-event into
+    // user-role messages — we keep it module-side here so the gate stays a
+    // pure activation layer (no representation responsibility) and so the
+    // message format is colocated with the event source.
+    //
+    // Note: addMessages is applied unconditionally by the framework, but
+    // requestInference still passes through the EventGate. A gate-suppressed
+    // event will leave the message in context for the next inference to see —
+    // which is exactly what you want for the "burst landed during streaming"
+    // case.
+    const paths = ((event as { paths?: string[] }).paths ?? []).filter(p => typeof p === 'string');
+    const conflicts = (event as { conflicts?: string[] }).conflicts;
+    if (paths.length === 0) return { requestInference: true };
+
+    let text: string;
+    if (paths.length === 1) {
+      text = `[workspace event · ${op} · ${paths[0]}]`;
+    } else {
+      const list = paths.map(p => `- ${p}`).join('\n');
+      text = `[workspace event · ${op} · ${paths.length} files in ${mountName}/]\n${list}`;
+    }
+    if (conflicts && conflicts.length > 0) {
+      text += `\n[conflicts: ${conflicts.join(', ')}]`;
+    }
+
+    return {
+      requestInference: true,
+      addMessages: [
+        {
+          participant: 'user',
+          content: [{ type: 'text', text }],
+          metadata: {
+            source: 'workspace',
+            mount: mountName,
+            op,
+            paths,
+            triggered: true,
+            ...(conflicts && conflicts.length > 0 ? { conflicts } : {}),
+          },
+        },
+      ],
+    };
   }
 
   // ==========================================================================


### PR DESCRIPTION
## Summary

A gate-matched filesystem event was firing `requestInference` but adding nothing to the agent's context. The wake started a fresh inference, but with no textual signal that anything had happened — so the model would either ignore the wake (continuing whatever it had been working on) or wake into emptiness with no ticket to react to.

The triumvirate dry-run reproduced this end-to-end: clerk wrote a ticket to `knowledge-requests/`, miner's filesystem watcher fired, miner's gate matched the `new-tickets` policy (`matchCount` 1→2), and miner went idle without ever processing the ticket. Inspecting the miner's message log showed a 5-minute gap between its own tool calls — no injected `[file created: …]` notice anywhere.

`WorkspaceModule.onProcess` now returns `addMessages` alongside `requestInference` whenever a mount's `wakeOnChange` flag matches the event op:

- Single-path: `[workspace event · created · knowledge-requests/2026-04-23-foo.md]`
- Multi-path: header + bullet list grouped by op
- Conflicts (modified-only) appended as `[conflicts: …]`
- Metadata mirrors the MCPL push shape (`source`, `mount`, `op`, `paths`, `triggered`, optional `conflicts`) so context strategies that key on those fields work uniformly across event sources

Symmetric with how the framework converts `mcpl:channel-incoming` and `mcpl:push-event` into user-role messages — kept module-side here so the gate stays a pure activation layer (no representation responsibility) and the message format lives next to its event source.

`addMessages` applies unconditionally; `requestInference` still passes through the EventGate. So if a burst of file events arrives while the agent is mid-stream and the gate suppresses the duplicate wake, the message still lands in context for whatever inference runs next — directly addresses the wake-during-streaming class of bugs.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`node --import tsx --test test/workspace-watcher.test.ts test/event-gate.test.ts\` — 39/39 pass
- [ ] End-to-end triumvirate dry-run: clerk writes a ticket → miner's gate matches → miner inference sees \`[workspace event · created · knowledge-requests/…]\` in context and processes the ticket → reviewer wakes on \`library-mined/\` write
- [ ] Burst handling: write multiple files in a debounce window, confirm a single message lists all paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)