### PR TITLE
Preserve image blocks through MCPL tool-result conversion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animalabs/agent-framework",
-  "version": "0.5.6",
+  "version": "0.5.7-dev",
   "description": "Multi-agent framework with pluggable modules, persistent state, and concurrent tool execution",
   "repository": {
     "type": "git",

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,5 +1,6 @@
 import type { Membrane, NormalizedMessage, NormalizedRequest, ContentBlock, YieldingStream } from '@animalabs/membrane';
 import { isAbortedResponse } from '@animalabs/membrane';
+import { toolResultDataToHistoryString } from './tool-result-history.js';
 
 export interface StartStreamResult {
   stream: YieldingStream;
@@ -509,13 +510,15 @@ export class Agent {
   }
 
   private buildToolResultMessages(results: CompletedToolCall[]): NormalizedMessage[] {
-    // Tool results go as a user message with tool_result blocks
+    // Tool results go as a user message with tool_result blocks. The history
+    // serializer turns MCP image blocks into `[image: type, size]` so the
+    // persisted transcript stays small and survives truncation.
     const content = results.map((r) => ({
       type: 'tool_result' as const,
       toolUseId: r.id,
       content: r.result.isError
         ? r.result.error ?? 'Unknown error'
-        : JSON.stringify(r.result.data),
+        : toolResultDataToHistoryString(r.result.data),
       isError: r.result.isError,
     }));
 

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path';
 import { JsStore } from '@animalabs/chronicle';
-import type { Membrane, ContentBlock, NormalizedRequest, YieldingStream, ToolResult as MembraneToolResult } from '@animalabs/membrane';
+import type { Membrane, ContentBlock, NormalizedRequest, YieldingStream, ToolResult as MembraneToolResult, ToolResultContentBlock } from '@animalabs/membrane';
 import { MembraneError } from '@animalabs/membrane';
 import { ContextManager, PassthroughStrategy } from '@animalabs/context-manager';
 import type {
@@ -2216,17 +2216,49 @@ export class AgentFramework {
   }
 
   private toMembraneToolResult(callId: string, afResult: ToolResult, maxChars?: number): MembraneToolResult {
-    let content: string;
     if (afResult.isError) {
-      content = afResult.error ?? 'Unknown error';
-    } else {
-      content = JSON.stringify(afResult.data);
-      if (maxChars && content.length > maxChars) {
-        content = safeSlice(content, 0, maxChars)
-          + '\n\n[truncated — original was ' + content.length + ' chars]';
-      }
+      return { toolUseId: callId, content: afResult.error ?? 'Unknown error', isError: true };
+    }
+    // MCPL tool results arrive as `data: McpToolResultContent[]` — preserve image
+    // blocks natively rather than JSON-stringifying them away. Anything else
+    // (objects, scalars) falls through to JSON.
+    const blocks = this.tryNativeToolResultContent(afResult.data);
+    if (blocks) {
+      return { toolUseId: callId, content: blocks, isError: afResult.isError };
+    }
+    let content = JSON.stringify(afResult.data);
+    if (maxChars && content.length > maxChars) {
+      content = safeSlice(content, 0, maxChars)
+        + '\n\n[truncated — original was ' + content.length + ' chars]';
     }
     return { toolUseId: callId, content, isError: afResult.isError };
+  }
+
+  /**
+   * If `data` is an MCP tool-result content array carrying at least one image,
+   * convert to Membrane's native ToolResultContentBlock[]. Returns null when
+   * the array is text-only (let JSON path handle it; saves a code path).
+   */
+  private tryNativeToolResultContent(data: unknown): ToolResultContentBlock[] | null {
+    if (!Array.isArray(data)) return null;
+    let hasImage = false;
+    const blocks: ToolResultContentBlock[] = [];
+    for (const b of data) {
+      if (!b || typeof b !== 'object') return null;
+      const type = (b as any).type;
+      if (type === 'text' && typeof (b as any).text === 'string') {
+        blocks.push({ type: 'text', text: (b as any).text });
+      } else if (type === 'image' && typeof (b as any).data === 'string' && typeof (b as any).mimeType === 'string') {
+        hasImage = true;
+        blocks.push({
+          type: 'image',
+          source: { type: 'base64', data: (b as any).data, mediaType: (b as any).mimeType },
+        });
+      } else {
+        return null; // unknown shape — bail to JSON path
+      }
+    }
+    return hasImage ? blocks : null;
   }
 
   private getMaxToolResultChars(agent: Agent): number | undefined {
@@ -2887,11 +2919,22 @@ export class AgentFramework {
           }
         }
 
-        // Convert MCP tool result to framework ToolResult
+        // Convert MCP tool result to framework ToolResult.
+        // When the result contains non-text blocks (e.g. images from an MCP
+        // tool like zulip-mcp's fetch_attachment), pass the full content array
+        // through so toMembraneToolResult can preserve image blocks natively.
+        // Text-only results still collapse to a joined string for backward
+        // compatibility with callers that expect data to be string-ish.
         const textContent = result.content
           ?.filter((c) => c.type === 'text' && c.text)
           .map((c) => c.text!)
           .join('\n');
+        const hasNonText = result.content?.some((c) => c.type !== 'text');
+        const data = result.isError
+          ? undefined
+          : hasNonText
+            ? result.content
+            : (textContent || undefined);
 
         this.pushEvent({
           type: 'tool-result',
@@ -2900,7 +2943,7 @@ export class AgentFramework {
           moduleName: `mcpl:${serverId}`,
           result: {
             success: !result.isError,
-            data: result.isError ? undefined : textContent || undefined,
+            data,
             error: result.isError ? (textContent || 'Tool call failed') : undefined,
             isError: result.isError ?? false,
           },

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -51,6 +51,7 @@ import { PushHandler, type McplPushEvent } from './mcpl/push-handler.js';
 import { InferenceRouter } from './mcpl/inference-router.js';
 import { ChannelRegistry } from './mcpl/channel-registry.js';
 import { safeSlice } from './safe-slice.js';
+import { toolResultDataToHistoryString } from './tool-result-history.js';
 import { CheckpointManager } from './mcpl/checkpoint-manager.js';
 import { isToolAllowed } from './mcpl/tool-policy.js';
 import { EventGate } from './gate/event-gate.js';
@@ -1392,25 +1393,18 @@ export class AgentFramework {
           // Compute truncation limit from agent's strategy (maxMessageTokens * 4 chars)
           const maxChars = this.getMaxToolResultChars(agent);
 
-          // Store tool results as a user message (tool_result blocks)
-          const toolResultContent: ContentBlock[] = currentState.toolResults.map(tc => {
-            let content: string;
-            if (tc.result.isError) {
-              content = tc.result.error ?? 'Unknown error';
-            } else {
-              content = JSON.stringify(tc.result.data);
-              if (maxChars && content.length > maxChars) {
-                content = safeSlice(content, 0, maxChars)
-                  + '\n\n[truncated — original was ' + content.length + ' chars]';
-              }
-            }
-            return {
-              type: 'tool_result' as const,
-              toolUseId: tc.id,
-              content,
-              isError: tc.result.isError,
-            };
-          });
+          // Store tool results as a user message (tool_result blocks).
+          // Use the history serializer so MCP image blocks become a short
+          // `[image: type, size]` placeholder instead of megabytes of base64
+          // that would corrupt under truncation.
+          const toolResultContent: ContentBlock[] = currentState.toolResults.map(tc => ({
+            type: 'tool_result' as const,
+            toolUseId: tc.id,
+            content: tc.result.isError
+              ? tc.result.error ?? 'Unknown error'
+              : toolResultDataToHistoryString(tc.result.data, maxChars),
+            isError: tc.result.isError,
+          }));
           agent.getContextManager().addMessage('user', toolResultContent);
 
           // Flush any messages that were deferred while waiting for tool results.
@@ -1909,7 +1903,9 @@ export class AgentFramework {
                 const toolResultContent: ContentBlock[] = readyState.toolResults.map(tc => ({
                   type: 'tool_result' as const,
                   toolUseId: tc.id,
-                  content: tc.result.isError ? (tc.result.error ?? 'Unknown error') : JSON.stringify(tc.result.data),
+                  content: tc.result.isError
+                    ? (tc.result.error ?? 'Unknown error')
+                    : toolResultDataToHistoryString(tc.result.data),
                   isError: tc.result.isError,
                 }));
                 agent.getContextManager().addMessage('user', toolResultContent);
@@ -2221,38 +2217,46 @@ export class AgentFramework {
     }
     // MCPL tool results arrive as `data: McpToolResultContent[]` — preserve image
     // blocks natively rather than JSON-stringifying them away. Anything else
-    // (objects, scalars) falls through to JSON.
-    const blocks = this.tryNativeToolResultContent(afResult.data);
+    // (objects, scalars) falls through to JSON. The error path was handled
+    // above, so isError is always false on these return paths.
+    const blocks = this.tryNativeToolResultContent(afResult.data, maxChars);
     if (blocks) {
-      return { toolUseId: callId, content: blocks, isError: afResult.isError };
+      return { toolUseId: callId, content: blocks, isError: false };
     }
     let content = JSON.stringify(afResult.data);
     if (maxChars && content.length > maxChars) {
       content = safeSlice(content, 0, maxChars)
         + '\n\n[truncated — original was ' + content.length + ' chars]';
     }
-    return { toolUseId: callId, content, isError: afResult.isError };
+    return { toolUseId: callId, content, isError: false };
   }
 
   /**
    * If `data` is an MCP tool-result content array carrying at least one image,
    * convert to Membrane's native ToolResultContentBlock[]. Returns null when
    * the array is text-only (let JSON path handle it; saves a code path).
+   * `maxChars`, when provided, caps each accompanying text block so an image
+   * inlined alongside an enormous text payload can't blow the context.
    */
-  private tryNativeToolResultContent(data: unknown): ToolResultContentBlock[] | null {
+  private tryNativeToolResultContent(data: unknown, maxChars?: number): ToolResultContentBlock[] | null {
     if (!Array.isArray(data)) return null;
     let hasImage = false;
     const blocks: ToolResultContentBlock[] = [];
-    for (const b of data) {
-      if (!b || typeof b !== 'object') return null;
-      const type = (b as any).type;
-      if (type === 'text' && typeof (b as any).text === 'string') {
-        blocks.push({ type: 'text', text: (b as any).text });
-      } else if (type === 'image' && typeof (b as any).data === 'string' && typeof (b as any).mimeType === 'string') {
+    for (const raw of data) {
+      if (!raw || typeof raw !== 'object') return null;
+      const b = raw as { type?: unknown; text?: unknown; data?: unknown; mimeType?: unknown };
+      if (b.type === 'text' && typeof b.text === 'string') {
+        let text = b.text;
+        if (maxChars && text.length > maxChars) {
+          text = safeSlice(text, 0, maxChars)
+            + '\n\n[truncated — original was ' + text.length + ' chars]';
+        }
+        blocks.push({ type: 'text', text });
+      } else if (b.type === 'image' && typeof b.data === 'string' && typeof b.mimeType === 'string') {
         hasImage = true;
         blocks.push({
           type: 'image',
-          source: { type: 'base64', data: (b as any).data, mediaType: (b as any).mimeType },
+          source: { type: 'base64', data: b.data, mediaType: b.mimeType },
         });
       } else {
         return null; // unknown shape — bail to JSON path

--- a/src/tool-result-history.ts
+++ b/src/tool-result-history.ts
@@ -1,0 +1,57 @@
+/**
+ * Convert an AF `ToolResult.data` value into the string form that lives in
+ * the agent's conversation history.
+ *
+ * The live path (`toMembraneToolResult` in framework.ts) preserves MCP image
+ * blocks natively so the model sees the bytes on the current turn. The
+ * *persisted* copy needs to survive recompilation, compression, and
+ * `/restore` — storing megabytes of base64 there gets corrupted on the next
+ * `maxChars` slice and re-introduces, one turn deferred, exactly the silent
+ * hallucination this feature exists to kill.
+ *
+ * For MCP-shaped content arrays, this helper keeps text blocks verbatim and
+ * replaces image blocks with a short `[image: mimeType, ~NKB]` placeholder.
+ * For anything else it falls back to JSON.
+ */
+
+import { safeSlice } from './safe-slice.js';
+
+export function toolResultDataToHistoryString(data: unknown, maxChars?: number): string {
+  const fromArray = tryHistoryStringFromContentArray(data);
+  const str = fromArray ?? JSON.stringify(data);
+  if (maxChars && str.length > maxChars) {
+    return safeSlice(str, 0, maxChars)
+      + '\n\n[truncated — original was ' + str.length + ' chars]';
+  }
+  return str;
+}
+
+/**
+ * If `data` is an MCP content array whose every block has a shape we
+ * recognize, return a history-safe string (images → placeholders). Otherwise
+ * return `null` to defer to the caller's fallback (JSON, usually).
+ */
+function tryHistoryStringFromContentArray(data: unknown): string | null {
+  if (!Array.isArray(data)) return null;
+  const parts: string[] = [];
+  for (const raw of data) {
+    if (!raw || typeof raw !== 'object') return null;
+    const b = raw as { type?: unknown; text?: unknown; data?: unknown; mimeType?: unknown };
+    if (b.type === 'text' && typeof b.text === 'string') {
+      parts.push(b.text);
+    } else if (b.type === 'image' && typeof b.data === 'string' && typeof b.mimeType === 'string') {
+      // Decoded byte estimate from base64 length (3/4 ratio, rounded).
+      const approxBytes = Math.floor(b.data.length * 3 / 4);
+      parts.push(`[image: ${b.mimeType}, ${formatSize(approxBytes)}]`);
+    } else {
+      return null;
+    }
+  }
+  return parts.join('\n');
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `~${Math.round(bytes / 1024)}KB`;
+  return `~${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+}

--- a/test/framework.test.ts
+++ b/test/framework.test.ts
@@ -853,7 +853,10 @@ describe('Streaming lifecycle', () => {
     assert.strictEqual(results.length, 1);
     assert.strictEqual(results[0].toolUseId, 'call_conv');
     assert.strictEqual(results[0].content, JSON.stringify({ echoed: 'convert' }));
-    assert.strictEqual(results[0].isError, undefined);
+    // Non-error results are now explicitly `isError: false` (the error path
+    // returns early, so the previous `isError: afResult.isError` was always
+    // falsy and misleading to read).
+    assert.strictEqual(results[0].isError, false);
 
     await framework.stop();
     rmSync(tempDir, { recursive: true });

--- a/test/tool-result-history.test.ts
+++ b/test/tool-result-history.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for the tool-result history serializer.
+ *
+ * Run: node --import tsx --test test/tool-result-history.test.ts
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { toolResultDataToHistoryString } from '../src/tool-result-history.js';
+
+test('text-only MCP content array: blocks join with newlines', () => {
+  const data = [
+    { type: 'text', text: 'first' },
+    { type: 'text', text: 'second' },
+  ];
+  assert.equal(toolResultDataToHistoryString(data), 'first\nsecond');
+});
+
+test('image block becomes placeholder, not base64', () => {
+  // 1MB of base64 = ~750KB of decoded bytes
+  const fakeBase64 = 'A'.repeat(1024 * 1024);
+  const data = [
+    { type: 'text', text: 'Fetched x.png:' },
+    { type: 'image', data: fakeBase64, mimeType: 'image/png' },
+  ];
+  const out = toolResultDataToHistoryString(data);
+  assert.ok(out.includes('Fetched x.png:'));
+  assert.ok(out.includes('[image: image/png,'));
+  assert.ok(!out.includes(fakeBase64), 'base64 payload must NOT appear in history string');
+  assert.ok(out.length < 200, `expected small string, got ${out.length} chars`);
+});
+
+test('size formatter: bytes / KB / MB', () => {
+  const tiny = toolResultDataToHistoryString([{ type: 'image', data: 'A'.repeat(16), mimeType: 'image/png' }]);
+  assert.match(tiny, /\[image: image\/png, \d+B\]/);
+  const kb = toolResultDataToHistoryString([{ type: 'image', data: 'A'.repeat(10 * 1024), mimeType: 'image/png' }]);
+  assert.match(kb, /\[image: image\/png, ~\d+KB\]/);
+  const mb = toolResultDataToHistoryString([{ type: 'image', data: 'A'.repeat(2 * 1024 * 1024), mimeType: 'image/png' }]);
+  assert.match(mb, /\[image: image\/png, ~\d+\.\d+MB\]/);
+});
+
+test('unknown block shape falls back to JSON', () => {
+  const data = [{ type: 'mystery', payload: 42 }];
+  assert.equal(toolResultDataToHistoryString(data), JSON.stringify(data));
+});
+
+test('mixed known + unknown block shape falls back to JSON (all-or-nothing)', () => {
+  const data = [
+    { type: 'text', text: 'fine' },
+    { type: 'audio', data: 'XX', mimeType: 'audio/mpeg' },
+  ];
+  assert.equal(toolResultDataToHistoryString(data), JSON.stringify(data));
+});
+
+test('non-array data: JSON stringify', () => {
+  assert.equal(toolResultDataToHistoryString({ ok: true }), '{"ok":true}');
+  assert.equal(toolResultDataToHistoryString('hello'), '"hello"');
+  assert.equal(toolResultDataToHistoryString(42), '42');
+  assert.equal(toolResultDataToHistoryString(undefined), undefined as any); // JSON.stringify(undefined) === undefined
+});
+
+test('maxChars truncates the resulting string with a marker', () => {
+  const data = [{ type: 'text', text: 'a'.repeat(1000) }];
+  const out = toolResultDataToHistoryString(data, 100);
+  assert.ok(out.length < 1000);
+  assert.match(out, /\[truncated — original was \d+ chars\]/);
+});
+
+test('maxChars does NOT truncate the placeholder itself (image is summarized, not chopped)', () => {
+  // 4MB of base64 → ~3MB decoded, comfortably across the MB threshold.
+  const fakeBase64 = 'A'.repeat(4 * 1024 * 1024);
+  const data = [{ type: 'image', data: fakeBase64, mimeType: 'image/png' }];
+  const out = toolResultDataToHistoryString(data, 50_000);
+  // The placeholder is ~30 chars regardless of input size; maxChars=50_000 leaves it untouched.
+  assert.match(out, /\[image: image\/png, ~\d+\.\d+MB\]/);
+  assert.ok(!out.includes('truncated'));
+  assert.ok(out.length < 100);
+});
+
+test('null entry in array falls back to JSON', () => {
+  const data = [{ type: 'text', text: 'x' }, null];
+  assert.equal(toolResultDataToHistoryString(data), JSON.stringify(data));
+});
+
+test('empty array: empty string', () => {
+  assert.equal(toolResultDataToHistoryString([]), '');
+});


### PR DESCRIPTION
Pairs with [antra-tess/membrane#feat/tool-result-image-content](https://github.com/antra-tess/membrane/pulls) and antra-tess/zulip_mcp#7. All three are needed for an MCPL tool to deliver an image to a vision-capable model — this PR carries the AF half.

## What changes

Two coordinated changes in `src/framework.ts`:

### 1. `dispatchMcplToolCall` — keep non-text content blocks

Before:
```ts
const textContent = result.content
  ?.filter((c) => c.type === 'text' && c.text)
  .map((c) => c.text!)
  .join('\n');
// data: textContent  ← image blocks silently dropped here
```

The async MCPL dispatch path was extracting *only* text blocks and joining them into a string before pushing the `tool-result` event. If an MCP tool returned `[{type:'text'}, {type:'image'}, …]`, the image was gone before AF's own conversion layer ever saw it.

Now: when any non-text block is present, pass the full `result.content` array through as `data`. Text-only results still collapse to a joined string for callers that expect string-ish data.

### 2. `toMembraneToolResult` — native fast-path for arrays carrying images

`toMembraneToolResult` was unconditionally `JSON.stringify`-ing every tool result, which would have collapsed any preserved image array into a JSON literal even if (1) hadn't dropped it first.

Add `tryNativeToolResultContent()` that detects an MCP content array carrying at least one image and converts to Membrane's native `ToolResultContentBlock[]`. Text-only / scalar / object results still go through `JSON.stringify`; the existing conversion tests for the JSON path continue to pass.

Bump `0.5.6` → `0.5.7-dev` so workspace-linked downstreams can pick this up via dev-link without a tagged release.

## Tests

All 20 existing framework tests pass. No new tests added in this PR — the round-trip is exercised by the end-to-end run described below.

## End-to-end validation

Tested against a live Zulip channel through the full chain (zulip-mcp → AF → membrane → Anthropic):

1. A 1.5MB Zero-K screenshot. Claude described top-down Mars terrain, gray platform with "STA: 0:0" overlay, triangular metal structures, red enemy markers — all matching the actual bytes.
2. A Zulip UI screenshot. Claude verbatim-quoted strings from the pixels including the exact filename `knowledge-requests/2026-05-12-system-check-across-fleet.md` that couldn't have been in its context.

Found *during* this validation: an earlier round of the test "passed" with Claude confidently describing a Python REPL (topic name was "round") — but pulling the image down and comparing showed it was actually a game screenshot, and the inference log showed `tool_result.content` arriving at Anthropic as a 77-char text string. That hallucination is what exposed the dispatch-path drop and motivated change (1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)