### PR TITLE
Per-channel conversation routing: fork-per-channel agents from a template trunk

### DIFF
--- a/src/framework.ts
+++ b/src/framework.ts
@@ -75,6 +75,7 @@ import type {
 import type { ContextInjection } from '@animalabs/context-manager';
 
 const FRAMEWORK_STATE_ID = 'framework/state';
+const CONVERSATION_ROUTER_STATE_ID = 'framework/conversation-router';
 const INFERENCE_LOG_ID = 'framework/inference-log';
 const PROCESS_LOG_ID = 'framework/process-log';
 const TURN_CHECKPOINTS_ID = 'framework/turn-checkpoints';
@@ -232,6 +233,10 @@ export class AgentFramework {
   private conversationAgentHomes: Map<string, string> = new Map();
   /** Last idle-TTL sweep timestamp. */
   private lastConversationSweep = 0;
+
+  /** Forks whose TTL closure turn has been queued — disposed (removed from
+   * agents/agentConfigs/conversationAgentHomes) when their stream ends. */
+  private closingConversationAgents: Set<string> = new Set();
   private mcplTools: import('./types/index.js').ToolDefinition[] = [];
   private mcplToolRefreshInFlight = false;
   private mcplToolRefreshPending = false;
@@ -374,6 +379,24 @@ export class AgentFramework {
         );
       }
       framework.conversationRouter = new ConversationRouter(config.conversations);
+
+      // Generation counters persist across restarts — reusing generation 1's
+      // agent name after a restart would reopen (and re-seed) the previous
+      // engagement's Chronicle namespace.
+      try {
+        store.registerState({ id: CONVERSATION_ROUTER_STATE_ID, strategy: 'snapshot' });
+      } catch {
+        // Already registered
+      }
+      try {
+        const data = store.getStateJson(CONVERSATION_ROUTER_STATE_ID) as
+          { generations?: Record<string, number> } | null;
+        if (data?.generations) {
+          framework.conversationRouter.hydrateGenerations(data.generations);
+        }
+      } catch {
+        // No persisted state yet
+      }
     }
 
     // Initialize EventGate if configured (before MCPL so it can be wired as trigger filter)
