### PR TITLE
feat(agent): thinking config in AgentConfig; bump cm to ^0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animalabs/agent-framework",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Multi-agent framework with pluggable modules, persistent state, and concurrent tool execution",
   "type": "module",
   "main": "dist/src/index.js",
@@ -39,7 +39,7 @@
   "license": "MIT",
   "dependencies": {
     "@animalabs/chronicle": "^0.1.0",
-    "@animalabs/context-manager": "^0.3.0",
+    "@animalabs/context-manager": "^0.4.1",
     "@animalabs/membrane": "^0.5.43",
     "chokidar": "^4.0.3",
     "discord.js": "^14.25.1",

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -37,6 +37,12 @@ export class Agent {
    * return HTTP 400 if it's set, even to 1.
    */
   readonly temperature: number | undefined;
+  /**
+   * Extended thinking config. When set with `enabled: true`, Membrane will
+   * request native thinking from the provider. Signatures on response thinking
+   * blocks are preserved through Chronicle.
+   */
+  readonly thinking: { enabled: boolean; budgetTokens?: number } | undefined;
 
   private _state: AgentState = { status: 'idle' };
   private _inferenceStartedAt = 0;
@@ -58,6 +64,7 @@ export class Agent {
     this.triggerSources = config.triggerSources ?? 'all';
     this.maxTokens = config.maxTokens ?? 4096;
     this.temperature = config.temperature;
+    this.thinking = config.thinking;
     this.maxStreamTokens = config.maxStreamTokens ?? 150_000;
     this.contextManager = contextManager;
     this.membrane = membrane;
@@ -187,6 +194,7 @@ export class Agent {
         model: this.model,
         maxTokens: this.maxTokens,
         ...(this.temperature !== undefined && { temperature: this.temperature }),
+        ...(this.thinking !== undefined && { thinking: this.thinking }),
       },
       tools: tools.length > 0 ? tools : undefined,
       assistantParticipant: this.name,
@@ -317,6 +325,7 @@ export class Agent {
         model: this.model,
         maxTokens: this.maxTokens,
         ...(this.temperature !== undefined && { temperature: this.temperature }),
+        ...(this.thinking !== undefined && { thinking: this.thinking }),
       },
       tools: availableTools.length > 0 ? availableTools : undefined,
       promptCaching: true,

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -41,6 +41,17 @@ export interface AgentConfig {
   /** Max input tokens before framework breaks a yielding stream and
    *  restarts with recompiled (compressed) context. Default: 150000. */
   maxStreamTokens?: number;
+
+  /**
+   * Extended thinking config. When `enabled: true`, the agent runs with
+   * Anthropic's native extended thinking; responses include `thinking` blocks
+   * with cryptographic signatures, and the API enforces `temperature: 1`
+   * (Membrane handles this). Omit or set `enabled: false` to disable.
+   */
+  thinking?: {
+    enabled: boolean;
+    budgetTokens?: number;
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds \`AgentConfig.thinking?: { enabled; budgetTokens? }\`, plumbed through to Membrane's \`request.config.thinking\` in both inference paths. Membrane already supported native extended thinking end-to-end; this just makes it reachable from \`AgentConfig\`.
- Bumps \`@animalabs/context-manager\` from \`^0.3.0\` → \`^0.4.1\` to pick up \`AutobiographicalStrategy.getProgressSnapshot\` (anima-research/context-manager#20).
- Bumps version to 0.5.2. Both changes are non-breaking.

## Motivation

Resurrecting a long-running claude.ai conversation against the API: we want continuation turns to run with extended thinking on (matches the cognitive mode the conversation was originally in on the web), but \`AgentConfig\` had no way to express that.

Empirical context: claude.ai exports include thinking text but no cryptographic signatures, so historical thinking blocks can't be re-sent as native thinking (the API rejects them — \`signature: Field required\` / \`Invalid signature in thinking block\`). Probed and recorded at the consumer side in \`connectome-host/scripts/test-historical-thinking.ts\`. Wrapped-text representation works for historical turns; this PR enables thinking for the model's *new* turns.

## Test plan

- [ ] CI passes (build + existing tests)
- [ ] Downstream conhost smoke (\`recipes/claude-export-revive.json\`) — pending context-manager#20 merge + npm publish, then conhost PR