### PR TITLE
fix(mcpl): normalize featureSets array → Record + omit temperature when unset

### DIFF
--- a/src/mcpl/feature-set-manager.ts
+++ b/src/mcpl/feature-set-manager.ts
@@ -145,7 +145,20 @@ export class FeatureSetManager {
     capabilities: McplCapabilities,
     config?: { enabledFeatureSets?: string[]; disabledFeatureSets?: string[] }
   ): FeatureSetsUpdateParams {
-    const declared = capabilities.featureSets ?? {};
+    // Cross-package compat: agent-framework's McplCapabilities types
+    // featureSets as Record<string, FeatureSetDeclaration>, but mcpl-core-ts
+    // (used by discord-mcpl and other servers) types it as an array of
+    // {name, ...FeatureSetDeclaration}. Both representations arrive over
+    // the wire. Normalize to Record here so downstream code (resolvePatterns,
+    // validateInbound, etc.) can rely on the keyed shape.
+    const featureSetsRaw = capabilities.featureSets ?? {};
+    const declared: Record<string, FeatureSetDeclaration> = Array.isArray(featureSetsRaw)
+      ? Object.fromEntries(
+          (featureSetsRaw as ReadonlyArray<FeatureSetDeclaration & { name: string }>).map(
+            (d) => [d.name, d],
+          ),
+        )
+      : featureSetsRaw;
 
     const state: ServerState = {
       declared: { ...declared },


### PR DESCRIPTION
Two host-side fixes for cross-package compat with the current MCPL ecosystem.

## `fix(mcpl): normalize featureSets array → Record in initializeServer` (5f477d4)

`McplCapabilities.featureSets` is typed as `Record<string, FeatureSetDeclaration>` here, but `@connectome/mcpl-core` types it as `FeatureSetDeclaration[]`. Servers built against mcpl-core advertise the array form over the wire; downstream code in `FeatureSetManager` (`resolvePatterns`, `validateInbound`, the `{...declared}` spread) only works with the keyed shape. An array spreads as numeric keys, so:

- `enabledFeatureSets` patterns match nothing → feature set never enabled
- `validateInbound` throws `FEATURE_SET_NOT_ENABLED` on every `push/event`

`discord-mcpl` dodges this because messages arrive via `channels/incoming` (which doesn't go through `validateInbound`). But pure-push MCPLs (heartbeat, etc.) hit it immediately.

This PR normalizes array → Record at the entry to `initializeServer`, so downstream code can rely on the keyed shape regardless of which sender authored the advertisement.

Caught while wiring a heartbeat MCPL for Cinder — push events were silently rejected; took adding response-logging in the MCPL itself to surface the actual reason.

## `fix(agent): omit temperature when not configured` (de73337, already on branch)

opus-4-7 compat — the previous behaviour of always sending a default temperature caused certain provider error paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)