@@ -1712,7 +1735,7 @@ export class AgentFramework {
     const decision = router.route({
       channelId: event.channelId,
       mentioned: event.metadata?.mentioned === true,
-      isDm: ConversationRouter.isDmChannel(descriptor, event.metadata),
+      kind: ConversationRouter.classifyChannel(descriptor, event.metadata),
     });
 
     if (decision.kind === 'unbound') {
@@ -1729,6 +1752,7 @@ export class AgentFramework {
       try {
         agent = await this.createConversationAgent(decision.agentName, event.channelId);
         router.bind(event.channelId, decision.agentName, decision.generation);
+        this.persistConversationRouterState();
         this.emitTrace({
           type: 'mcpl:conversation-spawned',
           channelId: event.channelId,
@@ -1807,10 +1831,17 @@ export class AgentFramework {
 
     // Seed with the template's compiled context, renaming the template
     // participant so the fork reads its inheritance as its own history.
-    const { messages: compiled } = await template.getContextManager().compile();
-    for (const msg of compiled) {
-      const participant = msg.participant === template.name ? name : msg.participant;
-      contextManager.addMessage(participant, msg.content);
+    // Guard: only seed a genuinely fresh namespace. Generation counters are
+    // persisted precisely so names aren't reused, but if this namespace has
+    // history anyway (counter state lost, crash between spawn and persist),
+    // seeding again would stack another template copy on top of it.
+    const { messages: existing } = await contextManager.compile();
+    if (existing.length === 0) {
+      const { messages: compiled } = await template.getContextManager().compile();
+      for (const msg of compiled) {
+        const participant = msg.participant === template.name ? name : msg.participant;
+        contextManager.addMessage(participant, msg.content);
+      }
     }
 
     const config: AgentConfig = { ...templateConfig, name, strategy: undefined };
@@ -1819,6 +1850,37 @@ export class AgentFramework {
     this.agentConfigs.set(name, config);
     this.conversationAgentHomes.set(name, channelId);
     return agent;
+  }
+
+  /** Persist the router's generation counters (see hydration in create()). */
+  private persistConversationRouterState(): void {
+    if (!this.conversationRouter) return;
+    try {
+      this.store.setStateJson(CONVERSATION_ROUTER_STATE_ID, {
+        generations: this.conversationRouter.exportGenerations(),
+      });
+    } catch (error) {
+      console.error('Failed to persist conversation router state:', error);
+    }
+  }
+
+  /**
+   * Remove a closed conversation fork from the framework: its closure turn
+   * has finished, so the home mapping has served its purpose and keeping the
+   * agent registered would just grow every agent scan and broadcast filter
+   * forever. The fork's context stays in Chronicle for investigation.
+   */
+  private disposeConversationAgent(agentName: string): void {
+    this.closingConversationAgents.delete(agentName);
+    const channelId = this.conversationAgentHomes.get(agentName);
+    this.agents.delete(agentName);
+    this.agentConfigs.delete(agentName);
+    this.conversationAgentHomes.delete(agentName);
+    this.emitTrace({
+      type: 'mcpl:conversation-disposed',
+      agentName,
+      channelId,
+    });
   }
 
   /**
@@ -1868,7 +1930,13 @@ export class AgentFramework {
       });
 
       const agent = this.agents.get(binding.agentName);
-      if (!agent) continue;
+      if (!agent) {
+        // Agent vanished (external reset) — nothing to close, just make sure
+        // its bookkeeping doesn't linger.
+        this.agentConfigs.delete(binding.agentName);
+        this.conversationAgentHomes.delete(binding.agentName);
+        continue;
+      }
       agent.getContextManager().addMessage(
         'user',
         [{ type: 'text', text: this.conversationRouter.closurePrompt }],
@@ -1880,6 +1948,21 @@ export class AgentFramework {
         source: 'framework',
         timestamp: now,
       });
+      // Disposed when the closure stream ends (driveStream finally), with
+      // the reaper below as fallback.
+      this.closingConversationAgents.add(binding.agentName);
+    }
+
+    // Fallback reaper: a closing fork whose closure inference never ran
+    // (request dropped as stale, inference policy veto) would otherwise stay
+    // registered forever. No active stream + no pending request = done.
+    for (const agentName of [...this.closingConversationAgents]) {
+      if (
+        !this.activeStreams.has(agentName) &&
+        !this.pendingRequests.some((r) => r.agentName === agentName)
+      ) {
+        this.disposeConversationAgent(agentName);
+      }
     }
   }
 
@@ -1996,6 +2079,11 @@ export class AgentFramework {
       let injections: ContextInjection[] | undefined;
 
       // Module gatherContext (fail-open, 5s timeout per module)
+      // NOTE: module injections are NOT channel-scoped — only the MCPL hook
+      // injections below pass through scopeInjectionsForAgent (channel
+      // context arrives via beforeInference hooks by adapter convention). A
+      // module that starts emitting per-channel context must scope it per
+      // agent itself, or conversation forks will see cross-channel content.
       try {
         const moduleInjections = await this.moduleRegistry.gatherContext(agent.name);
         if (moduleInjections.length > 0) {
@@ -2395,6 +2483,12 @@ export class AgentFramework {
     } finally {
       this.activeStreams.delete(agent.name);
       this.pendingAssistantBlocks.delete(agent.name);
+
+      // A conversation fork whose TTL closure turn just finished is done for
+      // good — dispose it so the agent map doesn't grow monotonically.
+      if (this.closingConversationAgents.has(agent.name)) {
+        this.disposeConversationAgent(agent.name);
+      }
 
       // Flush any deferred messages (e.g. if stream failed while tools were pending)
       if (this.deferredMessages.length > 0 && this.pendingAssistantBlocks.size === 0) {
@@ -3173,30 +3267,40 @@ export class AgentFramework {
    * Dispatch a synthesized channel tool call.
    */
   private dispatchChannelToolCall(agentName: string, call: ToolCall): void {
-    // Conversation forks publish only to their home channel: a missing
-    // channelId defaults to it, an explicit foreign channelId is rejected.
+    // Conversation forks act only on their home channel. channel_publish and
+    // channel_close default a missing channelId to home and reject foreign
+    // ones; channel_open is rejected outright — opening channels mutates
+    // framework-global state (the open-channel set every agent's injections
+    // are scoped against), which is not a fork's call to make.
     const home = this.conversationAgentHomes.get(agentName);
-    if (home && call.name === 'channel_publish') {
-      const input = (call.input ?? {}) as { channelId?: string };
-      if (!input.channelId) {
-        call = { ...call, input: { ...input, channelId: home } };
-      } else if (input.channelId !== home) {
+    if (home) {
+      const reject = (error: string): void => {
         this.emitTrace({
           type: 'tool:failed', module: 'channels', tool: call.name, callId: call.id,
-          error: `conversation agent ${agentName} attempted publish to ${input.channelId}`,
+          error: `conversation agent ${agentName}: ${error}`,
         });
         this.pushEvent({
           type: 'tool-result',
           callId: call.id,
           agentName,
           moduleName: 'channels',
-          result: {
-            success: false,
-            error: `This conversation is bound to channel ${home}; publishing to ${input.channelId} is not allowed.`,
-            isError: true,
-          },
+          result: { success: false, error, isError: true },
         });
+      };
+
+      if (call.name === 'channel_open') {
+        reject(`This conversation is bound to channel ${home}; conversation agents cannot open channels.`);
         return;
+      }
+      if (call.name === 'channel_publish' || call.name === 'channel_close') {
+        const input = (call.input ?? {}) as { channelId?: string };
+        if (!input.channelId) {
+          call = { ...call, input: { ...input, channelId: home } };
+        } else if (input.channelId !== home) {
+          const verb = call.name === 'channel_publish' ? 'publishing to' : 'closing';
+          reject(`This conversation is bound to channel ${home}; ${verb} ${input.channelId} is not allowed.`);
+          return;
+        }
       }
     }
 

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -50,6 +50,7 @@ import { HookOrchestrator } from './mcpl/hook-orchestrator.js';
 import { PushHandler, type McplPushEvent } from './mcpl/push-handler.js';
 import { InferenceRouter } from './mcpl/inference-router.js';
 import { ChannelRegistry } from './mcpl/channel-registry.js';
+import { ConversationRouter } from './mcpl/conversation-router.js';
 import { safeSlice } from './safe-slice.js';
 import { CheckpointManager } from './mcpl/checkpoint-manager.js';
 import { isToolAllowed } from './mcpl/tool-policy.js';
@@ -219,6 +220,18 @@ export class AgentFramework {
   private inferenceRouter: InferenceRouter | null = null;
   private channelRegistry: ChannelRegistry | null = null;
   private checkpointManager: CheckpointManager | null = null;
+  /** Per-channel conversation routing (null unless config.conversations set). */
+  private conversationRouter: ConversationRouter | null = null;
+  /** Agent configs by name — fork agents are built from the template's config. */
+  private agentConfigs: Map<string, AgentConfig> = new Map();
+  /**
+   * Fork agent → its home channel. Permanent (unlike router bindings, which
+   * expire): publish/injection scoping must survive unbinding so the closure
+   * turn still lands in the right channel.
+   */
+  private conversationAgentHomes: Map<string, string> = new Map();
+  /** Last idle-TTL sweep timestamp. */
+  private lastConversationSweep = 0;
   private mcplTools: import('./types/index.js').ToolDefinition[] = [];
   private mcplToolRefreshInFlight = false;
   private mcplToolRefreshPending = false;
@@ -350,6 +363,17 @@ export class AgentFramework {
     // Add modules
     for (const module of config.modules) {
       await framework.addModule(module);
+    }
+
+    // Initialize per-channel conversation routing (if configured)
+    if (config.conversations) {
+      if (!framework.agents.has(config.conversations.templateAgent)) {
+        throw new Error(
+          `conversations.templateAgent "${config.conversations.templateAgent}" ` +
+          `is not a configured agent`
+        );
+      }
+      framework.conversationRouter = new ConversationRouter(config.conversations);
     }
 
     // Initialize EventGate if configured (before MCPL so it can be wired as trigger filter)
@@ -538,6 +562,14 @@ export class AgentFramework {
    */
   getAllAgents(): Agent[] {
     return Array.from(this.agents.values());
+  }
+
+  /**
+   * Get the per-channel conversation router (null unless config.conversations
+   * was set). Exposed for modules/UIs that surface active engagements.
+   */
+  getConversationRouter(): ConversationRouter | null {
+    return this.conversationRouter;
   }
 
   /**
@@ -1307,6 +1339,7 @@ export class AgentFramework {
 
     const agent = new Agent(config, contextManager, this.membrane);
     this.agents.set(config.name, agent);
+    this.agentConfigs.set(config.name, config);
 
     // First non-ephemeral agent becomes the primary for message routing
     if (!this.primaryAgentName) {
@@ -1333,6 +1366,9 @@ export class AgentFramework {
     if (event) {
       await this.handleProcessEvent(event);
     }
+
+    // Close idle conversation forks (no-op unless conversations configured)
+    this.sweepExpiredConversations();
 
     // Check for inference requests
     await this.processInferenceRequests();
@@ -1482,7 +1518,7 @@ export class AgentFramework {
     // These events are protocol-level (spec Sections 9 & 14) and always
     // represent content intended for the model's context window.
     if (event.type === 'mcpl:channel-incoming') {
-      this.handleMcplChannelIncoming(event as unknown as {
+      await this.handleMcplChannelIncoming(event as unknown as {
         type: 'mcpl:channel-incoming';
         serverId: string;
         channelId: string;
@@ -1578,9 +1614,11 @@ export class AgentFramework {
         if (!decision.trigger) return;
       }
 
+      // Broadcast requests exclude conversation forks — they are driven by
+      // their own channel's messages, not by framework-wide events.
       const targetAgents =
         response.requestInference === true
-          ? Array.from(this.agents.keys())
+          ? Array.from(this.agents.keys()).filter((n) => !this.conversationAgentHomes.has(n))
           : response.requestInference;
 
       for (const agentName of targetAgents) {
@@ -1605,7 +1643,7 @@ export class AgentFramework {
    * Convert an incoming MCPL channel message to a context message.
    * This replaces the old MCPLModule.onProcess() message conversion.
    */
-  private handleMcplChannelIncoming(event: {
+  private async handleMcplChannelIncoming(event: {
     type: 'mcpl:channel-incoming';
     serverId: string;
     channelId: string;
@@ -1616,7 +1654,7 @@ export class AgentFramework {
     timestamp: string;
     metadata?: Record<string, unknown>;
     triggerInference?: boolean;
-  }): void {
+  }): Promise<void> {
     const metadata: Record<string, unknown> = {
       ...event.metadata,
       channelId: event.channelId,
@@ -1626,6 +1664,14 @@ export class AgentFramework {
       serverId: event.serverId,
     };
     if (event.threadId) metadata.threadId = event.threadId;
+
+    // Per-channel conversation routing: messages go to the channel's fork
+    // agent (spawned from the template on first qualifying message), never
+    // to the primary conversation.
+    if (this.conversationRouter) {
+      await this.routeConversationIncoming(event, metadata);
+      return;
+    }
 
     const id = this.addMessage('user', event.content, metadata);
     this.emitTrace({ type: 'message:added', messageId: id, source: 'mcpl:channel-incoming' });
@@ -1639,6 +1685,201 @@ export class AgentFramework {
           timestamp: Date.now(),
         });
       }
+    }
+  }
+
+  /**
+   * Route an incoming channel message through the ConversationRouter:
+   * deliver to the channel's bound fork agent, spawning it from the template
+   * agent first when the bind policy matches. Unrouted messages are dropped —
+   * the template ("trunk") is a dormant warm checkpoint, not a listener.
+   */
+  private async routeConversationIncoming(
+    event: {
+      serverId: string;
+      channelId: string;
+      messageId: string;
+      author: { id: string; name: string };
+      content: ContentBlock[];
+      metadata?: Record<string, unknown>;
+      triggerInference?: boolean;
+    },
+    messageMetadata: Record<string, unknown>,
+  ): Promise<void> {
+    const router = this.conversationRouter!;
+    const descriptor = this.channelRegistry?.getDescriptor(event.channelId);
+
+    const decision = router.route({
+      channelId: event.channelId,
+      mentioned: event.metadata?.mentioned === true,
+      isDm: ConversationRouter.isDmChannel(descriptor, event.metadata),
+    });
+
+    if (decision.kind === 'unbound') {
+      this.emitTrace({
+        type: 'mcpl:conversation-unrouted',
+        channelId: event.channelId,
+        messageId: event.messageId,
+      });
+      return;
+    }
+
+    let agent: Agent | undefined;
+    if (decision.kind === 'spawn') {
+      try {
+        agent = await this.createConversationAgent(decision.agentName, event.channelId);
+        router.bind(event.channelId, decision.agentName, decision.generation);
+        this.emitTrace({
+          type: 'mcpl:conversation-spawned',
+          channelId: event.channelId,
+          agentName: decision.agentName,
+          generation: decision.generation,
+          template: router.templateAgent,
+        });
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        console.error(`Failed to spawn conversation agent for ${event.channelId}:`, err);
+        this.emitTrace({
+          type: 'mcpl:conversation-spawn-failed',
+          channelId: event.channelId,
+          agentName: decision.agentName,
+          error: err.message,
+        });
+        return; // next qualifying message proposes the same spawn again
+      }
+    } else {
+      agent = this.agents.get(decision.agentName);
+      if (!agent) {
+        // Bound agent vanished (e.g. external reset) — unbind so the next
+        // qualifying message respawns a fresh fork.
+        router.unbind(event.channelId);
+        this.emitTrace({
+          type: 'mcpl:conversation-binding-orphaned',
+          channelId: event.channelId,
+          agentName: decision.agentName,
+        });
+        return;
+      }
+    }
+
+    // Respect an explicit server-config-level veto (shouldTriggerInference)
+    // on top of the router's own trigger policy.
+    const trigger = decision.trigger && event.triggerInference !== false;
+    messageMetadata.triggered = trigger;
+
+    const id = agent.getContextManager().addMessage('user', event.content, messageMetadata);
+    this.emitTrace({ type: 'message:added', messageId: id, source: 'mcpl:channel-incoming' });
+
+    if (trigger) {
+      this.pendingRequests.push({
+        agentName: agent.name,
+        reason: 'mcpl:channel-incoming',
+        source: event.serverId,
+        timestamp: Date.now(),
+      });
+    }
+  }
+
+  /**
+   * Spawn a persistent per-channel conversation agent ("fork") from the
+   * template agent: own ContextManager under `conversations/{name}`, seeded
+   * with a copy of the template's compiled context (the SubagentModule
+   * wholesale-copy pattern), registered in the event loop like any agent —
+   * but never primary.
+   */
+  private async createConversationAgent(name: string, channelId: string): Promise<Agent> {
+    const router = this.conversationRouter!;
+    const templateConfig = this.agentConfigs.get(router.templateAgent);
+    const template = this.agents.get(router.templateAgent);
+    if (!template || !templateConfig) {
+      throw new Error(`conversation template agent "${router.templateAgent}" not found`);
+    }
+
+    const contextManager = await ContextManager.open({
+      store: this.store,
+      namespace: `conversations/${name}`,
+      isolate: true,
+      // Strategy instances are stateful — never share the template's.
+      strategy: router.strategyFactory?.() ?? new PassthroughStrategy(),
+      membrane: this.membrane,
+      debugLogContext: !!process.env.DEBUG_CONTEXT,
+    });
+
+    // Seed with the template's compiled context, renaming the template
+    // participant so the fork reads its inheritance as its own history.
+    const { messages: compiled } = await template.getContextManager().compile();
+    for (const msg of compiled) {
+      const participant = msg.participant === template.name ? name : msg.participant;
+      contextManager.addMessage(participant, msg.content);
+    }
+
+    const config: AgentConfig = { ...templateConfig, name, strategy: undefined };
+    const agent = new Agent(config, contextManager, this.membrane);
+    this.agents.set(name, agent);
+    this.agentConfigs.set(name, config);
+    this.conversationAgentHomes.set(name, channelId);
+    return agent;
+  }
+
+  /**
+   * Scope MCPL context injections for a conversation-bound agent: drop
+   * injections that are another open channel's context (injection namespace
+   * = channelId by adapter convention), keep its own channel and anything
+   * that isn't channel context.
+   */
+  private scopeInjectionsForAgent(
+    agentName: string,
+    injections: ContextInjection[],
+  ): ContextInjection[] {
+    const home = this.conversationAgentHomes.get(agentName);
+    if (!home || !this.channelRegistry || injections.length === 0) {
+      return injections;
+    }
+    const openChannelIds = new Set(
+      this.channelRegistry.getOpenChannels().map((e) => e.descriptor.id),
+    );
+    return injections.filter((inj) => {
+      const ns = inj.namespace;
+      if (!ns || !openChannelIds.has(ns)) return true;
+      return ns === home;
+    });
+  }
+
+  /**
+   * Idle-TTL sweep for conversation bindings (runs at most once per minute
+   * from the event loop). Expired forks get a final system-initiated closure
+   * turn — publish scoping still works because the agent's home channel
+   * mapping is permanent — and the channel unbinds immediately, so the next
+   * qualifying message spawns a fresh fork from the current template.
+   */
+  private sweepExpiredConversations(): void {
+    if (!this.conversationRouter) return;
+    const now = Date.now();
+    if (now - this.lastConversationSweep < 60_000) return;
+    this.lastConversationSweep = now;
+
+    for (const binding of this.conversationRouter.expired(now)) {
+      this.conversationRouter.unbind(binding.channelId);
+      this.emitTrace({
+        type: 'mcpl:conversation-closed',
+        channelId: binding.channelId,
+        agentName: binding.agentName,
+        reason: 'idle-ttl',
+      });
+
+      const agent = this.agents.get(binding.agentName);
+      if (!agent) continue;
+      agent.getContextManager().addMessage(
+        'user',
+        [{ type: 'text', text: this.conversationRouter.closurePrompt }],
+        { channelId: binding.channelId, conversationClosure: true },
+      );
+      this.pendingRequests.push({
+        agentName: binding.agentName,
+        reason: 'conversation:closure',
+        source: 'framework',
+        timestamp: now,
+      });
     }
   }
 
@@ -1658,7 +1899,9 @@ export class AgentFramework {
     this.emitTrace({ type: 'message:added', messageId: id, source: 'mcpl:push-event' });
 
     if (event.triggerInference) {
-      const targetAgents = event.targetAgents ?? [...this.agents.keys()];
+      // Default broadcast excludes conversation forks (channel-driven).
+      const targetAgents = event.targetAgents
+        ?? [...this.agents.keys()].filter((n) => !this.conversationAgentHomes.has(n));
       for (const agentName of targetAgents) {
         this.pendingRequests.push({
           agentName,
@@ -1766,7 +2009,10 @@ export class AgentFramework {
       if (this.hookOrchestrator) {
         try {
           const hookParams = this.buildBeforeInferenceParams(agent, trigger);
-          const hookInjections = await this.hookOrchestrator.beforeInference(hookParams);
+          const hookInjections = this.scopeInjectionsForAgent(
+            agent.name,
+            await this.hookOrchestrator.beforeInference(hookParams),
+          );
           if (hookInjections.length > 0) {
             injections = injections ? [...injections, ...hookInjections] : hookInjections;
           }
@@ -2927,6 +3173,33 @@ export class AgentFramework {
    * Dispatch a synthesized channel tool call.
    */
   private dispatchChannelToolCall(agentName: string, call: ToolCall): void {
+    // Conversation forks publish only to their home channel: a missing
+    // channelId defaults to it, an explicit foreign channelId is rejected.
+    const home = this.conversationAgentHomes.get(agentName);
+    if (home && call.name === 'channel_publish') {
+      const input = (call.input ?? {}) as { channelId?: string };
+      if (!input.channelId) {
+        call = { ...call, input: { ...input, channelId: home } };
+      } else if (input.channelId !== home) {
+        this.emitTrace({
+          type: 'tool:failed', module: 'channels', tool: call.name, callId: call.id,
+          error: `conversation agent ${agentName} attempted publish to ${input.channelId}`,
+        });
+        this.pushEvent({
+          type: 'tool-result',
+          callId: call.id,
+          agentName,
+          moduleName: 'channels',
+          result: {
+            success: false,
+            error: `This conversation is bound to channel ${home}; publishing to ${input.channelId} is not allowed.`,
+            isError: true,
+          },
+        });
+        return;
+      }
+    }
+
     this.emitTrace({ type: 'tool:started', module: 'channels', tool: call.name, callId: call.id, input: call.input });
     const startTime = Date.now();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,18 @@ export type { GateConfig, GateOptions, GatePolicy, GatePolicyMatch, GateBehavior
 // MCPL channel registry (exposed for modules that need channel-level operations)
 export { ChannelRegistry } from './mcpl/index.js';
 
+// Per-channel conversation routing
+export { ConversationRouter, DEFAULT_CLOSURE_PROMPT } from './mcpl/index.js';
+export type {
+  ConversationRouterConfig,
+  ConversationBinding,
+  RoutingDecision,
+  IncomingMessageFacts,
+  BindRule,
+  TriggerRule,
+  ChannelKind,
+} from './mcpl/index.js';
+
 // Re-export commonly used types from dependencies
 export type { ContextManager, ContextStrategy, TokenBudget } from '@animalabs/context-manager';
 export { PassthroughStrategy, AutobiographicalStrategy, KnowledgeStrategy } from '@animalabs/context-manager';

--- a/src/mcpl/channel-registry.ts
+++ b/src/mcpl/channel-registry.ts
@@ -537,6 +537,14 @@ export class ChannelRegistry {
   }
 
   /**
+   * Get the descriptor for a channel by its channelId (first match across
+   * servers). Used by the conversation router for DM classification.
+   */
+  getDescriptor(channelId: string): ChannelDescriptor | undefined {
+    return this.findChannelEntry(channelId)?.descriptor;
+  }
+
+  /**
    * Get all open channels.
    */
   getOpenChannels(): ChannelEntry[] {

--- a/src/mcpl/conversation-router.ts
+++ b/src/mcpl/conversation-router.ts
@@ -21,9 +21,12 @@
  * that channel spawns a *fresh* fork (generation + 1) from the current
  * trunk, so handbook/template updates propagate between engagements.
  *
- * The binding table is in-memory. Fork agent context lives in Chronicle
- * under its own namespace and survives restarts; bindings themselves are
- * re-established by the next qualifying message.
+ * The binding table is in-memory — bindings are re-established by the next
+ * qualifying message after a restart. The generation counters, by contrast,
+ * are persisted by the framework (exportGenerations/hydrateGenerations):
+ * a restarted host must NOT reuse generation 1's agent name, or it would
+ * reopen the previous engagement's Chronicle namespace and re-seed the
+ * template context on top of the old history.
  */
 
 import type { ContextStrategy } from '@animalabs/context-manager';
@@ -40,15 +43,23 @@ export type BindRule = 'always' | 'mention' | 'never';
  * the fork's context). */
 export type TriggerRule = 'always' | 'mention';
 
+/** How a channel is classified for bind/trigger rules. Group DMs are their
+ * own kind: the bot was added deliberately (so they bind like DMs) but they
+ * host multi-human chatter (so they trigger like channels by default —
+ * inferring on every message of a four-human group DM is a firehose). */
+export type ChannelKind = 'dm' | 'groupDm' | 'channel';
+
 export interface ConversationRouterConfig {
   /** Agent whose context seeds new forks (the "trunk"/warm checkpoint). */
   templateAgent: string;
 
-  /** Bind rules per channel kind. Defaults: dm 'always', channel 'mention'. */
-  bind?: { dm?: BindRule; channel?: BindRule };
+  /** Bind rules per channel kind.
+   * Defaults: dm 'always', groupDm 'always', channel 'mention'. */
+  bind?: { dm?: BindRule; groupDm?: BindRule; channel?: BindRule };
 
-  /** Trigger rules per channel kind. Defaults: dm 'always', channel 'mention'. */
-  trigger?: { dm?: TriggerRule; channel?: TriggerRule };
+  /** Trigger rules per channel kind.
+   * Defaults: dm 'always', groupDm 'mention', channel 'mention'. */
+  trigger?: { dm?: TriggerRule; groupDm?: TriggerRule; channel?: TriggerRule };
 
   /** Idle time before a binding expires and the fork is closed. Default 12h. */
   idleTtlMs?: number;
@@ -82,8 +93,8 @@ export interface IncomingMessageFacts {
   channelId: string;
   /** Personal mention of the bot (metadata.mentioned from the adapter). */
   mentioned: boolean;
-  /** DM or group-DM channel (see isDmChannel). */
-  isDm: boolean;
+  /** Channel classification (see classifyChannel). */
+  kind: ChannelKind;
   /** Clock injection for tests; defaults to Date.now(). */
   now?: number;
 }
@@ -156,9 +167,8 @@ export class ConversationRouter {
       };
     }
 
-    const bindRule = facts.isDm
-      ? (this.config.bind?.dm ?? 'always')
-      : (this.config.bind?.channel ?? 'mention');
+    const bindRule = this.config.bind?.[facts.kind]
+      ?? (facts.kind === 'channel' ? 'mention' : 'always');
 
     const binds =
       bindRule === 'always' || (bindRule === 'mention' && facts.mentioned);
@@ -224,25 +234,43 @@ export class ConversationRouter {
   // ==========================================================================
 
   /**
-   * Classify a channel as DM-like from its descriptor and/or message
-   * metadata. Slack marks DMs/group DMs with is_im/is_mpim on the channel
-   * descriptor and channel_type on each message; other platforms can adopt
-   * either convention.
+   * Classify a channel from its descriptor and/or message metadata. Slack
+   * marks DMs/group DMs with is_im/is_mpim on the channel descriptor and
+   * channel_type on each message; other platforms can adopt either
+   * convention.
    */
-  static isDmChannel(
+  static classifyChannel(
     descriptor?: ChannelDescriptor,
     messageMetadata?: Record<string, unknown>,
-  ): boolean {
+  ): ChannelKind {
     const meta = descriptor?.metadata as Record<string, unknown> | undefined;
-    if (meta?.is_im === true || meta?.is_mpim === true) return true;
+    if (meta?.is_im === true) return 'dm';
+    if (meta?.is_mpim === true) return 'groupDm';
     const channelType = messageMetadata?.channel_type;
-    return channelType === 'im' || channelType === 'mpim';
+    if (channelType === 'im') return 'dm';
+    if (channelType === 'mpim') return 'groupDm';
+    return 'channel';
+  }
+
+  /** Export the per-channel engagement counters for persistence — they must
+   * survive restarts, or a re-engaged channel reuses generation 1's name and
+   * reopens (and re-seeds) the previous engagement's Chronicle namespace. */
+  exportGenerations(): Record<string, number> {
+    return Object.fromEntries(this.generations);
+  }
+
+  /** Restore persisted engagement counters (see exportGenerations). */
+  hydrateGenerations(generations: Record<string, number>): void {
+    for (const [channelId, generation] of Object.entries(generations)) {
+      if (typeof generation === 'number' && generation > (this.generations.get(channelId) ?? 0)) {
+        this.generations.set(channelId, generation);
+      }
+    }
   }
 
   private shouldTrigger(facts: IncomingMessageFacts): boolean {
-    const rule = facts.isDm
-      ? (this.config.trigger?.dm ?? 'always')
-      : (this.config.trigger?.channel ?? 'mention');
+    const rule = this.config.trigger?.[facts.kind]
+      ?? (facts.kind === 'dm' ? 'always' : 'mention');
     return rule === 'always' || facts.mentioned;
   }
 

--- a/src/mcpl/conversation-router.ts
+++ b/src/mcpl/conversation-router.ts
@@ -1,0 +1,256 @@
+/**
+ * ConversationRouter — routes incoming channel messages to per-channel
+ * conversation agents ("forks") instead of the primary conversation.
+ *
+ * The router is a lookup table plus policy — deliberately no LLM in the
+ * routing path. The framework consults it from handleMcplChannelIncoming:
+ *
+ * - A channel with an active binding routes to its bound agent. Whether the
+ *   message *triggers* inference (vs. just landing in the fork's context) is
+ *   a separate per-channel-kind rule: in a busy channel everything is case
+ *   input but only mentions demand a reply.
+ * - An unbound channel binds (→ the framework spawns a fork from the
+ *   template/trunk agent) when the bind rule matches: by default any message
+ *   in a DM, an explicit bot mention in a channel (`metadata.mentioned`,
+ *   set server-side by the platform adapters).
+ * - Everything else is left unrouted and dropped by the framework — the
+ *   trunk is a dormant template, not a listener.
+ *
+ * Bindings expire after an idle TTL. Expiry runs a final closure turn on the
+ * fork (see framework wiring) and unbinds; the next qualifying message on
+ * that channel spawns a *fresh* fork (generation + 1) from the current
+ * trunk, so handbook/template updates propagate between engagements.
+ *
+ * The binding table is in-memory. Fork agent context lives in Chronicle
+ * under its own namespace and survives restarts; bindings themselves are
+ * re-established by the next qualifying message.
+ */
+
+import type { ContextStrategy } from '@animalabs/context-manager';
+import type { ChannelDescriptor } from './types.js';
+
+// ============================================================================
+// Config & types
+// ============================================================================
+
+/** When an unbound channel acquires a fork. */
+export type BindRule = 'always' | 'mention' | 'never';
+
+/** When a message on a bound channel triggers inference (it always lands in
+ * the fork's context). */
+export type TriggerRule = 'always' | 'mention';
+
+export interface ConversationRouterConfig {
+  /** Agent whose context seeds new forks (the "trunk"/warm checkpoint). */
+  templateAgent: string;
+
+  /** Bind rules per channel kind. Defaults: dm 'always', channel 'mention'. */
+  bind?: { dm?: BindRule; channel?: BindRule };
+
+  /** Trigger rules per channel kind. Defaults: dm 'always', channel 'mention'. */
+  trigger?: { dm?: TriggerRule; channel?: TriggerRule };
+
+  /** Idle time before a binding expires and the fork is closed. Default 12h. */
+  idleTtlMs?: number;
+
+  /** Final system-initiated user message sent to a fork on expiry. */
+  closurePrompt?: string;
+
+  /** Prefix for generated fork agent names. Default 'conversation'. */
+  agentPrefix?: string;
+
+  /**
+   * Fresh compression strategy per fork. Strategy instances are stateful and
+   * must not be shared between ContextManagers, so the template agent's own
+   * strategy is never reused — without a factory, forks get passthrough.
+   */
+  strategyFactory?: () => ContextStrategy;
+}
+
+export interface ConversationBinding {
+  channelId: string;
+  agentName: string;
+  /** Engagement counter per channel — fresh forks get a new generation. */
+  generation: number;
+  boundAt: number;
+  lastActivity: number;
+}
+
+/** The facts route() needs about one incoming message, pre-extracted by the
+ * framework so the router stays free of event-shape knowledge. */
+export interface IncomingMessageFacts {
+  channelId: string;
+  /** Personal mention of the bot (metadata.mentioned from the adapter). */
+  mentioned: boolean;
+  /** DM or group-DM channel (see isDmChannel). */
+  isDm: boolean;
+  /** Clock injection for tests; defaults to Date.now(). */
+  now?: number;
+}
+
+export type RoutingDecision =
+  /** Channel already has a fork — deliver there. */
+  | { kind: 'existing'; agentName: string; trigger: boolean }
+  /** Bind rule matched — framework should spawn this agent, then bind(). */
+  | { kind: 'spawn'; agentName: string; generation: number; trigger: boolean }
+  /** No binding and bind rule didn't match — drop. */
+  | { kind: 'unbound' };
+
+const DEFAULT_IDLE_TTL_MS = 12 * 60 * 60 * 1000;
+
+export const DEFAULT_CLOSURE_PROMPT =
+  '[system] This engagement is closing due to inactivity. Finalize your ' +
+  'work: post any promised results to the channel and record outstanding ' +
+  'threads as unresolved. Do not ask follow-up questions.';
+
+// ============================================================================
+// ConversationRouter
+// ============================================================================
+
+export class ConversationRouter {
+  private config: ConversationRouterConfig;
+
+  /** Active bindings, keyed by channelId. */
+  private bindings = new Map<string, ConversationBinding>();
+
+  /** Engagement counter per channel — survives unbind, so a re-bound channel
+   * gets a distinct fork agent name. */
+  private generations = new Map<string, number>();
+
+  constructor(config: ConversationRouterConfig) {
+    this.config = config;
+  }
+
+  get templateAgent(): string {
+    return this.config.templateAgent;
+  }
+
+  get closurePrompt(): string {
+    return this.config.closurePrompt ?? DEFAULT_CLOSURE_PROMPT;
+  }
+
+  get idleTtlMs(): number {
+    return this.config.idleTtlMs ?? DEFAULT_IDLE_TTL_MS;
+  }
+
+  get strategyFactory(): (() => ContextStrategy) | undefined {
+    return this.config.strategyFactory;
+  }
+
+  /**
+   * Decide where an incoming message goes. Pure read except for refreshing
+   * lastActivity on an existing binding — a 'spawn' decision does NOT create
+   * the binding; the framework calls bind() after the fork agent actually
+   * exists, so a failed spawn doesn't leave a dangling route.
+   */
+  route(facts: IncomingMessageFacts): RoutingDecision {
+    const now = facts.now ?? Date.now();
+    const existing = this.bindings.get(facts.channelId);
+
+    if (existing) {
+      existing.lastActivity = now;
+      return {
+        kind: 'existing',
+        agentName: existing.agentName,
+        trigger: this.shouldTrigger(facts),
+      };
+    }
+
+    const bindRule = facts.isDm
+      ? (this.config.bind?.dm ?? 'always')
+      : (this.config.bind?.channel ?? 'mention');
+
+    const binds =
+      bindRule === 'always' || (bindRule === 'mention' && facts.mentioned);
+    if (!binds) {
+      return { kind: 'unbound' };
+    }
+
+    const generation = (this.generations.get(facts.channelId) ?? 0) + 1;
+    return {
+      kind: 'spawn',
+      agentName: this.forkAgentName(facts.channelId, generation),
+      generation,
+      trigger: this.shouldTrigger(facts),
+    };
+  }
+
+  /**
+   * Record a binding after the framework successfully spawned the fork.
+   * Returns the new binding.
+   */
+  bind(channelId: string, agentName: string, generation: number, now = Date.now()): ConversationBinding {
+    this.generations.set(channelId, generation);
+    const binding: ConversationBinding = {
+      channelId,
+      agentName,
+      generation,
+      boundAt: now,
+      lastActivity: now,
+    };
+    this.bindings.set(channelId, binding);
+    return binding;
+  }
+
+  unbind(channelId: string): void {
+    this.bindings.delete(channelId);
+  }
+
+  getBinding(channelId: string): ConversationBinding | undefined {
+    return this.bindings.get(channelId);
+  }
+
+  /** Reverse lookup: the channel an agent is bound to, if any. */
+  channelForAgent(agentName: string): string | undefined {
+    for (const binding of this.bindings.values()) {
+      if (binding.agentName === agentName) return binding.channelId;
+    }
+    return undefined;
+  }
+
+  getBindings(): ConversationBinding[] {
+    return Array.from(this.bindings.values());
+  }
+
+  /** Bindings whose idle TTL has elapsed. Does not unbind — the framework
+   * runs the closure turn first, then calls unbind(). */
+  expired(now = Date.now()): ConversationBinding[] {
+    const ttl = this.idleTtlMs;
+    return this.getBindings().filter((b) => now - b.lastActivity >= ttl);
+  }
+
+  // ==========================================================================
+  // Helpers
+  // ==========================================================================
+
+  /**
+   * Classify a channel as DM-like from its descriptor and/or message
+   * metadata. Slack marks DMs/group DMs with is_im/is_mpim on the channel
+   * descriptor and channel_type on each message; other platforms can adopt
+   * either convention.
+   */
+  static isDmChannel(
+    descriptor?: ChannelDescriptor,
+    messageMetadata?: Record<string, unknown>,
+  ): boolean {
+    const meta = descriptor?.metadata as Record<string, unknown> | undefined;
+    if (meta?.is_im === true || meta?.is_mpim === true) return true;
+    const channelType = messageMetadata?.channel_type;
+    return channelType === 'im' || channelType === 'mpim';
+  }
+
+  private shouldTrigger(facts: IncomingMessageFacts): boolean {
+    const rule = facts.isDm
+      ? (this.config.trigger?.dm ?? 'always')
+      : (this.config.trigger?.channel ?? 'mention');
+    return rule === 'always' || facts.mentioned;
+  }
+
+  /** `conversation-slack-C123-g2` — agent names double as Chronicle
+   * namespace components, so the channel id is sanitized. */
+  private forkAgentName(channelId: string, generation: number): string {
+    const prefix = this.config.agentPrefix ?? 'conversation';
+    const safe = channelId.replace(/[^A-Za-z0-9_-]+/g, '-');
+    return `${prefix}-${safe}-g${generation}`;
+  }
+}

--- a/src/mcpl/index.ts
+++ b/src/mcpl/index.ts
@@ -139,6 +139,7 @@ export type {
   IncomingMessageFacts,
   BindRule,
   TriggerRule,
+  ChannelKind,
 } from './conversation-router.js';
 
 // State management (Section 8, checkpoint trees + JSON Patch)

--- a/src/mcpl/index.ts
+++ b/src/mcpl/index.ts
@@ -130,5 +130,16 @@ export { InferenceRouter } from './inference-router.js';
 // Channel registry (channel lifecycle, incoming messages, synthesized tools)
 export { ChannelRegistry } from './channel-registry.js';
 
+// Per-channel conversation routing (fork-per-channel agents)
+export { ConversationRouter, DEFAULT_CLOSURE_PROMPT } from './conversation-router.js';
+export type {
+  ConversationRouterConfig,
+  ConversationBinding,
+  RoutingDecision,
+  IncomingMessageFacts,
+  BindRule,
+  TriggerRule,
+} from './conversation-router.js';
+
 // State management (Section 8, checkpoint trees + JSON Patch)
 export { CheckpointManager, applyJsonPatch } from './checkpoint-manager.js';

--- a/src/types/framework.ts
+++ b/src/types/framework.ts
@@ -4,6 +4,7 @@ import type { Module, EventResponse } from './module.js';
 import type { AgentConfig, InferenceRequest } from './agent.js';
 import type { ProcessEvent } from './events.js';
 import type { McplServerConfig, InferenceRoutingPolicy } from '../mcpl/types.js';
+import type { ConversationRouterConfig } from '../mcpl/conversation-router.js';
 import type { GateOptions } from '../gate/types.js';
 
 // Re-export trace types
@@ -66,6 +67,14 @@ export interface FrameworkConfig {
 
   /** EventGate config. If omitted, all events trigger inference (unchanged default). */
   gate?: GateOptions;
+
+  /**
+   * Per-channel conversation routing. When set, incoming MCPL channel
+   * messages route to per-channel fork agents spawned from the template
+   * agent instead of the primary conversation. If omitted, behavior is
+   * unchanged (all messages go to the primary agent).
+   */
+  conversations?: ConversationRouterConfig;
 }
 
 /**

--- a/src/types/trace.ts
+++ b/src/types/trace.ts
@@ -265,6 +265,11 @@ export type TraceEvent =
       channelId: string;
       agentName: string;
       reason: 'idle-ttl';
+    })
+  | (TraceEventBase & {
+      type: 'mcpl:conversation-disposed';
+      agentName: string;
+      channelId?: string;
     });
 
 /**

--- a/src/types/trace.ts
+++ b/src/types/trace.ts
@@ -234,6 +234,37 @@ export type TraceEvent =
       type: 'mcpl:server-stderr';
       serverId: string;
       line: string;
+    })
+
+  // Per-channel conversation routing lifecycle
+  | (TraceEventBase & {
+      type: 'mcpl:conversation-spawned';
+      channelId: string;
+      agentName: string;
+      generation: number;
+      template: string;
+    })
+  | (TraceEventBase & {
+      type: 'mcpl:conversation-spawn-failed';
+      channelId: string;
+      agentName: string;
+      error: string;
+    })
+  | (TraceEventBase & {
+      type: 'mcpl:conversation-unrouted';
+      channelId: string;
+      messageId: string;
+    })
+  | (TraceEventBase & {
+      type: 'mcpl:conversation-binding-orphaned';
+      channelId: string;
+      agentName: string;
+    })
+  | (TraceEventBase & {
+      type: 'mcpl:conversation-closed';
+      channelId: string;
+      agentName: string;
+      reason: 'idle-ttl';
     });
 
 /**

--- a/test/conversation-router.test.ts
+++ b/test/conversation-router.test.ts
@@ -1,0 +1,147 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { ConversationRouter } from '../src/mcpl/conversation-router.js';
+import type { ChannelDescriptor } from '../src/mcpl/types.js';
+
+const T0 = 1_750_000_000_000;
+
+function makeRouter(overrides: Partial<ConstructorParameters<typeof ConversationRouter>[0]> = {}) {
+  return new ConversationRouter({ templateAgent: 'trunk', ...overrides });
+}
+
+// ---------------------------------------------------------------------------
+// Bind policy
+// ---------------------------------------------------------------------------
+
+test('DM message binds without a mention (default dm bind: always)', () => {
+  const router = makeRouter();
+  const decision = router.route({ channelId: 'slack:D1', mentioned: false, isDm: true, now: T0 });
+  assert.equal(decision.kind, 'spawn');
+  if (decision.kind === 'spawn') {
+    assert.equal(decision.generation, 1);
+    assert.match(decision.agentName, /^conversation-slack-D1-g1$/);
+    assert.equal(decision.trigger, true);
+  }
+});
+
+test('channel message without mention stays unbound (default channel bind: mention)', () => {
+  const router = makeRouter();
+  const decision = router.route({ channelId: 'slack:C1', mentioned: false, isDm: false, now: T0 });
+  assert.equal(decision.kind, 'unbound');
+});
+
+test('channel mention spawns a fork', () => {
+  const router = makeRouter();
+  const decision = router.route({ channelId: 'slack:C1', mentioned: true, isDm: false, now: T0 });
+  assert.equal(decision.kind, 'spawn');
+});
+
+test('bind rule never keeps DMs unbound', () => {
+  const router = makeRouter({ bind: { dm: 'never' } });
+  const decision = router.route({ channelId: 'slack:D1', mentioned: true, isDm: true, now: T0 });
+  assert.equal(decision.kind, 'unbound');
+});
+
+// ---------------------------------------------------------------------------
+// Spawn is two-phase: route() proposes, bind() commits
+// ---------------------------------------------------------------------------
+
+test('spawn decision does not create the binding until bind() is called', () => {
+  const router = makeRouter();
+  const d1 = router.route({ channelId: 'slack:C1', mentioned: true, isDm: false, now: T0 });
+  assert.equal(d1.kind, 'spawn');
+  assert.equal(router.getBinding('slack:C1'), undefined);
+
+  // Framework failed to spawn → next mention proposes the same generation.
+  const d2 = router.route({ channelId: 'slack:C1', mentioned: true, isDm: false, now: T0 + 1 });
+  assert.equal(d2.kind, 'spawn');
+  if (d2.kind === 'spawn') assert.equal(d2.generation, 1);
+
+  if (d2.kind === 'spawn') router.bind('slack:C1', d2.agentName, d2.generation, T0 + 1);
+  const d3 = router.route({ channelId: 'slack:C1', mentioned: false, isDm: false, now: T0 + 2 });
+  assert.equal(d3.kind, 'existing');
+});
+
+// ---------------------------------------------------------------------------
+// Trigger policy on bound channels
+// ---------------------------------------------------------------------------
+
+test('bound channel: non-mentions land without triggering, mentions trigger', () => {
+  const router = makeRouter();
+  router.bind('slack:C1', 'conversation-slack-C1-g1', 1, T0);
+
+  const ambient = router.route({ channelId: 'slack:C1', mentioned: false, isDm: false, now: T0 + 1 });
+  assert.equal(ambient.kind, 'existing');
+  if (ambient.kind === 'existing') assert.equal(ambient.trigger, false);
+
+  const mention = router.route({ channelId: 'slack:C1', mentioned: true, isDm: false, now: T0 + 2 });
+  assert.equal(mention.kind, 'existing');
+  if (mention.kind === 'existing') assert.equal(mention.trigger, true);
+});
+
+test('bound DM: every message triggers', () => {
+  const router = makeRouter();
+  router.bind('slack:D1', 'conversation-slack-D1-g1', 1, T0);
+  const decision = router.route({ channelId: 'slack:D1', mentioned: false, isDm: true, now: T0 + 1 });
+  assert.equal(decision.kind, 'existing');
+  if (decision.kind === 'existing') assert.equal(decision.trigger, true);
+});
+
+// ---------------------------------------------------------------------------
+// TTL + generations
+// ---------------------------------------------------------------------------
+
+test('expired() respects lastActivity refresh from route()', () => {
+  const router = makeRouter({ idleTtlMs: 1000 });
+  router.bind('slack:C1', 'conversation-slack-C1-g1', 1, T0);
+
+  // Ambient traffic keeps the binding alive even without triggering.
+  router.route({ channelId: 'slack:C1', mentioned: false, isDm: false, now: T0 + 900 });
+  assert.deepEqual(router.expired(T0 + 1500), []);
+  assert.equal(router.expired(T0 + 1901).length, 1);
+});
+
+test('rebind after expiry gets a fresh generation and agent name', () => {
+  const router = makeRouter({ idleTtlMs: 1000 });
+  const d1 = router.route({ channelId: 'slack:C1', mentioned: true, isDm: false, now: T0 });
+  if (d1.kind !== 'spawn') assert.fail('expected spawn');
+  router.bind('slack:C1', d1.agentName, d1.generation, T0);
+
+  router.unbind('slack:C1'); // framework does this after the closure turn
+
+  const d2 = router.route({ channelId: 'slack:C1', mentioned: true, isDm: false, now: T0 + 5000 });
+  assert.equal(d2.kind, 'spawn');
+  if (d2.kind === 'spawn') {
+    assert.equal(d2.generation, 2);
+    assert.match(d2.agentName, /-g2$/);
+    assert.notEqual(d2.agentName, d1.agentName);
+  }
+});
+
+test('channelForAgent reverse lookup', () => {
+  const router = makeRouter();
+  router.bind('slack:C1', 'fork-a', 1, T0);
+  assert.equal(router.channelForAgent('fork-a'), 'slack:C1');
+  assert.equal(router.channelForAgent('fork-b'), undefined);
+});
+
+// ---------------------------------------------------------------------------
+// DM classification
+// ---------------------------------------------------------------------------
+
+test('isDmChannel reads descriptor metadata and message channel_type', () => {
+  const im: ChannelDescriptor = {
+    id: 'slack:D1', type: 'slack', label: 'DM: @alice', direction: 'bidirectional',
+    address: {}, metadata: { is_im: true },
+  };
+  const channel: ChannelDescriptor = {
+    id: 'slack:C1', type: 'slack', label: '#general', direction: 'bidirectional',
+    address: {}, metadata: { is_member: true },
+  };
+  assert.equal(ConversationRouter.isDmChannel(im), true);
+  assert.equal(ConversationRouter.isDmChannel(channel), false);
+  assert.equal(ConversationRouter.isDmChannel(undefined, { channel_type: 'im' }), true);
+  assert.equal(ConversationRouter.isDmChannel(undefined, { channel_type: 'mpim' }), true);
+  assert.equal(ConversationRouter.isDmChannel(undefined, { channel_type: 'channel' }), false);
+  assert.equal(ConversationRouter.isDmChannel(undefined, undefined), false);
+});

--- a/test/conversation-router.test.ts
+++ b/test/conversation-router.test.ts
@@ -15,7 +15,7 @@ function makeRouter(overrides: Partial<ConstructorParameters<typeof Conversation
 
 test('DM message binds without a mention (default dm bind: always)', () => {
   const router = makeRouter();
-  const decision = router.route({ channelId: 'slack:D1', mentioned: false, isDm: true, now: T0 });
+  const decision = router.route({ channelId: 'slack:D1', mentioned: false, kind: 'dm', now: T0 });
   assert.equal(decision.kind, 'spawn');
   if (decision.kind === 'spawn') {
     assert.equal(decision.generation, 1);
@@ -26,19 +26,19 @@ test('DM message binds without a mention (default dm bind: always)', () => {
 
 test('channel message without mention stays unbound (default channel bind: mention)', () => {
   const router = makeRouter();
-  const decision = router.route({ channelId: 'slack:C1', mentioned: false, isDm: false, now: T0 });
+  const decision = router.route({ channelId: 'slack:C1', mentioned: false, kind: 'channel', now: T0 });
   assert.equal(decision.kind, 'unbound');
 });
 
 test('channel mention spawns a fork', () => {
   const router = makeRouter();
-  const decision = router.route({ channelId: 'slack:C1', mentioned: true, isDm: false, now: T0 });
+  const decision = router.route({ channelId: 'slack:C1', mentioned: true, kind: 'channel', now: T0 });
   assert.equal(decision.kind, 'spawn');
 });
 
 test('bind rule never keeps DMs unbound', () => {
   const router = makeRouter({ bind: { dm: 'never' } });
-  const decision = router.route({ channelId: 'slack:D1', mentioned: true, isDm: true, now: T0 });
+  const decision = router.route({ channelId: 'slack:D1', mentioned: true, kind: 'dm', now: T0 });
   assert.equal(decision.kind, 'unbound');
 });
 
@@ -48,17 +48,17 @@ test('bind rule never keeps DMs unbound', () => {
 
 test('spawn decision does not create the binding until bind() is called', () => {
   const router = makeRouter();
-  const d1 = router.route({ channelId: 'slack:C1', mentioned: true, isDm: false, now: T0 });
+  const d1 = router.route({ channelId: 'slack:C1', mentioned: true, kind: 'channel', now: T0 });
   assert.equal(d1.kind, 'spawn');
   assert.equal(router.getBinding('slack:C1'), undefined);
 
   // Framework failed to spawn → next mention proposes the same generation.
-  const d2 = router.route({ channelId: 'slack:C1', mentioned: true, isDm: false, now: T0 + 1 });
+  const d2 = router.route({ channelId: 'slack:C1', mentioned: true, kind: 'channel', now: T0 + 1 });
   assert.equal(d2.kind, 'spawn');
   if (d2.kind === 'spawn') assert.equal(d2.generation, 1);
 
   if (d2.kind === 'spawn') router.bind('slack:C1', d2.agentName, d2.generation, T0 + 1);
-  const d3 = router.route({ channelId: 'slack:C1', mentioned: false, isDm: false, now: T0 + 2 });
+  const d3 = router.route({ channelId: 'slack:C1', mentioned: false, kind: 'channel', now: T0 + 2 });
   assert.equal(d3.kind, 'existing');
 });
 
@@ -70,11 +70,11 @@ test('bound channel: non-mentions land without triggering, mentions trigger', ()
   const router = makeRouter();
   router.bind('slack:C1', 'conversation-slack-C1-g1', 1, T0);
 
-  const ambient = router.route({ channelId: 'slack:C1', mentioned: false, isDm: false, now: T0 + 1 });
+  const ambient = router.route({ channelId: 'slack:C1', mentioned: false, kind: 'channel', now: T0 + 1 });
   assert.equal(ambient.kind, 'existing');
   if (ambient.kind === 'existing') assert.equal(ambient.trigger, false);
 
-  const mention = router.route({ channelId: 'slack:C1', mentioned: true, isDm: false, now: T0 + 2 });
+  const mention = router.route({ channelId: 'slack:C1', mentioned: true, kind: 'channel', now: T0 + 2 });
   assert.equal(mention.kind, 'existing');
   if (mention.kind === 'existing') assert.equal(mention.trigger, true);
 });
@@ -82,7 +82,7 @@ test('bound channel: non-mentions land without triggering, mentions trigger', ()
 test('bound DM: every message triggers', () => {
   const router = makeRouter();
   router.bind('slack:D1', 'conversation-slack-D1-g1', 1, T0);
-  const decision = router.route({ channelId: 'slack:D1', mentioned: false, isDm: true, now: T0 + 1 });
+  const decision = router.route({ channelId: 'slack:D1', mentioned: false, kind: 'dm', now: T0 + 1 });
   assert.equal(decision.kind, 'existing');
   if (decision.kind === 'existing') assert.equal(decision.trigger, true);
 });
@@ -96,20 +96,20 @@ test('expired() respects lastActivity refresh from route()', () => {
   router.bind('slack:C1', 'conversation-slack-C1-g1', 1, T0);
 
   // Ambient traffic keeps the binding alive even without triggering.
-  router.route({ channelId: 'slack:C1', mentioned: false, isDm: false, now: T0 + 900 });
+  router.route({ channelId: 'slack:C1', mentioned: false, kind: 'channel', now: T0 + 900 });
   assert.deepEqual(router.expired(T0 + 1500), []);
   assert.equal(router.expired(T0 + 1901).length, 1);
 });
 
 test('rebind after expiry gets a fresh generation and agent name', () => {
   const router = makeRouter({ idleTtlMs: 1000 });
-  const d1 = router.route({ channelId: 'slack:C1', mentioned: true, isDm: false, now: T0 });
+  const d1 = router.route({ channelId: 'slack:C1', mentioned: true, kind: 'channel', now: T0 });
   if (d1.kind !== 'spawn') assert.fail('expected spawn');
   router.bind('slack:C1', d1.agentName, d1.generation, T0);
 
   router.unbind('slack:C1'); // framework does this after the closure turn
 
-  const d2 = router.route({ channelId: 'slack:C1', mentioned: true, isDm: false, now: T0 + 5000 });
+  const d2 = router.route({ channelId: 'slack:C1', mentioned: true, kind: 'channel', now: T0 + 5000 });
   assert.equal(d2.kind, 'spawn');
   if (d2.kind === 'spawn') {
     assert.equal(d2.generation, 2);
@@ -126,22 +126,59 @@ test('channelForAgent reverse lookup', () => {
 });
 
 // ---------------------------------------------------------------------------
-// DM classification
+// Channel classification
 // ---------------------------------------------------------------------------
 
-test('isDmChannel reads descriptor metadata and message channel_type', () => {
+test('classifyChannel reads descriptor metadata and message channel_type', () => {
   const im: ChannelDescriptor = {
     id: 'slack:D1', type: 'slack', label: 'DM: @alice', direction: 'bidirectional',
     address: {}, metadata: { is_im: true },
+  };
+  const mpim: ChannelDescriptor = {
+    id: 'slack:G1', type: 'slack', label: 'Group DM', direction: 'bidirectional',
+    address: {}, metadata: { is_mpim: true },
   };
   const channel: ChannelDescriptor = {
     id: 'slack:C1', type: 'slack', label: '#general', direction: 'bidirectional',
     address: {}, metadata: { is_member: true },
   };
-  assert.equal(ConversationRouter.isDmChannel(im), true);
-  assert.equal(ConversationRouter.isDmChannel(channel), false);
-  assert.equal(ConversationRouter.isDmChannel(undefined, { channel_type: 'im' }), true);
-  assert.equal(ConversationRouter.isDmChannel(undefined, { channel_type: 'mpim' }), true);
-  assert.equal(ConversationRouter.isDmChannel(undefined, { channel_type: 'channel' }), false);
-  assert.equal(ConversationRouter.isDmChannel(undefined, undefined), false);
+  assert.equal(ConversationRouter.classifyChannel(im), 'dm');
+  assert.equal(ConversationRouter.classifyChannel(mpim), 'groupDm');
+  assert.equal(ConversationRouter.classifyChannel(channel), 'channel');
+  assert.equal(ConversationRouter.classifyChannel(undefined, { channel_type: 'im' }), 'dm');
+  assert.equal(ConversationRouter.classifyChannel(undefined, { channel_type: 'mpim' }), 'groupDm');
+  assert.equal(ConversationRouter.classifyChannel(undefined, { channel_type: 'channel' }), 'channel');
+  assert.equal(ConversationRouter.classifyChannel(undefined, undefined), 'channel');
+});
+
+test('group DMs bind on any message but trigger only on mention by default', () => {
+  const router = new ConversationRouter({ templateAgent: 'main' });
+  const ambient = router.route({ channelId: 'slack:G1', mentioned: false, kind: 'groupDm', now: T0 });
+  assert.equal(ambient.kind, 'spawn', 'group DM binds without a mention');
+  assert.equal((ambient as { trigger: boolean }).trigger, false, 'no firehose replies in group DMs');
+
+  const mention = router.route({ channelId: 'slack:G2', mentioned: true, kind: 'groupDm', now: T0 });
+  assert.equal(mention.kind, 'spawn');
+  assert.equal((mention as { trigger: boolean }).trigger, true, 'mention triggers');
+});
+
+test('generation counters export/hydrate round-trips and never regresses', () => {
+  const router = new ConversationRouter({ templateAgent: 'main' });
+  router.bind('slack:C1', 'conversation-slack-C1-g3', 3, T0);
+  router.bind('slack:D1', 'conversation-slack-D1-g1', 1, T0);
+  const exported = router.exportGenerations();
+  assert.deepEqual(exported, { 'slack:C1': 3, 'slack:D1': 1 });
+
+  const restored = new ConversationRouter({ templateAgent: 'main' });
+  restored.hydrateGenerations(exported);
+  const decision = restored.route({ channelId: 'slack:C1', mentioned: true, kind: 'channel', now: T0 });
+  assert.equal(decision.kind, 'spawn');
+  assert.equal((decision as { generation: number }).generation, 4, 'restart must not reuse generation names');
+
+  // Hydration never regresses a counter that advanced in the meantime.
+  restored.bind('slack:D1', 'conversation-slack-D1-g5', 5, T0);
+  restored.hydrateGenerations(exported);
+  const d1 = restored.route({ channelId: 'slack:D2', mentioned: false, kind: 'dm', now: T0 });
+  assert.equal(d1.kind, 'spawn', 'sanity');
+  assert.equal(restored.exportGenerations()['slack:D1'], 5);
 });

--- a/test/conversation-routing.test.ts
+++ b/test/conversation-routing.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Integration tests for per-channel conversation routing: incoming MCPL
+ * channel messages spawn/route to fork agents instead of the primary
+ * conversation when FrameworkConfig.conversations is set.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { tmpdir } from 'node:os';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { AgentFramework } from '../src/index.js';
+import type { ProcessEvent } from '../src/index.js';
+import { MockMembrane, createMockResponse } from './helpers/mock-membrane.js';
+
+function incomingEvent(overrides: {
+  channelId: string;
+  text: string;
+  mentioned?: boolean;
+  channelType?: string;
+  messageId?: string;
+}): ProcessEvent {
+  return {
+    type: 'mcpl:channel-incoming',
+    serverId: 'srv',
+    channelId: overrides.channelId,
+    messageId: overrides.messageId ?? `m-${Math.random().toString(36).slice(2)}`,
+    author: { id: 'U1', name: 'alice' },
+    content: [{ type: 'text', text: overrides.text }],
+    timestamp: new Date().toISOString(),
+    metadata: {
+      mentioned: overrides.mentioned ?? false,
+      ...(overrides.channelType ? { channel_type: overrides.channelType } : {}),
+    },
+    triggerInference: true,
+  } as unknown as ProcessEvent;
+}
+
+describe('Conversation routing', () => {
+  let tempDir: string;
+  let membrane: MockMembrane;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'conv-routing-test-'));
+    membrane = new MockMembrane();
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  async function makeFramework(conversations: Record<string, unknown> = {}) {
+    return AgentFramework.create({
+      storePath: join(tempDir, 'test.chronicle'),
+      membrane: membrane.asMembrane(),
+      agents: [
+        { name: 'trunk', model: 'test-model', systemPrompt: 'You are the trunk.' },
+      ],
+      modules: [],
+      conversations: { templateAgent: 'trunk', ...conversations } as never,
+    });
+  }
+
+  it('rejects an unknown template agent at creation', async () => {
+    await assert.rejects(
+      () => AgentFramework.create({
+        storePath: join(tempDir, 'test.chronicle'),
+        membrane: membrane.asMembrane(),
+        agents: [{ name: 'trunk', model: 'test-model', systemPrompt: 'x' }],
+        modules: [],
+        conversations: { templateAgent: 'nope' },
+      }),
+      /templateAgent "nope"/,
+    );
+  });
+
+  it('DM message spawns a fork, routes the message there, and triggers inference', async () => {
+    membrane.pushResponse(createMockResponse([{ type: 'text', text: 'Hi alice!' }]));
+    const framework = await makeFramework();
+
+    framework.pushEvent(incomingEvent({
+      channelId: 'slack:D1', text: 'hello there', channelType: 'im',
+    }));
+    await framework.runUntilIdle();
+
+    const fork = framework.getAgent('conversation-slack-D1-g1');
+    assert.ok(fork, 'fork agent should exist');
+
+    // Message landed in the fork's context, not the trunk's.
+    const { messages: forkMessages } = await fork!.getContextManager().compile();
+    assert.ok(
+      forkMessages.some((m) => JSON.stringify(m.content).includes('hello there')),
+      'fork context should contain the incoming message',
+    );
+    const trunk = framework.getAgent('trunk')!;
+    const { messages: trunkMessages } = await trunk.getContextManager().compile();
+    assert.ok(
+      !trunkMessages.some((m) => JSON.stringify(m.content).includes('hello there')),
+      'trunk context must not receive routed messages',
+    );
+
+    // Inference ran for the fork.
+    assert.ok(membrane.calls.length >= 1, 'inference should have been triggered');
+
+    // Binding is live.
+    const router = framework.getConversationRouter()!;
+    assert.equal(router.getBinding('slack:D1')?.agentName, 'conversation-slack-D1-g1');
+
+    await framework.stop();
+  });
+
+  it('channel message without mention is dropped; mention spawns', async () => {
+    membrane.pushResponse(createMockResponse([{ type: 'text', text: 'On it.' }]));
+    const framework = await makeFramework();
+
+    framework.pushEvent(incomingEvent({ channelId: 'slack:C1', text: 'just chatting' }));
+    await framework.runUntilIdle();
+    assert.equal(framework.getAgent('conversation-slack-C1-g1'), null, 'no fork without mention');
+    assert.equal(membrane.calls.length, 0, 'no inference for unrouted messages');
+
+    framework.pushEvent(incomingEvent({ channelId: 'slack:C1', text: 'bot, help', mentioned: true }));
+    await framework.runUntilIdle();
+    assert.ok(framework.getAgent('conversation-slack-C1-g1'), 'mention spawns fork');
+
+    await framework.stop();
+  });
+
+  it('non-mention on a bound channel lands in context without triggering', async () => {
+    membrane.pushResponse(createMockResponse([{ type: 'text', text: 'ack' }]));
+    const framework = await makeFramework();
+
+    framework.pushEvent(incomingEvent({ channelId: 'slack:C1', text: 'first', mentioned: true }));
+    await framework.runUntilIdle();
+    const callsAfterSpawn = membrane.calls.length;
+
+    framework.pushEvent(incomingEvent({ channelId: 'slack:C1', text: 'ambient detail' }));
+    await framework.runUntilIdle();
+
+    const fork = framework.getAgent('conversation-slack-C1-g1')!;
+    const { messages } = await fork.getContextManager().compile();
+    assert.ok(
+      messages.some((m) => JSON.stringify(m.content).includes('ambient detail')),
+      'ambient message should land in fork context',
+    );
+    assert.equal(membrane.calls.length, callsAfterSpawn, 'ambient message must not trigger inference');
+
+    await framework.stop();
+  });
+
+  it('fork inherits the template context', async () => {
+    membrane.pushResponse(createMockResponse([{ type: 'text', text: 'ok' }]));
+    const framework = await makeFramework();
+
+    // Seed the trunk (primary agent) with handbook-like content.
+    framework.getAgent('trunk')!.getContextManager().addMessage('user', [
+      { type: 'text', text: 'HANDBOOK: always check the logs first.' },
+    ]);
+
+    framework.pushEvent(incomingEvent({ channelId: 'slack:D2', text: 'hi', channelType: 'im' }));
+    await framework.runUntilIdle();
+
+    const fork = framework.getAgent('conversation-slack-D2-g1')!;
+    const { messages } = await fork.getContextManager().compile();
+    assert.ok(
+      messages.some((m) => JSON.stringify(m.content).includes('HANDBOOK')),
+      'fork should inherit trunk context',
+    );
+
+    await framework.stop();
+  });
+
+  it('idle TTL runs a closure turn, unbinds, and the next message spawns g2', async () => {
+    membrane.pushResponse(createMockResponse([{ type: 'text', text: 'hello!' }]));
+    const framework = await makeFramework({ idleTtlMs: 1 });
+
+    framework.pushEvent(incomingEvent({ channelId: 'slack:D3', text: 'hi', channelType: 'im' }));
+    await framework.runUntilIdle();
+    const router = framework.getConversationRouter()!;
+    assert.ok(router.getBinding('slack:D3'));
+
+    // Let the TTL elapse, re-arm the sweep throttle, and provide the
+    // closure-turn response.
+    await new Promise((r) => setTimeout(r, 5));
+    (framework as unknown as { lastConversationSweep: number }).lastConversationSweep = 0;
+    membrane.pushResponse(createMockResponse([{ type: 'text', text: 'Final report posted.' }]));
+
+    // Nudge the loop so the sweep runs.
+    framework.pushEvent({ type: 'external-message', source: 'test', content: 'tick', metadata: {} } as unknown as ProcessEvent);
+    await framework.runUntilIdle();
+
+    assert.equal(router.getBinding('slack:D3'), undefined, 'binding should be gone after TTL');
+    const g1 = framework.getAgent('conversation-slack-D3-g1')!;
+    const { messages } = await g1.getContextManager().compile();
+    assert.ok(
+      messages.some((m) => JSON.stringify(m.content).includes('engagement is closing')),
+      'closure prompt should be in the fork context',
+    );
+
+    // Next DM spawns a fresh generation.
+    membrane.pushResponse(createMockResponse([{ type: 'text', text: 'hi again' }]));
+    framework.pushEvent(incomingEvent({ channelId: 'slack:D3', text: 'back again', channelType: 'im' }));
+    await framework.runUntilIdle();
+    assert.ok(framework.getAgent('conversation-slack-D3-g2'), 'rebind spawns generation 2');
+
+    await framework.stop();
+  });
+});

--- a/test/conversation-routing.test.ts
+++ b/test/conversation-routing.test.ts
@@ -10,7 +10,7 @@ import { tmpdir } from 'node:os';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { AgentFramework } from '../src/index.js';
-import type { ProcessEvent } from '../src/index.js';
+import type { ProcessEvent, ConversationRouterConfig, TraceEvent } from '../src/index.js';
 import { MockMembrane, createMockResponse } from './helpers/mock-membrane.js';
 
 function incomingEvent(overrides: {
@@ -49,16 +49,28 @@ describe('Conversation routing', () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  async function makeFramework(conversations: Record<string, unknown> = {}) {
+  async function makeFramework(
+    conversations: Partial<ConversationRouterConfig> = {},
+    storeFile = 'test.chronicle',
+  ) {
     return AgentFramework.create({
-      storePath: join(tempDir, 'test.chronicle'),
+      storePath: join(tempDir, storeFile),
       membrane: membrane.asMembrane(),
       agents: [
         { name: 'trunk', model: 'test-model', systemPrompt: 'You are the trunk.' },
       ],
       modules: [],
-      conversations: { templateAgent: 'trunk', ...conversations } as never,
+      conversations: { templateAgent: 'trunk', ...conversations },
     });
+  }
+
+  /** Make a binding look idle past the TTL and re-arm the sweep throttle —
+   * deterministic expiry instead of racing a 1ms TTL against the wall clock. */
+  function forceExpiry(framework: AgentFramework, channelId: string, idleTtlMs: number) {
+    const binding = framework.getConversationRouter()!.getBinding(channelId);
+    assert.ok(binding, `binding for ${channelId} should exist before forcing expiry`);
+    binding!.lastActivity = Date.now() - idleTtlMs - 1_000;
+    (framework as unknown as { lastConversationSweep: number }).lastConversationSweep = 0;
   }
 
   it('rejects an unknown template agent at creation', async () => {
@@ -169,19 +181,20 @@ describe('Conversation routing', () => {
     await framework.stop();
   });
 
-  it('idle TTL runs a closure turn, unbinds, and the next message spawns g2', async () => {
+  it('idle TTL runs a closure turn, unbinds, disposes the fork, and the next message spawns g2', async () => {
+    const IDLE_TTL_MS = 60_000;
     membrane.pushResponse(createMockResponse([{ type: 'text', text: 'hello!' }]));
-    const framework = await makeFramework({ idleTtlMs: 1 });
+    const framework = await makeFramework({ idleTtlMs: IDLE_TTL_MS });
 
     framework.pushEvent(incomingEvent({ channelId: 'slack:D3', text: 'hi', channelType: 'im' }));
     await framework.runUntilIdle();
     const router = framework.getConversationRouter()!;
-    assert.ok(router.getBinding('slack:D3'));
+    assert.ok(router.getBinding('slack:D3'), 'spawn should leave a live binding');
+    const g1 = framework.getAgent('conversation-slack-D3-g1');
+    assert.ok(g1, 'g1 fork should exist after spawn');
 
-    // Let the TTL elapse, re-arm the sweep throttle, and provide the
-    // closure-turn response.
-    await new Promise((r) => setTimeout(r, 5));
-    (framework as unknown as { lastConversationSweep: number }).lastConversationSweep = 0;
+    // Force expiry deterministically and provide the closure-turn response.
+    forceExpiry(framework, 'slack:D3', IDLE_TTL_MS);
     membrane.pushResponse(createMockResponse([{ type: 'text', text: 'Final report posted.' }]));
 
     // Nudge the loop so the sweep runs.
@@ -189,11 +202,14 @@ describe('Conversation routing', () => {
     await framework.runUntilIdle();
 
     assert.equal(router.getBinding('slack:D3'), undefined, 'binding should be gone after TTL');
-    const g1 = framework.getAgent('conversation-slack-D3-g1')!;
-    const { messages } = await g1.getContextManager().compile();
+    const { messages } = await g1!.getContextManager().compile();
     assert.ok(
       messages.some((m) => JSON.stringify(m.content).includes('engagement is closing')),
       'closure prompt should be in the fork context',
+    );
+    assert.equal(
+      framework.getAgent('conversation-slack-D3-g1'), null,
+      'closed fork should be disposed once its closure turn finished',
     );
 
     // Next DM spawns a fresh generation.
@@ -201,6 +217,70 @@ describe('Conversation routing', () => {
     framework.pushEvent(incomingEvent({ channelId: 'slack:D3', text: 'back again', channelType: 'im' }));
     await framework.runUntilIdle();
     assert.ok(framework.getAgent('conversation-slack-D3-g2'), 'rebind spawns generation 2');
+
+    await framework.stop();
+  });
+
+  it('restart does not reuse generation names or re-seed an existing namespace', async () => {
+    membrane.pushResponse(createMockResponse([{ type: 'text', text: 'noted' }]));
+    const fw1 = await makeFramework({}, 'restart.chronicle');
+    fw1.getAgent('trunk')!.getContextManager().addMessage('user', [
+      { type: 'text', text: 'HANDBOOK-V1: always check the logs first.' },
+    ]);
+
+    fw1.pushEvent(incomingEvent({ channelId: 'slack:D9', text: 'case one', channelType: 'im' }));
+    await fw1.runUntilIdle();
+    assert.ok(fw1.getAgent('conversation-slack-D9-g1'), 'first engagement spawns g1');
+    await fw1.stop();
+
+    // Restart: same store, fresh framework. The generation counter must come
+    // back from Chronicle so the next engagement is g2 in a fresh namespace.
+    membrane.pushResponse(createMockResponse([{ type: 'text', text: 'fresh' }]));
+    const fw2 = await makeFramework({}, 'restart.chronicle');
+    fw2.pushEvent(incomingEvent({ channelId: 'slack:D9', text: 'case two', channelType: 'im' }));
+    await fw2.runUntilIdle();
+
+    assert.equal(fw2.getAgent('conversation-slack-D9-g1'), null, 'g1 must not be resurrected');
+    const g2 = fw2.getAgent('conversation-slack-D9-g2');
+    assert.ok(g2, 'restart spawns the next generation, not generation 1 again');
+
+    const { messages } = await g2!.getContextManager().compile();
+    const handbookCopies = messages.filter(
+      (m) => JSON.stringify(m.content).includes('HANDBOOK-V1'),
+    ).length;
+    assert.equal(handbookCopies, 1, 'fresh namespace is seeded with exactly one template copy');
+    assert.ok(
+      !messages.some((m) => JSON.stringify(m.content).includes('case one')),
+      'a new generation must not inherit the previous engagement history',
+    );
+
+    await fw2.stop();
+  });
+
+  it('forks cannot open channels or close foreign ones', async () => {
+    membrane.pushResponse(createMockResponse([{ type: 'text', text: 'hi' }]));
+    const framework = await makeFramework();
+    framework.pushEvent(incomingEvent({ channelId: 'slack:C7', text: 'bot, help', mentioned: true }));
+    await framework.runUntilIdle();
+    const forkName = 'conversation-slack-C7-g1';
+    assert.ok(framework.getAgent(forkName), 'fork should exist');
+
+    const failures: Array<{ tool: string; error: string }> = [];
+    framework.onTrace((e: TraceEvent) => {
+      if (e.type === 'tool:failed') {
+        failures.push({ tool: (e as { tool: string }).tool, error: (e as { error: string }).error });
+      }
+    });
+
+    const fw = framework as unknown as {
+      dispatchChannelToolCall(agentName: string, call: { id: string; name: string; input: Record<string, unknown> }): void;
+    };
+    fw.dispatchChannelToolCall(forkName, { id: 't1', name: 'channel_open', input: { channelId: 'slack:C8' } });
+    fw.dispatchChannelToolCall(forkName, { id: 't2', name: 'channel_close', input: { channelId: 'slack:C8' } });
+
+    assert.equal(failures.length, 2, 'both foreign channel operations should be rejected');
+    assert.ok(failures[0]!.error.includes('cannot open channels'), 'channel_open is rejected outright');
+    assert.ok(failures[1]!.error.includes('closing slack:C8 is not allowed'), 'foreign channel_close is rejected');
 
     await framework.stop();
   });

--- a/test/helpers/mock-membrane.ts
+++ b/test/helpers/mock-membrane.ts
@@ -1,0 +1,184 @@
+/**
+ * Shared test helpers: mock Membrane + yielding stream.
+ *
+ * Mirrors the local mocks in framework.test.ts (kept duplicated there to
+ * avoid churn); new test files should import from here.
+ */
+
+import type {
+  NormalizedRequest,
+  NormalizedResponse,
+  ContentBlock,
+  YieldingStream,
+  StreamEvent,
+} from '@animalabs/membrane';
+
+export function createMockResponse(
+  content: ContentBlock[],
+  stopReason: NormalizedResponse['stopReason'] = 'end_turn',
+): NormalizedResponse {
+  const rawText = content
+    .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
+    .map((b) => b.text)
+    .join('');
+
+  const toolCalls = content
+    .filter((b): b is ContentBlock & { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> } => b.type === 'tool_use')
+    .map((b) => ({ id: b.id, name: b.name, input: b.input }));
+
+  return {
+    content,
+    stopReason,
+    rawAssistantText: rawText,
+    toolCalls,
+    toolResults: [],
+    usage: { inputTokens: 10, outputTokens: 5 },
+    details: {
+      raw: {},
+    },
+  } as unknown as NormalizedResponse;
+}
+
+/**
+ * Mock yielding stream: first response starts the stream, subsequent
+ * responses resume after each tool round.
+ */
+export class MockYieldingStream implements YieldingStream {
+  private events: StreamEvent[] = [];
+  private _done = false;
+  private _isWaitingForTools = false;
+  private _pendingToolCallIds: string[] = [];
+  private _toolDepth = 0;
+  private pendingResolve: (() => void) | null = null;
+  receivedToolResults: unknown[][] = [];
+
+  constructor(private responses: NormalizedResponse[]) {
+    this.processResponse(0);
+  }
+
+  private processResponse(index: number): void {
+    const response = this.responses[index];
+    if (!response) {
+      this._done = true;
+      return;
+    }
+
+    const text = response.rawAssistantText;
+    if (text) {
+      this.events.push({
+        type: 'block',
+        event: { event: 'block_start', index: 0, block: { type: 'text' } },
+      } as StreamEvent);
+      this.events.push({
+        type: 'tokens',
+        content: text,
+        meta: { type: 'text', visible: true, blockIndex: 0 },
+      } as StreamEvent);
+      this.events.push({
+        type: 'block',
+        event: { event: 'block_complete', index: 0, block: { type: 'text', content: text } },
+      } as StreamEvent);
+    }
+
+    if (response.usage) {
+      this.events.push({ type: 'usage', usage: response.usage } as StreamEvent);
+    }
+
+    if (response.toolCalls.length > 0) {
+      this._isWaitingForTools = true;
+      this._pendingToolCallIds = response.toolCalls.map((c) => c.id);
+      this.events.push({
+        type: 'tool-calls',
+        calls: response.toolCalls.map((tc) => ({
+          id: tc.id,
+          name: tc.name,
+          input: tc.input as Record<string, unknown>,
+        })),
+        context: {
+          rawText: '',
+          preamble: '',
+          depth: this._toolDepth,
+          previousResults: [],
+          accumulated: '',
+        },
+      } as StreamEvent);
+    } else {
+      this.events.push({ type: 'complete', response } as StreamEvent);
+      this._done = true;
+    }
+  }
+
+  provideToolResults(results: unknown[]): void {
+    if (!this._isWaitingForTools) throw new Error('Not waiting for tools');
+    this.receivedToolResults.push(results);
+    this._isWaitingForTools = false;
+    this._pendingToolCallIds = [];
+    this._toolDepth++;
+    this.processResponse(this._toolDepth);
+    if (this.pendingResolve) {
+      const resolve = this.pendingResolve;
+      this.pendingResolve = null;
+      resolve();
+    }
+  }
+
+  cancel(): void {
+    this._done = true;
+    this.events.push({ type: 'aborted', reason: 'user' } as StreamEvent);
+    if (this.pendingResolve) {
+      const resolve = this.pendingResolve;
+      this.pendingResolve = null;
+      resolve();
+    }
+  }
+
+  get isWaitingForTools() { return this._isWaitingForTools; }
+  get pendingToolCallIds() { return [...this._pendingToolCallIds]; }
+  get toolDepth() { return this._toolDepth; }
+
+  async *[Symbol.asyncIterator](): AsyncIterator<StreamEvent> {
+    while (true) {
+      while (this.events.length > 0) {
+        const event = this.events.shift()!;
+        yield event;
+        if (event.type === 'complete' || event.type === 'error' || event.type === 'aborted') {
+          return;
+        }
+      }
+      if (this._done) return;
+      await new Promise<void>((resolve) => { this.pendingResolve = resolve; });
+    }
+  }
+}
+
+export class MockMembrane {
+  responses: NormalizedResponse[] = [];
+  calls: NormalizedRequest[] = [];
+  lastStream: MockYieldingStream | null = null;
+  private responseIndex = 0;
+
+  pushResponse(response: NormalizedResponse): void {
+    this.responses.push(response);
+  }
+
+  async complete(request: NormalizedRequest): Promise<NormalizedResponse> {
+    this.calls.push(request);
+    if (this.responseIndex >= this.responses.length) {
+      return createMockResponse([{ type: 'text', text: 'Default response' }]);
+    }
+    return this.responses[this.responseIndex++];
+  }
+
+  streamYielding(request: NormalizedRequest, _options?: unknown): YieldingStream {
+    this.calls.push(request);
+    const remaining = this.responses.slice(this.responseIndex);
+    this.responseIndex = this.responses.length;
+    const stream = new MockYieldingStream(remaining);
+    this.lastStream = stream;
+    return stream;
+  }
+
+  asMembrane(): import('@animalabs/membrane').Membrane {
+    return this as unknown as import('@animalabs/membrane').Membrane;
+  }
+}


### PR DESCRIPTION
## What

Opt-in routing layer that gives each Slack/Discord/Zulip conversation (channel or DM) its own persistent agent, forked from a dormant "trunk" template. Designed for interactive, per-engagement agents (bug-investigation bots, support agents) where one shared conversation context doesn't scale past a single channel.

Enabled via a new `FrameworkConfig.conversations` block; **zero behavior change when unset**:

```ts
conversations: {
  templateAgent: 'trunk',                            // required, must name a configured agent
  bind:    { dm: 'always', channel: 'mention' },     // when an unbound channel acquires a fork (defaults shown)
  trigger: { dm: 'always', channel: 'mention' },     // when a message triggers inference vs. just landing in context
  idleTtlMs: 12 * 60 * 60 * 1000,                    // engagement lifetime
  closurePrompt: '…',                                // final turn on expiry (default provided)
  agentPrefix: 'conversation',
  strategyFactory: () => new MyStrategy(),           // fresh compression strategy per fork
}
```

## How

- **`ConversationRouter`** (`src/mcpl/conversation-router.ts`) — a lookup table plus policy, deliberately no LLM in the routing path. Two-phase spawn: `route()` proposes, the framework spawns the fork, `bind()` commits — a failed spawn self-heals on the next qualifying message.
- **Forks are namespace-copy agents** (the SubagentModule pattern): persistent Agent + ContextManager under `conversations/{name}` (e.g. `conversation-slack-C123-g1`), seeded by copying the template's compiled context. Survives restarts via Chronicle.
- **Bind vs trigger split**: in a bound channel, ambient (non-mention) messages land in the fork's context without triggering inference — a busy channel is all case input, but only mentions demand a reply. Composes with per-server `shouldTriggerInference`.
- **Scoping**: fork context injections are filtered to the home channel; `channel_publish` defaults to and is locked to it (foreign channel IDs get an error tool-result). The home mapping outlives the binding so the closure turn still publishes correctly. Broadcast inference excludes forks.
- **Lifecycle**: once-per-minute sweep; idle TTL → closure turn → unbind. The next mention spawns generation+1 from the *current* trunk, so template/handbook updates propagate between engagements without trunk accumulation.
- New trace events: `mcpl:conversation-spawned` / `-spawn-failed` / `-unrouted` / `-binding-orphaned` / `-closed`.

## Known v1 limitations

- Bindings are in-memory: a restart drops active engagements (fork contexts persist; the next mention starts a fresh generation rather than resuming). Persistable later via a Chronicle state slot.
- Routing granularity is the channel — threads within a channel share one fork.

## Tests

154/154 (`npm run build && node --test dist/test/*.test.js`): 137 pre-existing + 11 router unit tests (bind/trigger matrix, two-phase spawn, TTL, generations, DM classification) + 6 integration tests (DM spawn + trunk isolation, mention/no-mention channel behavior, ambient non-trigger, template context inheritance, TTL closure + g2 respawn). Shared `MockMembrane` extracted to `test/helpers/mock-membrane.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)