### PR TITLE
feat(mcpl): connection-lifecycle trace events + exponential reconnect backoff

### DIFF
--- a/src/framework.ts
+++ b/src/framework.ts
@@ -4006,6 +4006,17 @@ export class AgentFramework {
         // Fail-open: log and continue with remaining servers
         const err = error instanceof Error ? error : new Error(String(error));
         console.error(`Failed to connect MCPL server "${config.id}":`, err.message);
+        // Reaching this catch means no stub was created, so nothing will
+        // retry — except in the edge case where addServer succeeded (with a
+        // reconnecting stub) and a later setup step threw; config.reconnect
+        // is the best cheap approximation of that.
+        this.emitTrace({
+          type: 'mcpl:server-connect-failed',
+          serverId: config.id,
+          error: err.message,
+          attempt: 0,
+          willRetry: config.reconnect === true,
+        });
       }
     }
 
@@ -4109,14 +4120,62 @@ export class AgentFramework {
     });
 
     // Also refresh tools on reconnect (server may have different tools)
-    connection.on('reconnect', () => {
+    connection.on('reconnect', (info?: { attempts?: number }) => {
       this.handleToolsListChanged(connection.id);
+      this.emitTrace({
+        type: 'mcpl:server-reconnected',
+        serverId: connection.id,
+        attempts: info?.attempts ?? 0,
+      });
+      // Mirror the module:removed emitted on 'close' so module-lifecycle
+      // consumers see the server come back, not just vanish.
+      this.emitTrace({ type: 'module:added', moduleName: `mcpl:${connection.id}` });
+    });
+
+    // Surface connect/reconnect failures. Before these traces existed the
+    // only receipt was a console.error on the host's own stderr — invisible
+    // unless someone ssh'd in and read the process log.
+    connection.on('connect-failed', (params: { error: string; attempt: number }) => {
+      this.emitTrace({
+        type: 'mcpl:server-connect-failed',
+        serverId: connection.id,
+        error: params.error,
+        attempt: params.attempt,
+        willRetry: connection.willReconnect,
+      });
+    });
+    connection.on('reconnect-failed', (params: { error: string; attempt: number }) => {
+      this.emitTrace({
+        type: 'mcpl:server-connect-failed',
+        serverId: connection.id,
+        error: params.error,
+        attempt: params.attempt,
+        willRetry: connection.willReconnect,
+      });
+    });
+
+    // Connection-level errors (e.g. child process 'error' after spawn).
+    // Attaching this listener also keeps an unhandled EventEmitter 'error'
+    // from crashing the host process.
+    connection.on('error', (err: Error) => {
+      this.emitTrace({
+        type: 'mcpl:server-error',
+        serverId: connection.id,
+        error: err.message,
+      });
     });
 
     // Cleanup on disconnect
-    connection.on('close', () => {
+    connection.on('close', (code?: number | null, signal?: string | null) => {
       this.featureSetManager?.removeServer(connection.id);
       this.checkpointManager?.removeServer(connection.id);
+      this.emitTrace({
+        type: 'mcpl:server-closed',
+        serverId: connection.id,
+        code: code ?? null,
+        signal: signal ?? null,
+        willReconnect: connection.willReconnect,
+      });
       this.emitTrace({ type: 'module:removed', moduleName: `mcpl:${connection.id}` });
     });
   }

--- a/src/mcpl/server-connection.ts
+++ b/src/mcpl/server-connection.ts
@@ -73,6 +73,9 @@ interface PendingRequest {
  * - `'feature-sets-changed'` — Server sent `featureSets/changed`
  * - `'error'`              — Connection-level error
  * - `'close'`              — Connection closed
+ * - `'connect-failed'`     — Initial connect failed; background retry scheduled
+ * - `'reconnect-failed'`   — A background reconnect attempt failed; next retry scheduled
+ * - `'reconnect'`          — Background reconnect succeeded
  */
 export class McplServerConnection extends EventEmitter {
   /** Unique server identifier from config. */
@@ -97,7 +100,17 @@ export class McplServerConnection extends EventEmitter {
   private hostCapabilities: McplHostCapabilities | null = null;
   private reconnectEnabled = false;
   private reconnectIntervalMs = 5000;
+  private reconnectMaxIntervalMs = 300_000;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Consecutive failed connect attempts since the last successful handshake.
+   *  Drives the exponential backoff and is reported on reconnect events. */
+  private reconnectAttempts = 0;
+
+  /** Whether a background reconnect loop will revive this connection after a
+   *  drop. False once close() has been called (explicit close stops retrying). */
+  get willReconnect(): boolean {
+    return this.reconnectEnabled;
+  }
 
   /**
    * Private constructor. Use `McplServerConnection.connect()` instead.
@@ -174,6 +187,7 @@ export class McplServerConnection extends EventEmitter {
       connection.hostCapabilities = hostCapabilities;
       connection.reconnectEnabled = true;
       connection.reconnectIntervalMs = config.reconnectIntervalMs ?? 5000;
+      connection.reconnectMaxIntervalMs = config.reconnectMaxIntervalMs ?? 300_000;
     }
 
     return connection;
@@ -281,7 +295,12 @@ export class McplServerConnection extends EventEmitter {
 
       // Non-blocking start: create a disconnected stub that will reconnect in background
       console.error(`MCPL server "${config.id}" initial connect failed, will retry:`, (error as Error).message);
-      return McplServerConnection.createDisconnectedStub(config, hostCapabilities);
+      const stub = McplServerConnection.createDisconnectedStub(config, hostCapabilities);
+      // Surface the initial failure. The event is buffered by the emit()
+      // override until the host wires listeners and calls ready(), so it is
+      // not lost in the window before wireMcplEvents runs.
+      stub.emit('connect-failed', { error: (error as Error).message, attempt: 0 });
+      return stub;
     }
   }
 
@@ -301,6 +320,8 @@ export class McplServerConnection extends EventEmitter {
     stub.hostCapabilities = hostCapabilities;
     stub.reconnectEnabled = true;
     stub.reconnectIntervalMs = config.reconnectIntervalMs ?? 5000;
+    stub.reconnectMaxIntervalMs = config.reconnectMaxIntervalMs ?? 300_000;
+    stub.reconnectAttempts = 1; // the initial connect already failed
 
     // Schedule background reconnect
     stub.scheduleReconnect();
@@ -457,14 +478,26 @@ export class McplServerConnection extends EventEmitter {
 
   /**
    * Schedule a background reconnection attempt.
+   *
+   * Delay grows exponentially with consecutive failures (base
+   * `reconnectIntervalMs`, doubling per failure, capped at
+   * `reconnectMaxIntervalMs`) with ±25% jitter so a fleet of servers that
+   * died together doesn't thundering-herd the same instant. The counter
+   * resets on a successful handshake, so a later disconnect starts over at
+   * the base interval.
    */
   private scheduleReconnect(): void {
     if (!this.reconnectEnabled || this.reconnectTimer) return;
 
+    const exponent = Math.max(0, Math.min(this.reconnectAttempts - 1, 30));
+    const uncapped = this.reconnectIntervalMs * 2 ** exponent;
+    const capped = Math.min(uncapped, this.reconnectMaxIntervalMs);
+    const delay = capped * (0.75 + Math.random() * 0.5);
+
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null;
       this.attemptReconnect();
-    }, this.reconnectIntervalMs);
+    }, delay);
   }
 
   /**
@@ -475,6 +508,10 @@ export class McplServerConnection extends EventEmitter {
    */
   private async attemptReconnect(): Promise<void> {
     if (!this.reconnectEnabled || !this.config || !this.hostCapabilities) return;
+
+    // Ordinal of this attempt: 0 was the initial connect, so the Nth retry
+    // reports attempt N (reconnectAttempts counts failures so far).
+    const attempt = Math.max(1, this.reconnectAttempts);
 
     try {
       const { transport, capabilities } = await McplServerConnection.handshake(
@@ -494,9 +531,12 @@ export class McplServerConnection extends EventEmitter {
       this.readyFlag = true;
 
       console.error(`MCPL server "${this.id}" reconnected successfully`);
-      this.emit('reconnect');
+      this.reconnectAttempts = 0;
+      this.emit('reconnect', { attempts: attempt });
     } catch (error) {
       console.error(`MCPL server "${this.id}" reconnect failed:`, (error as Error).message);
+      this.reconnectAttempts = attempt + 1;
+      this.emit('reconnect-failed', { error: (error as Error).message, attempt });
       this.scheduleReconnect();
     }
   }

--- a/src/mcpl/types.ts
+++ b/src/mcpl/types.ts
@@ -234,10 +234,18 @@ export interface McplServerConfig {
   reconnect?: boolean;
 
   /**
-   * Interval between reconnection attempts in milliseconds.
+   * Base interval between reconnection attempts in milliseconds.
+   * The actual delay doubles with each consecutive failure (with ±25% jitter)
+   * up to `reconnectMaxIntervalMs`, and resets after a successful handshake.
    * Default: 5000 (5 seconds).
    */
   reconnectIntervalMs?: number;
+
+  /**
+   * Ceiling for the exponential reconnect backoff in milliseconds.
+   * Default: 300000 (5 minutes).
+   */
+  reconnectMaxIntervalMs?: number;
 
   /**
    * Optional callback to filter which incoming channel messages should trigger

--- a/src/types/trace.ts
+++ b/src/types/trace.ts
@@ -270,6 +270,40 @@ export type TraceEvent =
       type: 'mcpl:conversation-disposed';
       agentName: string;
       channelId?: string;
+    })
+
+  // MCPL server connection lifecycle (spawn / handshake / reconnect health).
+  // Previously these outcomes were visible only on the host process's own
+  // stderr, so a server that lost the boot handshake race just went missing.
+  | (TraceEventBase & {
+      type: 'mcpl:server-connect-failed';
+      serverId: string;
+      error: string;
+      /** Ordinal of the failed attempt: 0 is the initial connect, N is the Nth background retry. */
+      attempt: number;
+      /** True when a background reconnect loop will keep retrying. */
+      willRetry: boolean;
+    })
+  | (TraceEventBase & {
+      type: 'mcpl:server-reconnected';
+      serverId: string;
+      /** How many attempts the reconnect loop needed (1 = first retry succeeded). */
+      attempts: number;
+    })
+  | (TraceEventBase & {
+      type: 'mcpl:server-closed';
+      serverId: string;
+      /** Child process exit code, or null when killed by signal / closed explicitly. */
+      code: number | null;
+      /** Signal that terminated the child, if any. */
+      signal: string | null;
+      /** True when a background reconnect loop will revive the connection. */
+      willReconnect: boolean;
+    })
+  | (TraceEventBase & {
+      type: 'mcpl:server-error';
+      serverId: string;
+      error: string;
     });
 
 /**

--- a/test/fixtures/flaky-mcpl-server.mjs
+++ b/test/fixtures/flaky-mcpl-server.mjs
@@ -1,0 +1,39 @@
+// Minimal MCP server for reconnect tests.
+//
+// Availability is controlled by a flag file passed as argv[2]: when the file
+// does not exist the process exits(1) immediately (simulating a server that
+// loses the boot race); when it exists the process answers the MCP
+// `initialize` handshake and stays alive.
+//
+// Receiving a `tools/list` request makes it exit(7) — tests use this as a
+// remote-controlled crash to exercise the unexpected-exit reconnect path.
+import { existsSync } from 'node:fs';
+import { createInterface } from 'node:readline';
+
+const flagFile = process.argv[2];
+if (flagFile && !existsSync(flagFile)) process.exit(1);
+
+const rl = createInterface({ input: process.stdin });
+rl.on('line', (line) => {
+  let msg;
+  try {
+    msg = JSON.parse(line);
+  } catch {
+    return;
+  }
+  if (msg.method === 'initialize') {
+    process.stdout.write(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: msg.id,
+        result: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          serverInfo: { name: 'flaky-mcpl-server', version: '0.0.0' },
+        },
+      }) + '\n',
+    );
+  } else if (msg.method === 'tools/list') {
+    process.exit(7);
+  }
+});

--- a/test/mcpl-reconnect-events.test.ts
+++ b/test/mcpl-reconnect-events.test.ts
@@ -1,0 +1,139 @@
+/**
+ * McplServerConnection reconnect lifecycle events.
+ *
+ * Covers the event contract the framework's wireMcplEvents turns into
+ * mcpl:server-* trace events:
+ *   - 'connect-failed'   buffered on the disconnected stub until ready()
+ *   - 'reconnect-failed' per failed background attempt, with attempt ordinal
+ *   - 'reconnect'        on revival, with the attempt count that succeeded
+ *   - 'close'            with (code, signal) on unexpected child exit
+ */
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { McplServerConnection } from '../src/mcpl/server-connection.js';
+import type { McplHostCapabilities, McplServerConfig } from '../src/mcpl/types.js';
+
+const FIXTURE = join(import.meta.dirname, 'fixtures/flaky-mcpl-server.mjs');
+const TMP_DIR = join(import.meta.dirname, '../.test-tmp-reconnect');
+const FLAG_FILE = join(TMP_DIR, 'server-healthy');
+
+const HOST_CAPS: McplHostCapabilities = {
+  version: '0.4',
+  pushEvents: true,
+  contextHooks: { beforeInference: true, afterInference: { blocking: true } },
+  featureSets: true,
+};
+
+function makeConfig(overrides?: Partial<McplServerConfig>): McplServerConfig {
+  return {
+    id: 'flaky',
+    command: process.execPath,
+    args: [FIXTURE, FLAG_FILE],
+    reconnect: true,
+    reconnectIntervalMs: 50,
+    ...overrides,
+  };
+}
+
+/** Poll until `predicate` returns true or the deadline passes. */
+async function waitFor(predicate: () => boolean, timeoutMs = 5000, label = 'condition'): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error(`Timed out waiting for ${label}`);
+    }
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+let connection: McplServerConnection | null = null;
+
+beforeEach(() => {
+  mkdirSync(TMP_DIR, { recursive: true });
+});
+
+afterEach(async () => {
+  await connection?.close();
+  connection = null;
+  if (existsSync(TMP_DIR)) rmSync(TMP_DIR, { recursive: true, force: true });
+});
+
+describe('McplServerConnection — reconnect lifecycle events', () => {
+  it('buffers connect-failed on the stub, emits reconnect-failed per retry, then reconnect on recovery', async () => {
+    // Flag file absent: the initial connect fails and we get a stub.
+    connection = await McplServerConnection.connectWithReconnect(makeConfig(), HOST_CAPS);
+    assert.strictEqual(connection.capabilities, null);
+
+    const connectFailed: Array<{ error: string; attempt: number }> = [];
+    const reconnectFailed: Array<{ error: string; attempt: number }> = [];
+    const reconnected: Array<{ attempts: number }> = [];
+    connection.on('connect-failed', (p: { error: string; attempt: number }) => connectFailed.push(p));
+    connection.on('reconnect-failed', (p: { error: string; attempt: number }) => reconnectFailed.push(p));
+    connection.on('reconnect', (p: { attempts: number }) => reconnected.push(p));
+
+    // The initial failure fired before listeners existed — ready() flushes it.
+    connection.ready();
+    assert.strictEqual(connectFailed.length, 1);
+    assert.strictEqual(connectFailed[0]!.attempt, 0);
+    assert.match(connectFailed[0]!.error, /before handshake/);
+
+    // At least one background retry fails while the server stays down.
+    await waitFor(() => reconnectFailed.length >= 1, 5000, 'first reconnect-failed');
+    assert.strictEqual(reconnectFailed[0]!.attempt, 1);
+
+    // Bring the server up; the next attempt succeeds.
+    writeFileSync(FLAG_FILE, '');
+    await waitFor(() => reconnected.length === 1, 10_000, 'reconnect');
+    assert.ok(
+      reconnected[0]!.attempts >= 2,
+      `reconnect should report the attempt ordinal that succeeded, got ${reconnected[0]!.attempts}`,
+    );
+    assert.strictEqual(connection.willReconnect, true);
+  });
+
+  it('emits close with (code, signal) on unexpected exit, then revives with attempts=1', async () => {
+    writeFileSync(FLAG_FILE, '');
+    connection = await McplServerConnection.connect(makeConfig(), HOST_CAPS);
+
+    const closes: Array<{ code: number | null; signal: string | null }> = [];
+    const reconnected: Array<{ attempts: number }> = [];
+    connection.on('close', (code?: number | null, signal?: string | null) =>
+      closes.push({ code: code ?? null, signal: signal ?? null }));
+    connection.on('reconnect', (p: { attempts: number }) => reconnected.push(p));
+    connection.ready();
+
+    // The fixture exits(7) when it receives tools/list — a remote-controlled
+    // crash. The pending request rejects when the process dies.
+    connection.sendToolsList().catch(() => {});
+
+    await waitFor(() => closes.length === 1, 5000, 'close event');
+    assert.strictEqual(closes[0]!.code, 7);
+    assert.strictEqual(closes[0]!.signal, null);
+    assert.strictEqual(connection.willReconnect, true);
+
+    // The server is still healthy (flag file present), so the first retry wins.
+    await waitFor(() => reconnected.length === 1, 5000, 'reconnect after crash');
+    assert.strictEqual(reconnected[0]!.attempts, 1);
+  });
+
+  it('explicit close() disables reconnect and reports willReconnect=false', async () => {
+    writeFileSync(FLAG_FILE, '');
+    connection = await McplServerConnection.connect(makeConfig(), HOST_CAPS);
+    connection.ready();
+
+    const reconnected: unknown[] = [];
+    connection.on('reconnect', (p: unknown) => reconnected.push(p));
+
+    assert.strictEqual(connection.willReconnect, true);
+    await connection.close();
+    assert.strictEqual(connection.willReconnect, false);
+
+    // No revival after an explicit close.
+    await new Promise((r) => setTimeout(r, 200));
+    assert.strictEqual(reconnected.length, 0);
+    connection = null;
+  });
+});


### PR DESCRIPTION
## Problem

MCPL server connect/reconnect failures are only visible as `console.error` on the host process's own stderr. A server that loses the boot handshake race (e.g. the npx cold-cache race being fixed build-side in Tengro/connectome-cook#7) just goes missing — the first observable symptom is `MCPL server not found` at the routing layer, and diagnosing it means ssh-ing into the box and reading process logs.

## Changes

**New trace events** (`types/trace.ts`), wired in `wireMcplEvents`:

- `mcpl:server-connect-failed` — initial connect **and** each failed background retry, with the attempt ordinal and `willRetry`
- `mcpl:server-reconnected` — with the attempt count that succeeded; also re-emits `module:added` to mirror the `module:removed` from 'close'
- `mcpl:server-closed` — transport exit code/signal and `willReconnect`
- `mcpl:server-error` — transport-level errors

**Connection events** (`server-connection.ts`): the connection now emits `connect-failed` / `reconnect-failed`, and `reconnect` carries an `{ attempts }` payload. The initial failure is emitted on the disconnected stub and buffered by the existing `emit()` override until `ready()`, so it survives the window before the host wires listeners. New `willReconnect` getter.

**Latent crash fix**: nothing ever attached an `'error'` listener to connections, so a post-handshake transport 'error' would throw `ERR_UNHANDLED_ERROR` and take down the host. `wireMcplEvents` now listens (and emits the trace).

**Exponential reconnect backoff**: the fixed `reconnectIntervalMs` polling loop now doubles per consecutive failure with ±25% jitter, capped at a new `reconnectMaxIntervalMs` config field (default 5 min), and resets on a successful handshake. Fixed 5s forever was too chatty for a dead server; a single 30s handshake window with no retry was too fragile for a slow-booting one.

## Tests

New `test/mcpl-reconnect-events.test.ts` with a flag-file-controlled flaky fixture server (`test/fixtures/flaky-mcpl-server.mjs`) covering: buffered connect-failed → reconnect-failed per retry → reconnect on recovery; unexpected exit → close(code, signal) → revival; explicit close() disabling the retry loop.

Full suite passes; the pre-existing `liveness-watchdog` / `event-gate-script` failures and the `phaseChannel` tsc error reproduce identically on clean main (context-manager version skew).

## Companion

conhost-side consumer (per-server log lines + `reconnectMaxIntervalMs` plumbing) is in anima-research/connectome-host — PR linked in comments once open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)