### PR TITLE
fix(agent): omit temperature when not configured (opus-4-7 compat)

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -30,7 +30,13 @@ export class Agent {
   readonly allowedTools: 'all' | string[];
   readonly triggerSources: 'all' | string[];
   readonly maxTokens: number;
-  readonly temperature: number;
+  /**
+   * Sampling temperature. Optional — if undefined, the parameter is omitted
+   * from the inference request entirely. Required for newer Anthropic models
+   * (claude-opus-4-7+) that have deprecated the `temperature` parameter and
+   * return HTTP 400 if it's set, even to 1.
+   */
+  readonly temperature: number | undefined;
 
   private _state: AgentState = { status: 'idle' };
   private _inferenceStartedAt = 0;
@@ -51,7 +57,7 @@ export class Agent {
     this.allowedTools = config.allowedTools ?? 'all';
     this.triggerSources = config.triggerSources ?? 'all';
     this.maxTokens = config.maxTokens ?? 4096;
-    this.temperature = config.temperature ?? 1;
+    this.temperature = config.temperature;
     this.maxStreamTokens = config.maxStreamTokens ?? 150_000;
     this.contextManager = contextManager;
     this.membrane = membrane;
@@ -180,7 +186,7 @@ export class Agent {
       config: {
         model: this.model,
         maxTokens: this.maxTokens,
-        temperature: this.temperature,
+        ...(this.temperature !== undefined && { temperature: this.temperature }),
       },
       tools: tools.length > 0 ? tools : undefined,
       assistantParticipant: this.name,
@@ -310,7 +316,7 @@ export class Agent {
       config: {
         model: this.model,
         maxTokens: this.maxTokens,
-        temperature: this.temperature,
+        ...(this.temperature !== undefined && { temperature: this.temperature }),
       },
       tools: availableTools.length > 0 ? availableTools : undefined,
       promptCaching: true,


### PR DESCRIPTION
## Summary

`Agent` defaulted `temperature` to 1 in its constructor and unconditionally included it in every `NormalizedRequest.config`. Newer Anthropic models — **claude-opus-4-7** in particular — return HTTP 400 if temperature is set at all, even to 1:

```
400 invalid_request_error: \`temperature\` is deprecated for this model.
```

Caught in a live agent session: the model returned a response **and** an error simultaneously, because the request was malformed but Anthropic still returned content.

## Fix

- `Agent.temperature` is now `number | undefined` instead of `number`.
- Constructor no longer defaults to 1: `this.temperature = config.temperature`.
- Both `NormalizedRequest` builders (initial inference + tool-loop continuation) include `temperature` only when it's defined, via conditional spread: `...(this.temperature !== undefined && { temperature: this.temperature })`.

For sonnet / haiku / older opus, behavior is unchanged — they accept any temperature, and the model's own default (1) applies when omitted. For opus-4-7+, recipes that don't set `agent.temperature` now work out of the box.

## Test plan

- [x] `npm test` → **117/117 pass** (no regressions)
- [x] Verified against a live Lena session on claude-opus-4-7 — error gone after rebuild + restart
- [ ] Reviewer: confirm no recipes/configs set `agent.temperature` expecting a specific default; the new behavior treats unset as "model default" rather than 1

## Companion change

[anima-research/context-manager#15](https://github.com/anima-research/context-manager/pull/15) (commit `ed36659`) makes the same fix for AutobiographicalStrategy's compression LLM calls. Both changes are needed end-to-end for opus-4-7 to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)