### PR TITLE
fix(mcpl): attribute host-managed state to its feature set, not the first stateful one

### DIFF
--- a/src/framework.ts
+++ b/src/framework.ts
@@ -3894,14 +3894,20 @@ export class AgentFramework {
     const startTime = Date.now();
     const args = (call.input && typeof call.input === 'object') ? call.input as Record<string, unknown> : {};
 
-    // Build state params for stateful tools (Step 8)
+    // Build state params for stateful tools (Step 8).
+    // Host-managed state is single-valued per server, so inject the host-managed
+    // set's `state` for any call; otherwise fall back to a server-managed set's
+    // opaque `checkpoint`. Never blindly pick "first stateful" — when a server
+    // mixes host-managed (e.g. a feed) and server-managed (e.g. post/undo) sets,
+    // that misattributes the feed's state.
     let stateParams: { state?: unknown; checkpoint?: string } | undefined;
     if (this.checkpointManager) {
-      const fs = this.checkpointManager.getStatefulFeatureSet(serverId);
-      if (fs) {
-        if (this.checkpointManager.isHostManaged(serverId, fs)) {
-          stateParams = { state: this.checkpointManager.getCurrentState(serverId, fs) };
-        } else {
+      const hostFs = this.checkpointManager.getHostManagedFeatureSet(serverId);
+      if (hostFs) {
+        stateParams = { state: this.checkpointManager.getCurrentState(serverId, hostFs) };
+      } else {
+        const fs = this.checkpointManager.getStatefulFeatureSet(serverId);
+        if (fs) {
           const cp = this.checkpointManager.getCurrentCheckpoint(serverId, fs);
           if (cp) stateParams = { checkpoint: cp };
         }
@@ -3913,10 +3919,17 @@ export class AgentFramework {
         const durationMs = Date.now() - startTime;
         this.emitTrace({ type: 'tool:completed', module: `mcpl:${serverId}`, tool: toolName, callId: call.id, durationMs });
 
-        // Record checkpoint from stateful tool response (Step 8)
+        // Record checkpoint from stateful tool response (Step 8).
+        // Attribute to the set the server tagged (result.state.featureSet) first;
+        // else the host-managed set (host-managed checkpoints carry data/patch);
+        // else the single stateful set. Avoids recording a feed checkpoint onto a
+        // server-managed set just because it registered first.
         if (result.state && this.checkpointManager) {
-          const fs = this.checkpointManager.getStatefulFeatureSet(serverId);
-          if (fs) {
+          const tagged = result.state.featureSet;
+          const fs = tagged
+            ?? this.checkpointManager.getHostManagedFeatureSet(serverId)
+            ?? this.checkpointManager.getStatefulFeatureSet(serverId);
+          if (fs && this.checkpointManager.isStateful(serverId, fs)) {
             this.checkpointManager.recordCheckpoint(serverId, fs, result.state);
           }
         }

--- a/src/mcpl/checkpoint-manager.ts
+++ b/src/mcpl/checkpoint-manager.ts
@@ -368,6 +368,22 @@ export class CheckpointManager {
     return null;
   }
 
+  /**
+   * Get the server's host-managed (hostState) feature set. Host-managed state is
+   * single-valued by protocol (one unkeyed `state` per tool call), so there is at
+   * most one such set — return it so its state is threaded correctly even when the
+   * server also declares server-managed (rollback) sets. Returns null if none.
+   */
+  getHostManagedFeatureSet(serverId: string): string | null {
+    const prefix = `${serverId}:`;
+    for (const [key, tree] of this.trees) {
+      if (key.startsWith(prefix) && tree.hostState) {
+        return key.slice(prefix.length);
+      }
+    }
+    return null;
+  }
+
   // ==========================================================================
   // Rollback
   // ==========================================================================

--- a/src/mcpl/types.ts
+++ b/src/mcpl/types.ts
@@ -391,6 +391,13 @@ export interface StateCheckpoint {
   parent: string | null;
 
   /**
+   * Owning feature set, when the server tags it. Authoritative signal for
+   * attributing this checkpoint — lets the host record it to the right set
+   * instead of guessing when a server has more than one stateful feature set.
+   */
+  featureSet?: string;
+
+  /**
    * Full state data (for host-managed state).
    * Mutually exclusive with `patch`.
    */

--- a/test/checkpoint-attribution.test.ts
+++ b/test/checkpoint-attribution.test.ts
@@ -1,0 +1,45 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { CheckpointManager } from '../src/mcpl/checkpoint-manager.js';
+
+// Minimal in-memory JsStore covering the slots CheckpointManager touches.
+function fakeStore(): any {
+  const m = new Map<string, unknown>();
+  return {
+    registerState(_opts: { id: string; strategy: string }) {},
+    getStateJson(id: string) { return m.has(id) ? m.get(id) : null; },
+    setStateJson(id: string, v: unknown) { m.set(id, v); },
+  };
+}
+
+describe('CheckpointManager host-managed attribution', () => {
+  it('threads the host-managed set even when a server-managed set registers first', () => {
+    const cm = new CheckpointManager(fakeStore(), () => {});
+    const srv = 'xgate';
+    // Mirror x-mcpl's declaration order: x.post (rollback) BEFORE x.feed (host).
+    cm.registerFeatureSet(srv, 'x.post', { hostState: false, rollback: true });
+    cm.registerFeatureSet(srv, 'x.feed', { hostState: true, rollback: true });
+    cm.registerFeatureSet(srv, 'x.dm', { hostState: false, rollback: true });
+
+    // The old blind "first stateful" pick returns x.post (the bug); the fix
+    // selects the host-managed set for state threading.
+    assert.equal(cm.getStatefulFeatureSet(srv), 'x.post');
+    assert.equal(cm.getHostManagedFeatureSet(srv), 'x.feed');
+
+    // A tagged feed checkpoint lands on x.feed and is retrievable for injection.
+    cm.recordCheckpoint(srv, 'x.feed', {
+      checkpoint: '1', parent: null, featureSet: 'x.feed', data: { sources: ['alice'] },
+    });
+    assert.deepEqual(cm.getCurrentState(srv, 'x.feed'), { sources: ['alice'] });
+    // The server-managed set is not polluted by the feed's state.
+    assert.equal(cm.getCurrentState(srv, 'x.post'), undefined);
+  });
+
+  it('getHostManagedFeatureSet is null when the server has no host-managed set', () => {
+    const cm = new CheckpointManager(fakeStore(), () => {});
+    cm.registerFeatureSet('s', 'x.post', { hostState: false, rollback: true });
+    assert.equal(cm.getHostManagedFeatureSet('s'), null);
+    assert.equal(cm.getStatefulFeatureSet('s'), 'x.post');
+  });
+});


### PR DESCRIPTION
## Problem

A server with **more than one stateful feature set** breaks host-managed state.

The tool-call state path injects/records state for `getStatefulFeatureSet()` — the **first** set registered with `rollback || hostState` — regardless of which set the state actually belongs to (`framework.ts` inject ~3900, record ~3918).

So a server that declares a **host-managed** set (e.g. an `x.feed` with `hostState: true`) *after* a **server-managed** rollback set (e.g. `x.post` with `rollback: true`) has its feed state misattributed:
- the wrong set's state is injected into `tools/call`, and
- the feed's returned checkpoint is recorded onto the rollback set.

Net effect: the feed silently reads empty. (Hit in practice wiring the xgate/x-mcpl feed into a connectome-host agent.)

## Fix

Host-managed state is single-valued per server (one unkeyed `state` per `tools/call`), so:
- **inject** the host-managed set's `state` for any call (`getHostManagedFeatureSet`), falling back to a server-managed set's opaque `checkpoint`;
- **record** `result.state` to its explicit `featureSet` tag when present, else the host-managed set, else the single stateful set.

This mirrors the analogous mcpl-harness fix ("attribute host state per feature set, never guess"). Servers that tag `result.state.featureSet` (and their tools) get exact attribution; the explicit tag wins.

## Compatibility

Backward-compatible: servers with no host-managed or tagged state behave exactly as before (still fall through to `getStatefulFeatureSet`). All 158 existing tests pass.

## Changes
- `checkpoint-manager.ts`: add `getHostManagedFeatureSet(serverId)`.
- `types.ts`: add `StateCheckpoint.featureSet`.
- `framework.ts`: host-managed-aware inject + tag-aware record.
- `test/checkpoint-attribution.test.ts`: regression test capturing the exact scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)