### PR TITLE
fix(mcpl): reconnect re-registration, tools/call timeout, poison-history quarantine

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animalabs/agent-framework",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Multi-agent framework with pluggable modules, persistent state, and concurrent tool execution",
   "repository": {
     "type": "git",

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -219,6 +219,13 @@ interface RewindRecord {
   discordRef?: { channelId: string; messageId: string };
 }
 
+/** Cap an API error message for inline use in a rewind marker: keep enough to
+ *  identify the failure class without pasting a wall of provider JSON into the
+ *  agent's context. */
+function truncateReason(reason: string, max = 160): string {
+  return reason.length <= max ? reason : reason.slice(0, max) + '…';
+}
+
 export class AgentFramework {
   private store: JsStore;
   private ownsStore: boolean;
@@ -258,6 +265,11 @@ export class AgentFramework {
    *  chain (reset when a turn completes without a refusal). Bounds the auto
    *  rewind loop — see refusalHandling + rewindTriggeringTurn. */
   private refusalRewinds: Map<string, number> = new Map();
+  /** Per-agent count of poison-history rewinds performed by the hard-down
+   *  breaker (noteInferenceExhausted). Reset on any successful inference.
+   *  Bounds the automatic quarantine loop the same way refusalRewinds bounds
+   *  the refusal loop, so the breaker can never shed the whole history. */
+  private exhaustionRewinds: Map<string, number> = new Map();
   /** Per-agent current rewind episode: the single consolidated marker's id and
    *  how many turns have been shed so far. One marker per episode, updated in
    *  place (see updateRewindMarker); cleared when the episode ends. */
@@ -1441,15 +1453,24 @@ export class AgentFramework {
    * sits at the tail giving the model something actionable to answer once the
    * refusal clears. Returns the running count.
    */
-  private updateRewindMarker(agent: Agent, category: string): number {
+  private updateRewindMarker(
+    agent: Agent,
+    category: string,
+    cause: 'refusal' | 'inference-failure' = 'refusal',
+  ): number {
     const cm = agent.getContextManager();
     const ep = this.rewindEpisode.get(agent.name);
     const count = (ep?.count ?? 0) + 1;
+    const why = cause === 'refusal'
+      ? `the model refused on them (content filter: ${category}). Their content is ` +
+        `not reproduced here (so this note can't re-trigger the filter); the ` +
+        `originals remain in the raw record`
+      : `the model API kept rejecting the conversation on them (${category}). ` +
+        `Their content is not reproduced here (so this note can't re-trigger the ` +
+        `rejection); the originals remain in the raw record`;
     const text =
       `[refusal-rewind] The ${count} most recent turn(s) were set aside because ` +
-      `the model refused on them (content filter: ${category}). Their content is ` +
-      `not reproduced here (so this note can't re-trigger the filter); the ` +
-      `originals remain in the raw record. You are clear to continue — if you ` +
+      `${why}. You are clear to continue — if you ` +
       `were mid-task, take a different approach; otherwise carry on with whatever ` +
       `is now in front of you, or briefly acknowledge the gap and ask what's next.`;
     const blocks: ContentBlock[] = [{ type: 'text', text }];
@@ -1458,7 +1479,7 @@ export class AgentFramework {
       this.rewindEpisode.set(agent.name, { markerId: ep.markerId, count, category });
     } else {
       const id = cm.addMessage('user', blocks, {
-        system: true, kind: 'refusal-rewind', category, count,
+        system: true, kind: 'refusal-rewind', category, count, cause,
       });
       this.rewindEpisode.set(agent.name, { markerId: id, count, category });
     }
@@ -3051,7 +3072,8 @@ export class AgentFramework {
       // Both produce ContextInjection[] that get merged before inference.
       let injections: ContextInjection[] | undefined;
 
-      // Module gatherContext (fail-open, 5s timeout per module)
+      // Module gatherContext (fail-open, per-module timeout — the module's
+      // contextTimeoutMs, else the registry default)
       // NOTE: module injections are NOT channel-scoped — only the MCPL hook
       // injections below pass through scopeInjectionsForAgent (channel
       // context arrives via beforeInference hooks by adapter convention). A
@@ -3105,6 +3127,9 @@ export class AgentFramework {
           type: 'inference:exhausted',
           agentName: agent.name,
           error: err.message,
+          // Drives the poison-history breaker: only a known NON-retryable
+          // failure (e.g. a 400 on a corrupt history) triggers auto-rewind.
+          retryable: err instanceof MembraneError ? err.retryable : undefined,
         });
         this.eventGate?.onInferenceEnded(agent.name);
         if (action.emit) {
@@ -3612,6 +3637,9 @@ export class AgentFramework {
                 type: 'inference:exhausted',
                 agentName: agent.name,
                 error: err.message,
+                // Drives the poison-history breaker: only a known NON-retryable
+                // failure (e.g. a 400 on a corrupt history) triggers auto-rewind.
+                retryable: err instanceof MembraneError ? err.retryable : undefined,
               });
               this.eventGate?.onInferenceEnded(agent.name);
               if (action.emit) {
@@ -3759,7 +3787,10 @@ export class AgentFramework {
     if (blocks) {
       return { toolUseId: callId, content: blocks, isError: false };
     }
-    let content = JSON.stringify(afResult.data);
+    // JSON.stringify returns the VALUE undefined (not a string) for undefined
+    // input — a module tool returning `{ success: true }` with no data would
+    // otherwise make `content.length` below throw a TypeError mid-turn.
+    let content = JSON.stringify(afResult.data) ?? '';
     if (maxChars && content.length > maxChars) {
       content = safeSlice(content, 0, maxChars)
         + '\n\n[truncated — original was ' + content.length + ' chars]';
@@ -4089,13 +4120,18 @@ export class AgentFramework {
       this.noteInferenceExhausted(
         (event.agentName as string) ?? 'unknown',
         (event.error as string) ?? 'unknown error',
+        event.retryable as boolean | undefined,
       );
     } else if (event.type === 'inference:completed') {
       // A successful response — even mid-turn between tool calls — proves the
-      // agent isn't hard-down; clear its consecutive-failure streak.
+      // agent isn't hard-down; clear its consecutive-failure streak (and the
+      // poison-history breaker's rewind budget).
       const name = event.agentName as string | undefined;
       if (name && this.consecutiveInferenceFailures.get(name)) {
         this.consecutiveInferenceFailures.set(name, 0);
+      }
+      if (name && this.exhaustionRewinds.get(name)) {
+        this.exhaustionRewinds.set(name, 0);
       }
     }
 
@@ -4127,8 +4163,17 @@ export class AgentFramework {
    *      inference, so this never causes a retry/wake loop.
    *   3. escalation — after N consecutive failures the agent is hard-down;
    *      log that loudly (a repeated identical failure is the textbook signal).
+   *   4. breaker — when the failures are known NON-retryable (a 400-class
+   *      rejection of the history itself, e.g. corrupted tool_use/tool_result
+   *      pairing or an oversized attachment), retrying the same context can
+   *      never succeed: every new push event wakes the agent onto the same
+   *      poisoned history forever. At the hard-down threshold, automatically
+   *      quarantine: shed the newest complete exchange (the same forced-rewind
+   *      primitive `/unstick` uses — shedNewestTurn never orphans a
+   *      tool_use/thinking block) and retry, bounded by the same rewind cap so
+   *      the breaker can never eat the whole history.
    */
-  private noteInferenceExhausted(agentName: string, reason: string): void {
+  private noteInferenceExhausted(agentName: string, reason: string, retryable?: boolean): void {
     const streak = (this.consecutiveInferenceFailures.get(agentName) ?? 0) + 1;
     this.consecutiveInferenceFailures.set(agentName, streak);
 
@@ -4163,7 +4208,63 @@ export class AgentFramework {
         `[inference-hard-down] agent=${agentName} has FAILED ${streak} consecutive ` +
         `inferences — it cannot complete a turn. Last reason: ${reason}`,
       );
+
+      // (4) Poison-history breaker: only for known NON-retryable failures —
+      // a transient outage (overloaded/5xx) must never cost history.
+      if (retryable === false && agent) {
+        this.quarantinePoisonedHistory(agent, reason);
+      }
     }
+  }
+
+  /**
+   * Automatic poison-history quarantine (the actual "breaker"). Sheds the
+   * newest complete exchange from the agent's history — reusing the same
+   * primitives as the refusal auto-rewind / `/unstick` (shedNewestTurn +
+   * the single consolidated episode marker) — and queues a retry so the
+   * rewound history is verified immediately instead of waiting for the next
+   * push event to wake the agent onto the same poisoned context.
+   *
+   * Bounded: at most `refusalHandling.maxRewinds` (default 3, hard cap 10)
+   * sheds per failure episode; the budget resets on any successful inference.
+   * At the cap (or with nothing left to shed) it stops — the agent stays up
+   * and hard-down logging continues, but no further history is consumed.
+   */
+  private quarantinePoisonedHistory(agent: Agent, reason: string): void {
+    const cap = Math.max(1, Math.min(10, agent.refusalHandling?.maxRewinds ?? 3));
+    const used = this.exhaustionRewinds.get(agent.name) ?? 0;
+    if (used >= cap) {
+      console.error(
+        `[inference-rewind] agent=${agent.name} rewind cap ${cap} reached — ` +
+        `not shedding further history. Manual repair (/unstick or /undo) needed.`,
+      );
+      return;
+    }
+
+    const rec = this.shedNewestTurn(agent);
+    if (!rec) {
+      console.error(
+        `[inference-rewind] agent=${agent.name} has nothing left to shed — ` +
+        `history is only system markers. Manual repair needed.`,
+      );
+      return;
+    }
+
+    this.exhaustionRewinds.set(agent.name, used + 1);
+    const count = this.updateRewindMarker(agent, truncateReason(reason), 'inference-failure');
+    console.error(
+      `[inference-rewind] agent=${agent.name} auto-quarantined ${rec.descriptor} ` +
+      `(${count} turn(s) shed this episode, cap ${cap}) after non-retryable ` +
+      `inference failures — retrying on the rewound history.`,
+    );
+
+    // Retry immediately on the repaired history (bounded by the cap above).
+    this.pendingRequests.push({
+      agentName: agent.name,
+      reason: 'inference-failure-rewind-retry',
+      source: 'framework',
+      timestamp: Date.now(),
+    });
   }
 
   // ==========================================================================
@@ -4345,43 +4446,65 @@ export class AgentFramework {
     connection.ready();
 
     // Initialize feature sets if server advertises MCPL capabilities
-    if (connection.capabilities) {
-      const updateParams = this.featureSetManager!.initializeServer(
-        config.id,
-        connection.capabilities,
-        {
-          enabledFeatureSets: config.enabledFeatureSets,
-          disabledFeatureSets: config.disabledFeatureSets,
-        },
-      );
+    this.registerMcplServerFeatures(config, connection);
 
-      // Inform server which feature sets are enabled/disabled
-      if (updateParams.enabled?.length || updateParams.disabled?.length) {
-        connection.sendFeatureSetsUpdate(updateParams);
-      }
+    this.emitTrace({ type: 'module:added', moduleName: `mcpl:${config.id}` });
+  }
 
-      // Configure scope whitelist/blacklist patterns
-      if (config.scopes) {
-        this.scopeManager!.configureAll(config.scopes);
-      }
+  /**
+   * (Re-)establish a server's host-side MCPL registration: feature-set state
+   * (plus the featureSets/update sent to the server), scope patterns, and
+   * stateful-feature-set checkpoint registration.
+   *
+   * Called on initial connect (connectMcplServerInternal) AND after every
+   * auto-reconnect. The 'close' handler drops the feature-set registration, so
+   * without the reconnect re-run FeatureSetManager.validateInbound would throw
+   * "Unknown server" forever — every push event and inference request from the
+   * revived server silently rejected until a full host restart.
+   *
+   * CheckpointManager.registerFeatureSet is idempotent (no-op for a key that
+   * already has a tree), so checkpoint trees preserved across a transient
+   * disconnect are resumed, not reset.
+   */
+  private registerMcplServerFeatures(
+    config: import('./mcpl/types.js').McplServerConfig,
+    connection: McplServerConnection,
+  ): void {
+    if (!connection.capabilities) return;
 
-      // Register stateful feature sets with checkpoint manager (Step 8)
-      if (this.checkpointManager) {
-        const declared = this.featureSetManager!.getDeclaredFeatureSets(config.id);
-        if (declared) {
-          for (const [fsName, fsDecl] of Object.entries(declared)) {
-            if (fsDecl.rollback || fsDecl.hostState) {
-              this.checkpointManager.registerFeatureSet(config.id, fsName, {
-                hostState: fsDecl.hostState ?? false,
-                rollback: fsDecl.rollback ?? false,
-              });
-            }
+    const updateParams = this.featureSetManager!.initializeServer(
+      config.id,
+      connection.capabilities,
+      {
+        enabledFeatureSets: config.enabledFeatureSets,
+        disabledFeatureSets: config.disabledFeatureSets,
+      },
+    );
+
+    // Inform server which feature sets are enabled/disabled
+    if (updateParams.enabled?.length || updateParams.disabled?.length) {
+      connection.sendFeatureSetsUpdate(updateParams);
+    }
+
+    // Configure scope whitelist/blacklist patterns
+    if (config.scopes) {
+      this.scopeManager!.configureAll(config.scopes);
+    }
+
+    // Register stateful feature sets with checkpoint manager (Step 8)
+    if (this.checkpointManager) {
+      const declared = this.featureSetManager!.getDeclaredFeatureSets(config.id);
+      if (declared) {
+        for (const [fsName, fsDecl] of Object.entries(declared)) {
+          if (fsDecl.rollback || fsDecl.hostState) {
+            this.checkpointManager.registerFeatureSet(config.id, fsName, {
+              hostState: fsDecl.hostState ?? false,
+              rollback: fsDecl.rollback ?? false,
+            });
           }
         }
       }
     }
-
-    this.emitTrace({ type: 'module:added', moduleName: `mcpl:${config.id}` });
   }
 
   // ==========================================================================
@@ -4425,9 +4548,10 @@ export class AgentFramework {
   }
 
   /**
-   * Disconnect an MCPL server at runtime: close the connection (which also
-   * cleans feature sets and checkpoints via the 'close' handler), remove its
-   * channels from the registry, drop routing entries, and refresh tools.
+   * Disconnect an MCPL server at runtime: close the connection, destroy its
+   * feature-set and checkpoint state (permanent removal — unlike a transient
+   * transport close, which preserves checkpoints for the reconnect), remove
+   * its channels from the registry, drop routing entries, and refresh tools.
    * No-op-ish if the server is not connected (still clears routing state).
    */
   async disconnectMcplServer(id: string): Promise<void> {
@@ -4439,6 +4563,13 @@ export class AgentFramework {
 
     await this.mcplServerRegistry.removeServer(id);
     this.channelRegistry?.removeServer(id);
+
+    // Permanent removal: also destroy feature-set and checkpoint state
+    // explicitly. The 'close' handler usually does this, but a connection that
+    // already transiently closed (reconnect pending) emits no second 'close'
+    // from close(), and the transient path deliberately preserves checkpoints.
+    this.featureSetManager?.removeServer(id);
+    this.checkpointManager?.removeServer(id);
 
     const prefix = config?.toolPrefix ?? `mcpl--${id}`;
     this.mcplPrefixMap.delete(prefix);
@@ -4592,8 +4723,25 @@ export class AgentFramework {
       this.handleToolsListChanged(connection.id);
     });
 
-    // Also refresh tools on reconnect (server may have different tools)
+    // Re-establish full server registration on reconnect. The 'close' handler
+    // removed the feature-set state, so pushes / inference requests from the
+    // revived server would otherwise be rejected with "Unknown server" until a
+    // host restart. Re-runs the same init as the initial connect path (the
+    // fresh handshake refreshed connection.capabilities); checkpoint trees
+    // preserved across the transient close are resumed by idempotent
+    // registration. Then refresh tools (server may have different tools).
     connection.on('reconnect', (info?: { attempts?: number }) => {
+      try {
+        const config = this.mcplServerConfigs.get(connection.id);
+        if (config) {
+          this.registerMcplServerFeatures(config, connection);
+        }
+      } catch (error) {
+        console.error(
+          `MCPL server "${connection.id}" re-registration after reconnect failed:`,
+          error instanceof Error ? error.message : error,
+        );
+      }
       this.handleToolsListChanged(connection.id);
       this.emitTrace({
         type: 'mcpl:server-reconnected',
@@ -4638,10 +4786,19 @@ export class AgentFramework {
       });
     });
 
-    // Cleanup on disconnect
+    // Cleanup on disconnect. Feature-set state is always dropped (the server
+    // can't be validated while down; reconnect re-registers it), but checkpoint
+    // trees are durable state: CheckpointManager.removeServer deletes them AND
+    // persists the deletion to Chronicle, so calling it on a TRANSIENT close
+    // would let a single crash/blip permanently destroy every checkpoint the
+    // server had. Only destroy checkpoints when the disconnect is permanent
+    // (explicit close / no reconnect loop); disconnectMcplServer also removes
+    // them explicitly for the already-closed-stub path.
     connection.on('close', (code?: number | null, signal?: string | null) => {
       this.featureSetManager?.removeServer(connection.id);
-      this.checkpointManager?.removeServer(connection.id);
+      if (!connection.willReconnect) {
+        this.checkpointManager?.removeServer(connection.id);
+      }
       this.emitTrace({
         type: 'mcpl:server-closed',
         serverId: connection.id,

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -3127,9 +3127,13 @@ export class AgentFramework {
           type: 'inference:exhausted',
           agentName: agent.name,
           error: err.message,
-          // Drives the poison-history breaker: only a known NON-retryable
-          // failure (e.g. a 400 on a corrupt history) triggers auto-rewind.
+          // Drives the poison-history breaker. `retryable` is kept for
+          // observability, but the breaker gates on `errorType` — only an
+          // `invalid_request` (a 400-class rejection of the history itself)
+          // means retrying the same context can never succeed. auth/abort/
+          // context_length are also non-retryable but must NOT cost history.
           retryable: err instanceof MembraneError ? err.retryable : undefined,
+          errorType: err instanceof MembraneError ? err.type : undefined,
         });
         this.eventGate?.onInferenceEnded(agent.name);
         if (action.emit) {
@@ -3637,9 +3641,12 @@ export class AgentFramework {
                 type: 'inference:exhausted',
                 agentName: agent.name,
                 error: err.message,
-                // Drives the poison-history breaker: only a known NON-retryable
-                // failure (e.g. a 400 on a corrupt history) triggers auto-rewind.
+                // Drives the poison-history breaker. `retryable` is kept for
+                // observability, but the breaker gates on `errorType` — only an
+                // `invalid_request` (a 400-class rejection of the history
+                // itself) means retrying the same context can never succeed.
                 retryable: err instanceof MembraneError ? err.retryable : undefined,
+                errorType: err instanceof MembraneError ? err.type : undefined,
               });
               this.eventGate?.onInferenceEnded(agent.name);
               if (action.emit) {
@@ -4121,6 +4128,7 @@ export class AgentFramework {
         (event.agentName as string) ?? 'unknown',
         (event.error as string) ?? 'unknown error',
         event.retryable as boolean | undefined,
+        event.errorType as string | undefined,
       );
     } else if (event.type === 'inference:completed') {
       // A successful response — even mid-turn between tool calls — proves the
@@ -4163,7 +4171,7 @@ export class AgentFramework {
    *      inference, so this never causes a retry/wake loop.
    *   3. escalation — after N consecutive failures the agent is hard-down;
    *      log that loudly (a repeated identical failure is the textbook signal).
-   *   4. breaker — when the failures are known NON-retryable (a 400-class
+   *   4. breaker — when the failures are an `invalid_request` (a 400-class
    *      rejection of the history itself, e.g. corrupted tool_use/tool_result
    *      pairing or an oversized attachment), retrying the same context can
    *      never succeed: every new push event wakes the agent onto the same
@@ -4173,7 +4181,12 @@ export class AgentFramework {
    *      tool_use/thinking block) and retry, bounded by the same rewind cap so
    *      the breaker can never eat the whole history.
    */
-  private noteInferenceExhausted(agentName: string, reason: string, retryable?: boolean): void {
+  private noteInferenceExhausted(
+    agentName: string,
+    reason: string,
+    retryable?: boolean,
+    errorType?: string,
+  ): void {
     const streak = (this.consecutiveInferenceFailures.get(agentName) ?? 0) + 1;
     this.consecutiveInferenceFailures.set(agentName, streak);
 
@@ -4209,9 +4222,16 @@ export class AgentFramework {
         `inferences — it cannot complete a turn. Last reason: ${reason}`,
       );
 
-      // (4) Poison-history breaker: only for known NON-retryable failures —
-      // a transient outage (overloaded/5xx) must never cost history.
-      if (retryable === false && agent) {
+      // (4) Poison-history breaker: ONLY for `invalid_request` — a 400-class
+      // rejection of the history itself. Deliberately NOT keyed on
+      // `retryable === false`, which membrane also returns for auth (expired
+      // key), abort (deliberate cancel), context_length (compression's job,
+      // and shedding newest is the wrong direction), safety and unsupported —
+      // none of which mean the history is poisoned, and all of which would
+      // otherwise shed good exchanges and stamp a false "the API kept
+      // rejecting your history" marker. `retryable` is kept only for the trace.
+      void retryable;
+      if (errorType === 'invalid_request' && agent) {
         this.quarantinePoisonedHistory(agent, reason);
       }
     }
@@ -4775,6 +4795,24 @@ export class AgentFramework {
       });
     });
 
+    // A late response to a tools/call that already timed out, carrying
+    // stateful data the server advanced to. The host can't re-inject it (the
+    // dispatch context is gone), but surfacing it makes the checkpoint-tree
+    // divergence greppable instead of a silent drift into stale state.
+    connection.on('orphaned-response', (info: {
+      id: string | number;
+      hadState: boolean;
+      hadCheckpoint: boolean;
+    }) => {
+      this.emitTrace({
+        type: 'mcpl:orphaned-response',
+        serverId: connection.id,
+        responseId: info.id,
+        hadState: info.hadState,
+        hadCheckpoint: info.hadCheckpoint,
+      });
+    });
+
     // Connection-level errors (e.g. child process 'error' after spawn).
     // Attaching this listener also keeps an unhandled EventEmitter 'error'
     // from crashing the host process.
@@ -4787,18 +4825,16 @@ export class AgentFramework {
     });
 
     // Cleanup on disconnect. Feature-set state is always dropped (the server
-    // can't be validated while down; reconnect re-registers it), but checkpoint
-    // trees are durable state: CheckpointManager.removeServer deletes them AND
-    // persists the deletion to Chronicle, so calling it on a TRANSIENT close
-    // would let a single crash/blip permanently destroy every checkpoint the
-    // server had. Only destroy checkpoints when the disconnect is permanent
-    // (explicit close / no reconnect loop); disconnectMcplServer also removes
-    // them explicitly for the already-closed-stub path.
+    // can't be validated while down; reconnect re-registers it). Checkpoint
+    // trees, however, are durable state: CheckpointManager.removeServer deletes
+    // them AND persists the deletion to Chronicle. The close handler must
+    // therefore NEVER destroy checkpoints — `willReconnect` is false on a clean
+    // stop() too (reconnectEnabled is cleared before 'close' fires), so gating
+    // on it would erase every checkpoint tree on an ordinary host restart while
+    // a SIGKILL preserves them. Permanent removal is owned solely by
+    // disconnectMcplServer, which deletes the trees explicitly.
     connection.on('close', (code?: number | null, signal?: string | null) => {
       this.featureSetManager?.removeServer(connection.id);
-      if (!connection.willReconnect) {
-        this.checkpointManager?.removeServer(connection.id);
-      }
       this.emitTrace({
         type: 'mcpl:server-closed',
         serverId: connection.id,

--- a/src/mcpl/server-connection.ts
+++ b/src/mcpl/server-connection.ts
@@ -599,7 +599,10 @@ export class McplServerConnection extends EventEmitter {
           reject(new Error(
             `MCPL server "${this.id}" did not respond to ${method} (id=${id}) ` +
             `within ${this.requestTimeoutMs}ms — the server may be hung. ` +
-            `The request was abandoned; the connection remains open.`,
+            `The request was abandoned; the connection remains open. Note the ` +
+            `tool may still have completed server-side (this is only a response ` +
+            `timeout, not a cancellation) — verify state before retrying, as a ` +
+            `blind retry of a stateful/side-effecting tool may duplicate it.`,
           ));
         }, this.requestTimeoutMs);
         // Don't hold the event loop open for the watchdog alone.
@@ -708,6 +711,25 @@ export class McplServerConnection extends EventEmitter {
   private handleResponse(response: JsonRpcResponse): void {
     const pending = this.pendingRequests.get(response.id);
     if (!pending) {
+      // Orphaned response — the request already timed out (or was settled) and
+      // was removed from pendingRequests. Stateless late results are harmless to
+      // drop, but a late STATEFUL result carries a `state`/`checkpoint` the
+      // server has already advanced to: dropping it silently diverges the host's
+      // checkpoint tree from the server's, and every subsequent call then sends
+      // stale state. We can't safely re-inject it here (the dispatch context is
+      // gone), but we surface it so the divergence is greppable instead of
+      // invisible.
+      const result = response.result;
+      if (result && typeof result === 'object') {
+        const r = result as { state?: unknown; checkpoint?: unknown };
+        if (r.state !== undefined || r.checkpoint !== undefined) {
+          this.emit('orphaned-response', {
+            id: response.id,
+            hadState: r.state !== undefined,
+            hadCheckpoint: r.checkpoint !== undefined,
+          });
+        }
+      }
       return; // Orphaned response — ignore
     }
 

--- a/src/mcpl/server-connection.ts
+++ b/src/mcpl/server-connection.ts
@@ -46,6 +46,13 @@ import { McplMethod } from './types.js';
  *  Spring Boot + JDA servers can take 5-10s to boot, so 30s is safe. */
 const INITIALIZE_TIMEOUT_MS = 30_000;
 
+/** Default per-request timeout in milliseconds (see McplServerConfig.requestTimeoutMs).
+ *  A live-but-wedged server (accepts requests, never answers, never closes its
+ *  transport) would otherwise freeze the awaiting agent turn forever — no
+ *  endTurn, no further wakes, zero errors anywhere. 60s is generous for real
+ *  tool work while still bounding the hang. */
+const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
+
 /** MCP protocol version used in the initialize handshake. */
 const MCP_PROTOCOL_VERSION = '2024-11-05';
 
@@ -56,6 +63,8 @@ interface PendingRequest {
   resolve: (result: unknown) => void;
   reject: (error: Error) => void;
   method: string;
+  /** Per-request timeout timer; cleared on response/close/timeout. */
+  timer?: ReturnType<typeof setTimeout>;
 }
 
 /**
@@ -97,6 +106,9 @@ export class McplServerConnection extends EventEmitter {
   private nextRequestId = 1;
   private pendingRequests = new Map<string | number, PendingRequest>();
   private closed = false;
+
+  /** Per-request timeout in ms (0 disables). See McplServerConfig.requestTimeoutMs. */
+  private requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS;
 
   // Event buffering: events emitted before ready() are queued, not lost
   private readyFlag = false;
@@ -187,6 +199,7 @@ export class McplServerConnection extends EventEmitter {
     const { transport, capabilities } = await McplServerConnection.handshake(config, hostCapabilities);
 
     const connection = new McplServerConnection(config.id, capabilities, transport);
+    connection.requestTimeoutMs = config.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
 
     // Store config for reconnection
     if (config.reconnect) {
@@ -323,6 +336,7 @@ export class McplServerConnection extends EventEmitter {
     // Null transport — the stub is closed until its first background reconnect.
     const stub = new McplServerConnection(config.id, null, null);
     stub.closed = true;
+    stub.requestTimeoutMs = config.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
     stub.config = config;
     stub.hostCapabilities = hostCapabilities;
     stub.reconnectEnabled = true;
@@ -469,6 +483,7 @@ export class McplServerConnection extends EventEmitter {
 
     // Reject all pending requests
     for (const [id, pending] of this.pendingRequests) {
+      if (pending.timer) clearTimeout(pending.timer);
       pending.reject(new Error(`Connection to MCPL server "${this.id}" closed while awaiting response for ${pending.method} (id=${id})`));
     }
     this.pendingRequests.clear();
@@ -555,6 +570,13 @@ export class McplServerConnection extends EventEmitter {
   /**
    * Send a JSON-RPC request and return a promise that resolves with the result
    * or rejects with a JSON-RPC error.
+   *
+   * Every request carries a timeout (default 60s, configurable via
+   * McplServerConfig.requestTimeoutMs, 0 disables): a live-but-stuck server
+   * that accepts a request and never answers rejects the pending promise with
+   * a descriptive error instead of freezing the caller forever. For tools/call
+   * the framework maps the rejection to an isError tool_result, so a hung tool
+   * surfaces as a normal tool error and the turn completes.
    */
   private sendRequest(method: string, params: Record<string, unknown>): Promise<unknown> {
     if (this.closed) {
@@ -570,7 +592,20 @@ export class McplServerConnection extends EventEmitter {
     };
 
     return new Promise((resolve, reject) => {
-      this.pendingRequests.set(id, { resolve, reject, method });
+      const pending: PendingRequest = { resolve, reject, method };
+      if (this.requestTimeoutMs > 0) {
+        pending.timer = setTimeout(() => {
+          this.pendingRequests.delete(id);
+          reject(new Error(
+            `MCPL server "${this.id}" did not respond to ${method} (id=${id}) ` +
+            `within ${this.requestTimeoutMs}ms — the server may be hung. ` +
+            `The request was abandoned; the connection remains open.`,
+          ));
+        }, this.requestTimeoutMs);
+        // Don't hold the event loop open for the watchdog alone.
+        pending.timer.unref?.();
+      }
+      this.pendingRequests.set(id, pending);
       this.transport!.writeLine(JSON.stringify(request));
     });
   }
@@ -677,6 +712,7 @@ export class McplServerConnection extends EventEmitter {
     }
 
     this.pendingRequests.delete(response.id);
+    if (pending.timer) clearTimeout(pending.timer);
 
     if (response.error) {
       pending.reject(
@@ -729,6 +765,7 @@ export class McplServerConnection extends EventEmitter {
 
         // Reject all pending requests
         for (const [id, pending] of this.pendingRequests) {
+          if (pending.timer) clearTimeout(pending.timer);
           pending.reject(
             new Error(
               `MCPL server "${this.id}" disconnected unexpectedly (code=${info.code ?? 'n/a'}, signal=${info.signal ?? 'n/a'}, reason=${info.reason ?? 'unknown'}) while awaiting ${pending.method} (id=${id})`,

--- a/src/mcpl/types.ts
+++ b/src/mcpl/types.ts
@@ -248,6 +248,16 @@ export interface McplServerConfig {
   reconnectMaxIntervalMs?: number;
 
   /**
+   * Per-request timeout in milliseconds for outbound JSON-RPC requests
+   * (tools/call, tools/list, channels/*, hooks). A live-but-stuck server that
+   * accepts a request and never responds would otherwise freeze the awaiting
+   * agent turn forever; with the timeout the pending request rejects with a
+   * descriptive error, which the framework surfaces as a normal isError
+   * tool_result. Set 0 to disable. Default: 60000 (60 seconds).
+   */
+  requestTimeoutMs?: number;
+
+  /**
    * Optional callback to filter which incoming channel messages should trigger
    * agent inference. Receives the text content and message metadata.
    * Return true to trigger inference, false to silently accept the message.

--- a/src/module-registry.ts
+++ b/src/module-registry.ts
@@ -28,6 +28,15 @@ import type { Agent } from './agent.js';
 const MODULE_STATE_PREFIX = 'modules/';
 
 /**
+ * Hard ceiling for a single module's gatherContext budget, regardless of the
+ * `contextTimeoutMs` it declares. gatherContext runs on the critical path of
+ * every inference turn, so an unbounded self-declared budget would let one
+ * wedged module stall every agent. 30s is generous for legitimate work (e.g. a
+ * retrieval module's sequential LLM calls) while keeping the worst case bounded.
+ */
+const MAX_CONTEXT_TIMEOUT_MS = 30_000;
+
+/**
  * Registered speech handler.
  */
 interface SpeechHandler {
@@ -308,7 +317,8 @@ export class ModuleRegistry {
    * `timeoutMs` default (15s). Modules whose gatherContext does real work —
    * e.g. a retrieval module making sequential LLM calls with backoff — should
    * declare a larger `contextTimeoutMs` rather than silently losing their
-   * injection every turn to the shared default.
+   * injection every turn to the shared default. The declared value is clamped
+   * to MAX_CONTEXT_TIMEOUT_MS so no single module can hold every turn hostage.
    * Adapted from Anarchid/agent-framework@mcpl-module-proto.
    */
   async gatherContext(agentName: string, timeoutMs = 15_000): Promise<ContextInjection[]> {
@@ -318,7 +328,15 @@ export class ModuleRegistry {
     for (const module of this.modules.values()) {
       if (!module.gatherContext) continue;
 
-      const budgetMs = module.contextTimeoutMs ?? timeoutMs;
+      // Clamp the per-module budget. A module declaring `contextTimeoutMs`
+      // legitimately needs more than the shared default (e.g. a retrieval
+      // module doing sequential LLM calls), but it must not be able to hold
+      // EVERY inference turn of EVERY agent hostage: the fail-open contract is
+      // "a wedged module never blocks inference for long", so cap the wait.
+      const budgetMs = Math.min(
+        module.contextTimeoutMs ?? timeoutMs,
+        MAX_CONTEXT_TIMEOUT_MS,
+      );
       let timer: ReturnType<typeof setTimeout> | undefined;
       const promise = Promise.race([
         module.gatherContext(agentName).then(r => injections.push(...r)),

--- a/src/module-registry.ts
+++ b/src/module-registry.ts
@@ -302,20 +302,35 @@ export class ModuleRegistry {
   /**
    * Gather context injections from all modules before inference.
    * Calls each module's gatherContext() in parallel with a per-module timeout.
-   * Fail-open: timed-out or erroring modules are skipped silently.
+   * Fail-open: timed-out or erroring modules are skipped (with a stderr line).
+   *
+   * The per-module budget is `module.contextTimeoutMs` when declared, else the
+   * `timeoutMs` default (15s). Modules whose gatherContext does real work —
+   * e.g. a retrieval module making sequential LLM calls with backoff — should
+   * declare a larger `contextTimeoutMs` rather than silently losing their
+   * injection every turn to the shared default.
    * Adapted from Anarchid/agent-framework@mcpl-module-proto.
    */
-  async gatherContext(agentName: string, timeoutMs = 5000): Promise<ContextInjection[]> {
+  async gatherContext(agentName: string, timeoutMs = 15_000): Promise<ContextInjection[]> {
     const injections: ContextInjection[] = [];
     const promises: Promise<void>[] = [];
 
     for (const module of this.modules.values()) {
       if (!module.gatherContext) continue;
 
+      const budgetMs = module.contextTimeoutMs ?? timeoutMs;
+      let timer: ReturnType<typeof setTimeout> | undefined;
       const promise = Promise.race([
         module.gatherContext(agentName).then(r => injections.push(...r)),
-        new Promise<void>((_, rej) => setTimeout(() => rej(new Error('timeout')), timeoutMs)),
-      ]).catch(err => console.error(`[${module.name}] gatherContext:`, err));
+        new Promise<void>((_, rej) => {
+          timer = setTimeout(
+            () => rej(new Error(`gatherContext timed out after ${budgetMs}ms`)),
+            budgetMs,
+          );
+        }),
+      ])
+        .catch(err => console.error(`[${module.name}] gatherContext:`, err))
+        .finally(() => clearTimeout(timer));
 
       promises.push(promise as Promise<void>);
     }

--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -37,6 +37,15 @@ export interface Module {
   readonly name: string;
 
   /**
+   * Per-module budget (ms) for gatherContext() before the framework skips this
+   * module's injection for the turn (fail-open). Defaults to the registry-wide
+   * default (15s) when omitted. Declare a larger budget when gatherContext
+   * does real work — e.g. sequential LLM calls with provider backoff — so the
+   * injection isn't silently dropped every turn.
+   */
+  readonly contextTimeoutMs?: number;
+
+  /**
    * Start the module.
    * Called when the framework starts or when the module is added.
    */

--- a/src/types/trace.ts
+++ b/src/types/trace.ts
@@ -60,6 +60,13 @@ export type TraceEvent =
       type: 'inference:exhausted';
       agentName: string;
       error: string;
+      /** Whether membrane classified the failure as retryable (observability). */
+      retryable?: boolean;
+      /**
+       * The membrane error type (e.g. 'invalid_request', 'auth', 'context_length').
+       * The poison-history breaker fires only on 'invalid_request'.
+       */
+      errorType?: string;
     })
 
   // Streaming inference lifecycle
@@ -304,6 +311,16 @@ export type TraceEvent =
       type: 'mcpl:server-error';
       serverId: string;
       error: string;
+    })
+  | (TraceEventBase & {
+      type: 'mcpl:orphaned-response';
+      serverId: string;
+      /** The JSON-RPC id of the late response whose pending request already timed out. */
+      responseId: string | number;
+      /** True when the dropped response carried host-managed `state`. */
+      hadState: boolean;
+      /** True when the dropped response carried a server-managed `checkpoint`. */
+      hadCheckpoint: boolean;
     });
 
 /**

--- a/test/gather-context-timeout.test.ts
+++ b/test/gather-context-timeout.test.ts
@@ -1,0 +1,94 @@
+/**
+ * gatherContext per-module timeout (3.5): the flat 5s default silently
+ * dropped any module whose gatherContext does real work (e.g. a retrieval
+ * module making 2 sequential LLM calls with provider backoff) — fail-open
+ * meant "guaranteed timeout, every turn, invisibly".
+ *
+ * A module can now declare `contextTimeoutMs` for its own budget; the
+ * registry default was raised to 15s. Fail-open behavior is preserved for
+ * modules that actually exceed their budget.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { ModuleRegistry } from '../src/module-registry.js';
+import type { Module } from '../src/types/index.js';
+
+function makeRegistry(modules: Module[]): ModuleRegistry {
+  const registry = Object.create(ModuleRegistry.prototype) as ModuleRegistry;
+  (registry as any).modules = new Map(modules.map((m) => [m.name, m]));
+  return registry;
+}
+
+function slowModule(name: string, delayMs: number, contextTimeoutMs?: number): Module {
+  return {
+    name,
+    ...(contextTimeoutMs !== undefined ? { contextTimeoutMs } : {}),
+    start: async () => {},
+    stop: async () => {},
+    getTools: () => [],
+    handleToolCall: async () => ({ success: true }),
+    onProcess: async () => ({}),
+    gatherContext: async () => {
+      await new Promise((r) => setTimeout(r, delayMs));
+      return [{
+        namespace: name,
+        position: 'system' as const,
+        content: [{ type: 'text' as const, text: `from ${name}` }],
+      }];
+    },
+  };
+}
+
+test('a module slower than the shared default completes within its own contextTimeoutMs', async () => {
+  // Registry default budget of 100ms, module takes 300ms but declares 1000ms.
+  const registry = makeRegistry([slowModule('retrieval', 300, 1000)]);
+
+  const injections = await registry.gatherContext('agent', 100);
+  assert.equal(injections.length, 1, 'the slow module must inject, not silently time out');
+  assert.deepEqual(injections[0].content, [{ type: 'text', text: 'from retrieval' }]);
+});
+
+test('a module exceeding its own budget still fails open (skipped, no throw)', async () => {
+  const errs: string[] = [];
+  const orig = console.error;
+  console.error = (...a: unknown[]) => { errs.push(a.join(' ')); };
+  try {
+    const registry = makeRegistry([slowModule('laggard', 500, 50)]);
+    const injections = await registry.gatherContext('agent', 5000);
+    assert.equal(injections.length, 0);
+    assert.ok(errs.some((e) => e.includes('[laggard]') && e.includes('timed out after 50ms')));
+  } finally {
+    console.error = orig;
+  }
+});
+
+test('modules without contextTimeoutMs use the shared default; fast ones are unaffected', async () => {
+  const registry = makeRegistry([
+    slowModule('fast', 10),
+    slowModule('slow-no-override', 400),
+  ]);
+
+  const errs: string[] = [];
+  const orig = console.error;
+  console.error = (...a: unknown[]) => { errs.push(a.join(' ')); };
+  try {
+    const injections = await registry.gatherContext('agent', 100);
+    assert.equal(injections.length, 1, 'only the fast module injects');
+    assert.deepEqual(injections[0].content, [{ type: 'text', text: 'from fast' }]);
+  } finally {
+    console.error = orig;
+  }
+});
+
+test('per-module budgets run in parallel — total time is bounded by the largest budget, not the sum', async () => {
+  const registry = makeRegistry([
+    slowModule('a', 150, 1000),
+    slowModule('b', 150, 1000),
+    slowModule('c', 150, 1000),
+  ]);
+  const started = Date.now();
+  const injections = await registry.gatherContext('agent', 100);
+  const elapsed = Date.now() - started;
+  assert.equal(injections.length, 3);
+  assert.ok(elapsed < 450, `parallel gather took ${elapsed}ms`);
+});

--- a/test/gather-context-timeout.test.ts
+++ b/test/gather-context-timeout.test.ts
@@ -8,7 +8,7 @@
  * registry default was raised to 15s. Fail-open behavior is preserved for
  * modules that actually exceed their budget.
  */
-import { test } from 'node:test';
+import { test, mock } from 'node:test';
 import assert from 'node:assert/strict';
 import { ModuleRegistry } from '../src/module-registry.js';
 import type { Module } from '../src/types/index.js';
@@ -77,6 +77,41 @@ test('modules without contextTimeoutMs use the shared default; fast ones are una
     assert.deepEqual(injections[0].content, [{ type: 'text', text: 'from fast' }]);
   } finally {
     console.error = orig;
+  }
+});
+
+test('a self-declared contextTimeoutMs is CLAMPED so no module can hold every turn hostage', async () => {
+  // A module declaring an absurd 10-minute budget must still be cut off at the
+  // 30s ceiling, or one wedged module stalls every inference turn of every
+  // agent. Fake timers so the test doesn't actually wait 30s.
+  mock.timers.enable({ apis: ['setTimeout'] });
+  const errs: string[] = [];
+  const orig = console.error;
+  console.error = (...a: unknown[]) => { errs.push(a.join(' ')); };
+  try {
+    const hanging: Module = {
+      name: 'wedged',
+      contextTimeoutMs: 600_000, // 10 minutes — must be clamped to 30s
+      start: async () => {},
+      stop: async () => {},
+      getTools: () => [],
+      handleToolCall: async () => ({ success: true }),
+      onProcess: async () => ({}),
+      gatherContext: () => new Promise(() => {}), // never resolves
+    };
+    const registry = makeRegistry([hanging]);
+    const p = registry.gatherContext('agent', 5000);
+    // Advance to the 30s ceiling; if the budget weren't clamped, nothing fires.
+    mock.timers.tick(30_000);
+    const injections = await p;
+    assert.equal(injections.length, 0, 'the wedged module fails open at the ceiling');
+    assert.ok(
+      errs.some((e) => e.includes('[wedged]') && e.includes('timed out after 30000ms')),
+      `expected clamp to 30000ms, saw: ${errs.join(' | ')}`,
+    );
+  } finally {
+    console.error = orig;
+    mock.timers.reset();
   }
 });
 

--- a/test/inference-exhaustion-rewind.test.ts
+++ b/test/inference-exhaustion-rewind.test.ts
@@ -65,14 +65,14 @@ function makeHarness(opts?: { maxRewinds?: number; messages?: any[] }) {
 
 const REASON = '400 invalid_request: tool_use ids must have a corresponding tool_result';
 
-test('at the threshold, non-retryable failures trigger an automatic rewind + retry', () => {
+test('at the threshold, invalid_request failures trigger an automatic rewind + retry', () => {
   const { fw, removed, added, errs, restore } = makeHarness();
   try {
-    fw.noteInferenceExhausted('cairn', REASON, false); // 1
-    fw.noteInferenceExhausted('cairn', REASON, false); // 2
+    fw.noteInferenceExhausted('cairn', REASON, false, 'invalid_request'); // 1
+    fw.noteInferenceExhausted('cairn', REASON, false, 'invalid_request'); // 2
     assert.equal(removed.length, 0, 'no rewind before the threshold');
 
-    fw.noteInferenceExhausted('cairn', REASON, false); // 3 → breaker trips
+    fw.noteInferenceExhausted('cairn', REASON, false, 'invalid_request'); // 3 → breaker trips
   } finally { restore(); }
 
   // The poisoned tool exchange was shed as a COMPLETE pair (no orphans).
@@ -95,11 +95,33 @@ test('at the threshold, non-retryable failures trigger an automatic rewind + ret
 test('retryable / unknown-retryability failures NEVER shed history (outages cost nothing)', () => {
   const { fw, removed, restore } = makeHarness();
   try {
-    for (let i = 0; i < 6; i++) fw.noteInferenceExhausted('cairn', '529 overloaded', true);
-    for (let i = 0; i < 6; i++) fw.noteInferenceExhausted('cairn', 'weird transport error', undefined);
+    for (let i = 0; i < 6; i++) fw.noteInferenceExhausted('cairn', '529 overloaded', true, 'server');
+    for (let i = 0; i < 6; i++) fw.noteInferenceExhausted('cairn', 'weird transport error', undefined, undefined);
   } finally { restore(); }
   assert.equal(removed.length, 0, 'transient failures must not consume history');
   assert.equal(fw.pendingRequests.length, 0);
+});
+
+test('non-retryable but NON-poison failures (auth/context_length/abort) NEVER shed history', () => {
+  // The breaker keys on the membrane error TYPE, not on `retryable`. membrane
+  // marks auth (expired key), context_length, abort, safety and unsupported all
+  // non-retryable — but none of them mean the history is poisoned. Shedding
+  // good exchanges + stamping a false "the API kept rejecting your history"
+  // marker on an expired API key is exactly the category error this guards.
+  for (const errorType of ['auth', 'context_length', 'abort', 'safety', 'unsupported']) {
+    const { fw, removed, added, restore } = makeHarness();
+    try {
+      // Well past the hard-down threshold, all with retryable === false.
+      for (let i = 0; i < 6; i++) fw.noteInferenceExhausted('cairn', `non-retryable ${errorType}`, false, errorType);
+    } finally { restore(); }
+    assert.equal(removed.length, 0, `${errorType}: history must not be shed`);
+    assert.equal(fw.pendingRequests.length, 0, `${errorType}: no rewind-retry queued`);
+    assert.equal(
+      added.filter((m) => m.meta.kind === 'refusal-rewind').length,
+      0,
+      `${errorType}: no false rejection marker`,
+    );
+  }
 });
 
 test('the breaker is capped: repeated failures stop shedding at maxRewinds', () => {
@@ -115,7 +137,7 @@ test('the breaker is capped: repeated failures stop shedding at maxRewinds', () 
   try {
     // 10 consecutive non-retryable failures: the breaker fires from streak 3 on,
     // but only sheds up to the cap (2), then holds.
-    for (let i = 0; i < 10; i++) fw.noteInferenceExhausted('cairn', REASON, false);
+    for (let i = 0; i < 10; i++) fw.noteInferenceExhausted('cairn', REASON, false, 'invalid_request');
   } finally { restore(); }
 
   assert.equal(removed.length, 2, `cap of 2 respected, shed: ${removed.join(', ')}`);
@@ -128,9 +150,9 @@ test('the breaker is capped: repeated failures stop shedding at maxRewinds', () 
 test('a successful inference resets both the streak and the rewind budget', () => {
   const { fw, removed, restore } = makeHarness();
   try {
-    fw.noteInferenceExhausted('cairn', REASON, false);
-    fw.noteInferenceExhausted('cairn', REASON, false);
-    fw.noteInferenceExhausted('cairn', REASON, false); // shed #1
+    fw.noteInferenceExhausted('cairn', REASON, false, 'invalid_request');
+    fw.noteInferenceExhausted('cairn', REASON, false, 'invalid_request');
+    fw.noteInferenceExhausted('cairn', REASON, false, 'invalid_request'); // shed #1
     assert.equal(removed.length, 2); // one complete tool exchange
 
     fw.emitTrace({ type: 'inference:completed', agentName: 'cairn' });
@@ -146,7 +168,7 @@ test('nothing left to shed: the breaker degrades to logging, no crash, no loop',
     ],
   });
   try {
-    for (let i = 0; i < 5; i++) fw.noteInferenceExhausted('cairn', REASON, false);
+    for (let i = 0; i < 5; i++) fw.noteInferenceExhausted('cairn', REASON, false, 'invalid_request');
   } finally { restore(); }
   assert.equal(removed.length, 0);
   assert.equal(fw.pendingRequests.length, 0, 'no retry queued when nothing was repaired');

--- a/test/inference-exhaustion-rewind.test.ts
+++ b/test/inference-exhaustion-rewind.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Poison-history breaker (6.5): noteInferenceExhausted used to only log at
+ * streak>=3 ("[inference-hard-down]") while injecting a marker into the SAME
+ * poisoned history — every new push event woke the agent onto a context the
+ * API rejects, forever, until a manual /unstick.
+ *
+ * Now, at the hard-down threshold with a known NON-retryable failure, the
+ * breaker auto-quarantines: sheds the newest complete exchange (the same
+ * shedNewestTurn primitive the refusal auto-rewind and /unstick use — never
+ * orphaning a tool_use/thinking block), drops ONE consolidated marker, and
+ * queues a retry — bounded by the refusalHandling.maxRewinds cap so it can
+ * never eat the whole history.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AgentFramework } from '../src/framework.js';
+
+function makeHarness(opts?: { maxRewinds?: number; messages?: any[] }) {
+  const messages: any[] = opts?.messages ?? [
+    { id: 'u1', participant: 'human', content: [{ type: 'text', text: 'go' }], metadata: { messageId: '1' } },
+    { id: 'a1', participant: 'agent', content: [{ type: 'tool_use', name: 'shell', id: 't1' }] },
+    { id: 'r1', participant: 'user', content: [{ type: 'tool_result', toolUseId: 't1', content: 'X'.repeat(9_000_000) }] },
+  ];
+  const removed: string[] = [];
+  const added: Array<{ content: any[]; meta: any }> = [];
+  const cm = {
+    getAllMessages: () => messages,
+    removeMessage: (id: string) => {
+      removed.push(id);
+      const i = messages.findIndex((m) => m.id === id);
+      if (i >= 0) messages.splice(i, 1);
+    },
+    addMessage: (_p: string, content: any[], meta: any) => {
+      const id = `marker-${added.length}`;
+      added.push({ content, meta });
+      messages.push({ id, participant: 'user', content, metadata: meta });
+      return id;
+    },
+    editMessage: (id: string, content: any[]) => {
+      const m = messages.find((x) => x.id === id);
+      if (m) m.content = content;
+    },
+  };
+
+  const fw = Object.create(AgentFramework.prototype) as any;
+  fw.consecutiveInferenceFailures = new Map();
+  fw.exhaustionRewinds = new Map();
+  fw.rewindEpisode = new Map();
+  fw.pendingRequests = [];
+  fw.traceListeners = [];
+  fw.inferenceFailureEscalationThreshold = 3;
+  fw.agents = new Map([['cairn', {
+    name: 'cairn',
+    refusalHandling: { maxRewinds: opts?.maxRewinds ?? 3 },
+    getContextManager: () => cm,
+  }]]);
+
+  const errs: string[] = [];
+  const orig = console.error;
+  console.error = (...a: unknown[]) => { errs.push(a.join(' ')); };
+  const restore = () => { console.error = orig; };
+
+  return { fw, messages, removed, added, errs, restore };
+}
+
+const REASON = '400 invalid_request: tool_use ids must have a corresponding tool_result';
+
+test('at the threshold, non-retryable failures trigger an automatic rewind + retry', () => {
+  const { fw, removed, added, errs, restore } = makeHarness();
+  try {
+    fw.noteInferenceExhausted('cairn', REASON, false); // 1
+    fw.noteInferenceExhausted('cairn', REASON, false); // 2
+    assert.equal(removed.length, 0, 'no rewind before the threshold');
+
+    fw.noteInferenceExhausted('cairn', REASON, false); // 3 → breaker trips
+  } finally { restore(); }
+
+  // The poisoned tool exchange was shed as a COMPLETE pair (no orphans).
+  assert.deepEqual([...removed].sort(), ['a1', 'r1']);
+
+  // One consolidated rewind marker, attributed to the API rejection.
+  const marker = added.find((m) => m.meta.kind === 'refusal-rewind');
+  assert.ok(marker, 'rewind marker added');
+  assert.equal(marker!.meta.cause, 'inference-failure');
+  assert.match(marker!.content[0].text, /set aside/);
+  assert.match(marker!.content[0].text, /rejecting/);
+
+  // A retry was queued so the rewound history is verified immediately.
+  assert.equal(fw.pendingRequests.length, 1);
+  assert.equal(fw.pendingRequests[0].reason, 'inference-failure-rewind-retry');
+
+  assert.ok(errs.some((e) => e.includes('[inference-rewind]') && e.includes('auto-quarantined')));
+});
+
+test('retryable / unknown-retryability failures NEVER shed history (outages cost nothing)', () => {
+  const { fw, removed, restore } = makeHarness();
+  try {
+    for (let i = 0; i < 6; i++) fw.noteInferenceExhausted('cairn', '529 overloaded', true);
+    for (let i = 0; i < 6; i++) fw.noteInferenceExhausted('cairn', 'weird transport error', undefined);
+  } finally { restore(); }
+  assert.equal(removed.length, 0, 'transient failures must not consume history');
+  assert.equal(fw.pendingRequests.length, 0);
+});
+
+test('the breaker is capped: repeated failures stop shedding at maxRewinds', () => {
+  const { fw, removed, errs, restore } = makeHarness({
+    maxRewinds: 2,
+    messages: [
+      { id: 'm1', participant: 'human', content: [{ type: 'text', text: 'a' }], metadata: { messageId: '1' } },
+      { id: 'm2', participant: 'human', content: [{ type: 'text', text: 'b' }], metadata: { messageId: '2' } },
+      { id: 'm3', participant: 'human', content: [{ type: 'text', text: 'c' }], metadata: { messageId: '3' } },
+      { id: 'm4', participant: 'human', content: [{ type: 'text', text: 'd' }], metadata: { messageId: '4' } },
+    ],
+  });
+  try {
+    // 10 consecutive non-retryable failures: the breaker fires from streak 3 on,
+    // but only sheds up to the cap (2), then holds.
+    for (let i = 0; i < 10; i++) fw.noteInferenceExhausted('cairn', REASON, false);
+  } finally { restore(); }
+
+  assert.equal(removed.length, 2, `cap of 2 respected, shed: ${removed.join(', ')}`);
+  assert.equal(fw.pendingRequests.length, 2, 'retries stop when the cap is hit');
+  assert.ok(errs.some((e) => e.includes('rewind cap 2 reached')));
+  // History still has the untouched older messages — the breaker cannot eat it all.
+  assert.equal(fw.exhaustionRewinds.get('cairn'), 2);
+});
+
+test('a successful inference resets both the streak and the rewind budget', () => {
+  const { fw, removed, restore } = makeHarness();
+  try {
+    fw.noteInferenceExhausted('cairn', REASON, false);
+    fw.noteInferenceExhausted('cairn', REASON, false);
+    fw.noteInferenceExhausted('cairn', REASON, false); // shed #1
+    assert.equal(removed.length, 2); // one complete tool exchange
+
+    fw.emitTrace({ type: 'inference:completed', agentName: 'cairn' });
+    assert.equal(fw.consecutiveInferenceFailures.get('cairn'), 0);
+    assert.equal(fw.exhaustionRewinds.get('cairn'), 0);
+  } finally { restore(); }
+});
+
+test('nothing left to shed: the breaker degrades to logging, no crash, no loop', () => {
+  const { fw, removed, errs, restore } = makeHarness({
+    messages: [
+      { id: 'mk', participant: 'user', content: [{ type: 'text', text: 'sys' }], metadata: { system: true } },
+    ],
+  });
+  try {
+    for (let i = 0; i < 5; i++) fw.noteInferenceExhausted('cairn', REASON, false);
+  } finally { restore(); }
+  assert.equal(removed.length, 0);
+  assert.equal(fw.pendingRequests.length, 0, 'no retry queued when nothing was repaired');
+  assert.ok(errs.some((e) => e.includes('nothing left to shed')));
+});

--- a/test/inference-failure-observability.test.ts
+++ b/test/inference-failure-observability.test.ts
@@ -11,6 +11,9 @@ function makeHarness() {
   const fw = Object.create(AgentFramework.prototype) as any;
   fw.consecutiveInferenceFailures = new Map<string, number>();
   fw.inferenceFailureEscalationThreshold = 3;
+  fw.exhaustionRewinds = new Map<string, number>();
+  fw.rewindEpisode = new Map();
+  fw.pendingRequests = [];
 
   const markers: Array<{ text: string; meta: any }> = [];
   fw.agents = new Map([['cairn', {

--- a/test/mcpl-reconnect-events.test.ts
+++ b/test/mcpl-reconnect-events.test.ts
@@ -16,7 +16,12 @@ import { join } from 'node:path';
 import { McplServerConnection } from '../src/mcpl/server-connection.js';
 import type { McplHostCapabilities, McplServerConfig } from '../src/mcpl/types.js';
 
-const FIXTURE = join(import.meta.dirname, 'fixtures/flaky-mcpl-server.mjs');
+// The .mjs fixture is not compiled/copied by tsc, so when this test runs from
+// dist/test it must reach back into the source tree for it.
+const FIXTURE = [
+  join(import.meta.dirname, 'fixtures/flaky-mcpl-server.mjs'),
+  join(import.meta.dirname, '../../test/fixtures/flaky-mcpl-server.mjs'),
+].find((p) => existsSync(p))!;
 const TMP_DIR = join(import.meta.dirname, '../.test-tmp-reconnect');
 const FLAG_FILE = join(TMP_DIR, 'server-healthy');
 

--- a/test/mcpl-reconnect-reregistration.test.ts
+++ b/test/mcpl-reconnect-reregistration.test.ts
@@ -12,8 +12,9 @@
  * handlers with the REAL FeatureSetManager / CheckpointManager / PushHandler
  * and a fake connection (EventEmitter), asserting:
  *   1. a push event after close→reconnect is ACCEPTED again;
- *   2. checkpoint state SURVIVES a transient close (willReconnect=true);
- *   3. checkpoint state is destroyed only on PERMANENT removal.
+ *   2. checkpoint state SURVIVES any close (transient OR clean shutdown);
+ *   3. checkpoint state is destroyed only via disconnectMcplServer (explicit
+ *      permanent removal), never by the close handler.
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -176,18 +177,28 @@ test('checkpoint state SURVIVES a transient close + reconnect', () => {
   assert.deepEqual(fw.checkpointManager.getCurrentState('srv', 'mem'), { counter: 42 });
 });
 
-test('checkpoint state is destroyed on PERMANENT close (no reconnect loop)', () => {
+test('the close handler NEVER destroys checkpoints — even with willReconnect=false', () => {
+  // A clean AgentFramework.stop() sets reconnectEnabled=false BEFORE emitting
+  // 'close', so willReconnect is false on an ordinary host restart just as much
+  // as on a permanent teardown. Gating checkpoint destruction on willReconnect
+  // would therefore erase every durable checkpoint tree on a polite restart
+  // (while a SIGKILL, whose 'close' carries willReconnect=true, preserved them).
+  // Permanent removal is owned solely by disconnectMcplServer; the close handler
+  // must leave the persisted tree intact for loadFromStore() to resume.
   const { fw, store, connection } = makeHarness();
 
   fw.checkpointManager.recordCheckpoint('srv', 'mem', { checkpoint: 'cp1', data: { x: 1 } });
 
-  // Permanent: explicit close() disables reconnect before emitting 'close'.
+  // Even a "permanent-looking" close (reconnect disabled) must not delete state.
   connection.willReconnect = false;
   connection.emit('close', 0, null);
 
-  assert.equal(fw.checkpointManager.getCurrentCheckpoint('srv', 'mem'), null);
+  assert.equal(
+    fw.checkpointManager.getCurrentCheckpoint('srv', 'mem'), 'cp1',
+    'the close handler must not destroy checkpoints on a clean shutdown',
+  );
   const persisted = store.slots.get('mcpl/checkpoints') as { trees: Record<string, unknown> };
-  assert.equal(persisted.trees['srv:mem'], undefined, 'permanent removal persists the deletion');
+  assert.ok(persisted.trees['srv:mem'], 'the persisted tree survives a clean shutdown for later resume');
 });
 
 test('disconnectMcplServer destroys checkpoints even when the connection already closed transiently', async () => {

--- a/test/mcpl-reconnect-reregistration.test.ts
+++ b/test/mcpl-reconnect-reregistration.test.ts
@@ -1,0 +1,216 @@
+/**
+ * MCPL auto-reconnect must RE-REGISTER the server, not just refresh tools.
+ *
+ * Before the fix, the 'close' handler removed the server from the
+ * FeatureSetManager (and destroyed its checkpoint trees), while the
+ * 'reconnect' handler only re-listed tools. Result: after any transient
+ * crash + successful reconnect, validateInbound threw "Unknown server"
+ * forever — every push event and inference request rejected until a full
+ * host restart — and the server's durable checkpoint state was gone.
+ *
+ * These tests exercise the framework's wireMcplEvents close/reconnect
+ * handlers with the REAL FeatureSetManager / CheckpointManager / PushHandler
+ * and a fake connection (EventEmitter), asserting:
+ *   1. a push event after close→reconnect is ACCEPTED again;
+ *   2. checkpoint state SURVIVES a transient close (willReconnect=true);
+ *   3. checkpoint state is destroyed only on PERMANENT removal.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+
+import { AgentFramework } from '../src/framework.js';
+import { FeatureSetManager } from '../src/mcpl/feature-set-manager.js';
+import { ScopeManager } from '../src/mcpl/scope-manager.js';
+import { CheckpointManager } from '../src/mcpl/checkpoint-manager.js';
+import { PushHandler } from '../src/mcpl/push-handler.js';
+import type { McplCapabilities, McplServerConfig, PushEventResult } from '../src/mcpl/types.js';
+
+/** In-memory JsStore stub — CheckpointManager only needs the state-slot API. */
+function makeStoreStub() {
+  const slots = new Map<string, unknown>();
+  return {
+    slots,
+    registerState: (_opts: { id: string; strategy: string }) => {},
+    setStateJson: (id: string, value: unknown) => { slots.set(id, structuredClone(value)); },
+    getStateJson: (id: string) => slots.get(id) ?? null,
+  };
+}
+
+const CAPABILITIES: McplCapabilities = {
+  version: '0.4',
+  featureSets: {
+    chat: { description: 'chat events', uses: ['pushEvents'] },
+    mem: { description: 'stateful memory', uses: ['tools'], hostState: true, rollback: true },
+  },
+} as unknown as McplCapabilities;
+
+class FakeConnection extends EventEmitter {
+  readonly id: string;
+  capabilities: McplCapabilities | null = CAPABILITIES;
+  willReconnect = true;
+  featureSetUpdates: unknown[] = [];
+  constructor(id: string) {
+    super();
+    this.id = id;
+  }
+  sendFeatureSetsUpdate(params: unknown): void {
+    this.featureSetUpdates.push(params);
+  }
+}
+
+function makeHarness() {
+  const store = makeStoreStub();
+  const traces: Array<{ type: string }> = [];
+  const pushed: unknown[] = [];
+
+  const fw = Object.create(AgentFramework.prototype) as any;
+  fw.traceListeners = [];
+  fw.consecutiveInferenceFailures = new Map();
+  fw.exhaustionRewinds = new Map();
+  fw.agents = new Map();
+  fw.mcplTools = [];
+  fw.mcplToolRefreshInFlight = false;
+  fw.mcplToolRefreshPending = false;
+  fw.mcplServerRegistry = null; // handleToolsListChanged no-ops without it
+  fw.channelRegistry = null;
+  fw.inferenceRouter = null;
+  fw.eventGate = null;
+
+  fw.featureSetManager = new FeatureSetManager();
+  fw.scopeManager = new ScopeManager();
+  fw.checkpointManager = new CheckpointManager(store as never, (e: any) => traces.push(e));
+  fw.pushHandler = new PushHandler(
+    fw.featureSetManager,
+    (e: unknown) => pushed.push(e),
+    (e: any) => traces.push(e),
+  );
+
+  const config: McplServerConfig = {
+    id: 'srv',
+    command: 'unused',
+    enabledFeatureSets: ['chat', 'mem'],
+    reconnect: true,
+  };
+  fw.mcplServerConfigs = new Map([[config.id, config]]);
+
+  const connection = new FakeConnection('srv');
+  fw.wireMcplEvents(connection);
+  fw.registerMcplServerFeatures(config, connection);
+
+  const sendPush = (eventId: string): PushEventResult => {
+    let result: PushEventResult | undefined;
+    connection.emit(
+      'push-event',
+      {
+        featureSet: 'chat',
+        eventId,
+        timestamp: new Date().toISOString(),
+        payload: { content: [{ type: 'text', text: 'hello' }] },
+      },
+      {
+        respond: (r: PushEventResult) => { result = r; },
+        respondError: () => { assert.fail('push responded with a JSON-RPC error'); },
+      },
+    );
+    assert.ok(result, 'push handler must respond synchronously');
+    return result!;
+  };
+
+  return { fw, store, connection, config, sendPush, pushed, traces };
+}
+
+test('reconnect re-registers the server: pushes are accepted again after close→reconnect', () => {
+  const { fw, connection, sendPush, pushed } = makeHarness();
+
+  // Sanity: initial registration accepts pushes.
+  assert.equal(sendPush('e1').accepted, true);
+  assert.equal(pushed.length, 1);
+
+  // Transient crash: transport closed, background reconnect pending.
+  connection.willReconnect = true;
+  connection.emit('close', null, 'SIGKILL');
+
+  // While down, the server is deregistered — pushes are rejected.
+  const down = sendPush('e2');
+  assert.equal(down.accepted, false);
+  assert.match(down.reason ?? '', /Unknown server/);
+
+  // Reconnect succeeded (fresh handshake refreshed capabilities).
+  connection.emit('reconnect', { attempts: 1 });
+
+  // THE regression: before the fix this stayed rejected forever.
+  const revived = sendPush('e3');
+  assert.equal(revived.accepted, true, `push after reconnect must be accepted, got: ${revived.reason}`);
+  assert.equal(pushed.length, 2);
+
+  // The server was told its enabled feature sets again on re-registration.
+  assert.equal(connection.featureSetUpdates.length, 2, 'featureSets/update re-sent on reconnect');
+  assert.ok(fw.featureSetManager.isEnabled('srv', 'chat'));
+});
+
+test('checkpoint state SURVIVES a transient close + reconnect', () => {
+  const { fw, store, connection } = makeHarness();
+
+  // Record durable checkpoint state for the stateful feature set.
+  fw.checkpointManager.recordCheckpoint('srv', 'mem', {
+    checkpoint: 'cp1',
+    data: { counter: 42 },
+  });
+  assert.equal(fw.checkpointManager.getCurrentCheckpoint('srv', 'mem'), 'cp1');
+
+  // Transient close: reconnect loop is active.
+  connection.willReconnect = true;
+  connection.emit('close', 1, null);
+
+  assert.equal(
+    fw.checkpointManager.getCurrentCheckpoint('srv', 'mem'), 'cp1',
+    'a transient disconnect must NOT destroy checkpoint trees',
+  );
+  const persisted = store.slots.get('mcpl/checkpoints') as { trees: Record<string, unknown> };
+  assert.ok(persisted.trees['srv:mem'], 'the persisted tree must not be deleted from Chronicle');
+
+  // Reconnect: idempotent re-registration resumes (not resets) the tree.
+  connection.emit('reconnect', { attempts: 1 });
+  assert.equal(fw.checkpointManager.getCurrentCheckpoint('srv', 'mem'), 'cp1');
+  assert.deepEqual(fw.checkpointManager.getCurrentState('srv', 'mem'), { counter: 42 });
+});
+
+test('checkpoint state is destroyed on PERMANENT close (no reconnect loop)', () => {
+  const { fw, store, connection } = makeHarness();
+
+  fw.checkpointManager.recordCheckpoint('srv', 'mem', { checkpoint: 'cp1', data: { x: 1 } });
+
+  // Permanent: explicit close() disables reconnect before emitting 'close'.
+  connection.willReconnect = false;
+  connection.emit('close', 0, null);
+
+  assert.equal(fw.checkpointManager.getCurrentCheckpoint('srv', 'mem'), null);
+  const persisted = store.slots.get('mcpl/checkpoints') as { trees: Record<string, unknown> };
+  assert.equal(persisted.trees['srv:mem'], undefined, 'permanent removal persists the deletion');
+});
+
+test('disconnectMcplServer destroys checkpoints even when the connection already closed transiently', async () => {
+  const { fw, connection, config } = makeHarness();
+
+  fw.checkpointManager.recordCheckpoint('srv', 'mem', { checkpoint: 'cp1', data: { x: 1 } });
+
+  // Transient close first (checkpoints preserved for the pending reconnect)…
+  connection.willReconnect = true;
+  connection.emit('close', 1, null);
+  assert.equal(fw.checkpointManager.getCurrentCheckpoint('srv', 'mem'), 'cp1');
+
+  // …then the operator permanently removes the server. close() on an
+  // already-closed connection emits no second 'close', so the explicit
+  // cleanup in disconnectMcplServer must handle it.
+  fw.mcplServerRegistry = {
+    removeServer: async () => {},
+    getAllServers: () => [],
+    getServer: () => null,
+  };
+  fw.mcplPrefixMap = new Map([[`mcpl--srv`, 'srv']]);
+  await fw.disconnectMcplServer(config.id);
+
+  assert.equal(fw.checkpointManager.getCurrentCheckpoint('srv', 'mem'), null);
+  assert.equal(fw.featureSetManager.isEnabled('srv', 'chat'), false);
+});

--- a/test/mcpl-request-timeout.test.ts
+++ b/test/mcpl-request-timeout.test.ts
@@ -1,0 +1,120 @@
+/**
+ * MCPL per-request timeout (6.2): a live-but-stuck server — accepts a
+ * request, never responds, never closes its transport — must not freeze the
+ * awaiting caller forever. sendRequest rejects after requestTimeoutMs with a
+ * descriptive error; the framework maps that rejection to an isError
+ * tool_result, so the agent turn completes instead of hanging.
+ */
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { McplServerConnection } from '../src/mcpl/server-connection.js';
+import type { McplHostCapabilities, McplServerConfig } from '../src/mcpl/types.js';
+
+// Stdio server: answers initialize and tools/list, but swallows tools/call —
+// the "zulip HTML-error / event-loop-wedge" profile (alive, deaf).
+const HUNG_SERVER = `
+let buf = '';
+process.stdin.on('data', (c) => {
+  buf += c.toString('utf8');
+  let i;
+  while ((i = buf.indexOf('\\n')) >= 0) {
+    const line = buf.slice(0, i); buf = buf.slice(i + 1);
+    if (!line.trim()) continue;
+    let m; try { m = JSON.parse(line); } catch { continue; }
+    const reply = (result) => process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: m.id, result }) + '\\n');
+    if (m.method === 'initialize') reply({ capabilities: {} });
+    else if (m.method === 'tools/list') reply({ tools: [{ name: 'stuck', description: 's', inputSchema: { type: 'object' } }] });
+    // tools/call: deliberately NO response, connection stays open.
+  }
+});
+setInterval(() => {}, 1 << 30); // stay alive
+`;
+
+const HOST_CAPS: McplHostCapabilities = {
+  version: '0.4',
+  pushEvents: true,
+  contextHooks: { beforeInference: true, afterInference: { blocking: true } },
+  featureSets: true,
+};
+
+function config(overrides?: Partial<McplServerConfig>): McplServerConfig {
+  return {
+    id: 'hung',
+    command: process.execPath,
+    args: ['-e', HUNG_SERVER],
+    ...overrides,
+  };
+}
+
+let connection: McplServerConnection | null = null;
+afterEach(async () => {
+  await connection?.close();
+  connection = null;
+});
+
+test('tools/call against a hung server rejects within the configured timeout', async () => {
+  connection = await McplServerConnection.connect(config({ requestTimeoutMs: 250 }), HOST_CAPS);
+  connection.ready();
+
+  const started = Date.now();
+  await assert.rejects(
+    connection.sendToolsCall('stuck', {}),
+    (err: Error) => {
+      assert.match(err.message, /did not respond to tools\/call/);
+      assert.match(err.message, /250ms/);
+      assert.match(err.message, /hung/);
+      return true;
+    },
+  );
+  const elapsed = Date.now() - started;
+  assert.ok(elapsed >= 200 && elapsed < 5000, `rejected in ${elapsed}ms (expected ~250ms)`);
+
+  // The connection survives the abandoned request: a request the server DOES
+  // answer still works afterwards.
+  const list = await connection.sendToolsList();
+  assert.equal(list.tools[0]?.name, 'stuck');
+});
+
+test('a request the server answers in time is unaffected by the timeout', async () => {
+  connection = await McplServerConnection.connect(config({ requestTimeoutMs: 2000 }), HOST_CAPS);
+  connection.ready();
+
+  const list = await connection.sendToolsList();
+  assert.equal(list.tools.length, 1);
+});
+
+test('requestTimeoutMs: 0 disables the per-request watchdog', async () => {
+  connection = await McplServerConnection.connect(config({ requestTimeoutMs: 0 }), HOST_CAPS);
+  connection.ready();
+
+  let settled = false;
+  const call = connection.sendToolsCall('stuck', {}).catch(() => {}).finally(() => { settled = true; });
+  await new Promise((r) => setTimeout(r, 300));
+  assert.equal(settled, false, 'with timeout disabled the request stays pending');
+
+  // Cleanup: closing the connection rejects the pending request.
+  await connection.close();
+  connection = null;
+  await call;
+  assert.equal(settled, true);
+});
+
+test('a timed-out request that later receives a response does not crash (orphaned response ignored)', async () => {
+  // Server that answers tools/call after 500ms — beyond a 100ms timeout.
+  const SLOW_SERVER = HUNG_SERVER.replace(
+    '// tools/call: deliberately NO response, connection stays open.',
+    "else if (m.method === 'tools/call') setTimeout(() => reply({ content: [] }), 500);",
+  );
+  connection = await McplServerConnection.connect(
+    { id: 'slow', command: process.execPath, args: ['-e', SLOW_SERVER], requestTimeoutMs: 100 },
+    HOST_CAPS,
+  );
+  connection.ready();
+
+  await assert.rejects(connection.sendToolsCall('stuck', {}), /did not respond/);
+  // Wait past the server's late response; it must be ignored, not crash.
+  await new Promise((r) => setTimeout(r, 600));
+  const list = await connection.sendToolsList();
+  assert.equal(list.tools.length, 1);
+});

--- a/test/mcpl-request-timeout.test.ts
+++ b/test/mcpl-request-timeout.test.ts
@@ -100,6 +100,20 @@ test('requestTimeoutMs: 0 disables the per-request watchdog', async () => {
   assert.equal(settled, true);
 });
 
+test('the timeout error warns the model the tool may have completed server-side', async () => {
+  connection = await McplServerConnection.connect(config({ requestTimeoutMs: 150 }), HOST_CAPS);
+  connection.ready();
+  await assert.rejects(
+    connection.sendToolsCall('stuck', {}),
+    (err: Error) => {
+      // The model reads this string; it must not imply the call was cancelled.
+      assert.match(err.message, /may still have completed server-side/);
+      assert.match(err.message, /verify state before retrying/);
+      return true;
+    },
+  );
+});
+
 test('a timed-out request that later receives a response does not crash (orphaned response ignored)', async () => {
   // Server that answers tools/call after 500ms — beyond a 100ms timeout.
   const SLOW_SERVER = HUNG_SERVER.replace(
@@ -115,6 +129,34 @@ test('a timed-out request that later receives a response does not crash (orphane
   await assert.rejects(connection.sendToolsCall('stuck', {}), /did not respond/);
   // Wait past the server's late response; it must be ignored, not crash.
   await new Promise((r) => setTimeout(r, 600));
+  const list = await connection.sendToolsList();
+  assert.equal(list.tools.length, 1);
+});
+
+test('a late STATEFUL orphaned response is surfaced via mcpl:orphaned-response (not silently dropped)', async () => {
+  // Server answers tools/call after 500ms with a checkpoint-carrying result —
+  // beyond a 100ms timeout. The host advanced no checkpoint; the server did.
+  // That divergence must be greppable, so the connection emits an event.
+  const STATEFUL_SLOW = HUNG_SERVER.replace(
+    '// tools/call: deliberately NO response, connection stays open.',
+    "else if (m.method === 'tools/call') setTimeout(() => reply({ content: [], state: { checkpoint: 'cp-late', data: { n: 1 } } }), 500);",
+  );
+  connection = await McplServerConnection.connect(
+    { id: 'slow-stateful', command: process.execPath, args: ['-e', STATEFUL_SLOW], requestTimeoutMs: 100 },
+    HOST_CAPS,
+  );
+  connection.ready();
+
+  const orphaned: Array<{ hadState: boolean; hadCheckpoint: boolean }> = [];
+  connection.on('orphaned-response', (info) => orphaned.push(info));
+
+  await assert.rejects(connection.sendToolsCall('stuck', {}), /did not respond/);
+  await new Promise((r) => setTimeout(r, 600));
+
+  assert.equal(orphaned.length, 1, 'the dropped stateful response must be surfaced');
+  assert.equal(orphaned[0].hadState, true, 'the event records that state was carried');
+
+  // The connection still works afterwards.
   const list = await connection.sendToolsList();
   assert.equal(list.tools.length, 1);
 });

--- a/test/tool-result-content.test.ts
+++ b/test/tool-result-content.test.ts
@@ -1,0 +1,41 @@
+/**
+ * toMembraneToolResult (6.6): JSON.stringify(undefined) returns the VALUE
+ * undefined, not a string — a tool returning `{ success: true }` with no data
+ * plus a configured maxChars cap used to throw a TypeError on content.length
+ * mid-turn. It must degrade to a safe empty string instead.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AgentFramework } from '../src/framework.js';
+
+function makeFw() {
+  return Object.create(AgentFramework.prototype) as any;
+}
+
+test('undefined data + maxChars cap: no throw, content is a safe string', () => {
+  const fw = makeFw();
+  const result = fw.toMembraneToolResult('call-1', { success: true }, 1000);
+  assert.equal(result.toolUseId, 'call-1');
+  assert.equal(result.isError, false);
+  assert.equal(result.content, '');
+});
+
+test('undefined data without a cap also yields a string (never the value undefined)', () => {
+  const fw = makeFw();
+  const result = fw.toMembraneToolResult('call-2', { success: true, data: undefined });
+  assert.equal(typeof result.content, 'string');
+});
+
+test('normal data is still stringified and truncated by the cap', () => {
+  const fw = makeFw();
+  const result = fw.toMembraneToolResult('call-3', { success: true, data: { v: 'y'.repeat(500) } }, 100);
+  assert.equal(typeof result.content, 'string');
+  assert.match(result.content, /\[truncated — original was \d+ chars\]/);
+});
+
+test('error results pass through unchanged', () => {
+  const fw = makeFw();
+  const result = fw.toMembraneToolResult('call-4', { success: false, error: 'boom', isError: true }, 100);
+  assert.equal(result.isError, true);
+  assert.equal(result.content, 'boom');
+});


### PR DESCRIPTION
Part of the July 2026 fragility-audit remediation (see UNTESTED-ROUTES-TEST-PLAN.md §6.2, §6.3, §6.5, §6.6, §3.5).

## Fixes (all 5)
- **6.3 [H] MCPL reconnect deregistration + checkpoint destruction** — factored feature-set/scope/checkpoint init out of `connectMcplServerInternal` into idempotent `registerMcplServerFeatures()`, re-run on `'reconnect'`. `'close'` skips `checkpointManager.removeServer` when `connection.willReconnect`; `disconnectMcplServer` destroys state explicitly. Fixes the silent post-reconnect deafness (pushes/inference-requests rejected) and the transient-blip checkpoint deletion. (Found + handled a latent hole: an already-transiently-closed connection emits no second `close`.)
- **6.2 [H] No tools/call timeout** — per-request timer in `server-connection.ts` (default 60s, `McplServerConfig.requestTimeoutMs`, 0 disables, `unref`'d); late responses ignored; rejection maps to an `isError` tool_result so the turn completes instead of hanging.
- **6.5 [H] Log-only "circuit breaker"** — at streak≥3 with `retryable === false`, `quarantinePoisonedHistory()` sheds the newest complete exchange via the existing `/unstick` primitives (no orphaned tool_use/thinking) and queues a retry; capped by `refusalHandling.maxRewinds`. Retryable/unknown failures never shed history.
- **6.6 [M-H]** — `JSON.stringify(afResult.data) ?? ''` in `toMembraneToolResult`.
- **3.5 [M]** — new `Module.contextTimeoutMs` per-module gatherContext budget (the contract FKM's retrieval module consumes); registry default 5s → 15s; fail-open kept, race timer no longer leaks.

## Tests / build
`tsc --noEmit` + build clean; **261/261** (21 new across 5 files, incl. a real stdio child that swallows tools/call, and reconnect re-registration through the real wiring). Version 0.6.1 → 0.6.2 (not published).

## Not verified locally (documented)
Full-stack kill-9 reconnect drill (covered at the handler boundary instead) and live behavior against a real membrane-classified 400 — both belong to the post-deploy checklist. Baseline `main` had a pre-existing fixture-copy test failure (tsc doesn't copy the `.mjs` fixture into `dist`); fixed here by resolving the fixture from source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
