### PR TITLE
fix: eliminate set-rewrite quadratic states (inference log, process log, turn checkpoints) + whole-store scaling gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ data/
 .env
 package-lock.json
 bun.lock
+logs/

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "author": "Anima Research",
   "license": "MIT",
   "dependencies": {
-    "@animalabs/chronicle": "^0.2.0",
+    "@animalabs/chronicle": "^0.2.2",
     "@animalabs/context-manager": "^0.5.5",
     "@animalabs/membrane": "^0.5.64",
     "chokidar": "^4.0.3",

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -3708,11 +3708,27 @@ export class AgentFramework {
             // Only reset if this is still the active stream (a budget restart
             // may have already started a new stream, bumping streamId)
             if (agent.streamId === myStreamId) {
+              const durationMs = Date.now() - startTime;
               agent.reset();
               this.emitTrace({
                 type: 'inference:exhausted',
                 agentName: agent.name,
                 error: `Stream aborted: ${reason}`,
+              });
+              // Postmortem 2026-05-28 P2 #7: persist the abort to the
+              // inference log so future investigations can attribute the
+              // terminal cause without relying on live in-memory reducer
+              // state. Without this, abort-terminated inferences are
+              // invisible to forensic queries (only request-side telemetry
+              // via llm-calls.jsonl shows them, and only by absence).
+              this.logInference({
+                timestamp: startTime,
+                agentName: agent.name,
+                requestId,
+                success: false,
+                error: `Stream aborted: ${reason}`,
+                request: compiledRequest ?? { note: 'streaming request aborted' },
+                durationMs,
               });
               this.eventGate?.onInferenceEnded(agent.name);
             }
@@ -3738,6 +3754,7 @@ export class AgentFramework {
       // Stream itself threw (unexpected) — no retry path here, so also emit
       // inference:exhausted so ephemeral agent promises can settle.
       const err = error instanceof Error ? error : new Error(String(error));
+      const durationMs = Date.now() - startTime;
       this.emitTrace({
         type: 'inference:failed',
         agentName: agent.name,
@@ -3748,6 +3765,18 @@ export class AgentFramework {
         type: 'inference:exhausted',
         agentName: agent.name,
         error: err.message,
+      });
+      // Postmortem 2026-05-28 P2 #7: catch-path failures (stream itself
+      // threw) were previously only visible via in-memory trace listeners.
+      // Persist to inference log for forensic attribution.
+      this.logInference({
+        timestamp: startTime,
+        agentName: agent.name,
+        requestId,
+        success: false,
+        error: `Stream threw: ${err.message}`,
+        request: compiledRequest ?? { note: 'streaming request threw' },
+        durationMs,
       });
       agent.reset();
       this.eventGate?.onInferenceEnded(agent.name);

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -43,7 +43,7 @@ import type {
 } from './types/index.js';
 import { ProcessQueueImpl } from './queue.js';
 import { Agent } from './agent.js';
-import { ModuleRegistry } from './module-registry.js';
+import { ModuleRegistry, isStateExistsError } from './module-registry.js';
 import { McplServerRegistry } from './mcpl/server-registry.js';
 import { FeatureSetManager } from './mcpl/feature-set-manager.js';
 import { ScopeManager } from './mcpl/scope-manager.js';
@@ -81,7 +81,8 @@ const FRAMEWORK_STATE_ID = 'framework/state';
 const CONVERSATION_ROUTER_STATE_ID = 'framework/conversation-router';
 const INFERENCE_LOG_ID = 'framework/inference-log';
 const PROCESS_LOG_ID = 'framework/process-log';
-const TURN_CHECKPOINTS_ID = 'framework/turn-checkpoints';
+const TURN_CHECKPOINTS_ID = 'framework/turn-checkpoints'; // legacy single-map layout, read-only fallback
+const TURN_CHECKPOINTS_TREE_ID = 'framework/turn-checkpoints/tree';
 
 /** Maximum number of turn checkpoints to keep per agent. */
 const MAX_TURN_CHECKPOINTS = 20;
@@ -298,7 +299,6 @@ export class AgentFramework {
   // Undo/redo state
   private turnCounters: Map<string, number> = new Map(); // agentName → next turnIndex
   private redoStacks: Map<string, RedoEntry[]> = new Map(); // agentName → redo entries
-  private registeredCheckpointSlots: Set<string> = new Set(); // per-agent checkpoint state ids
 
   /** Liveness watchdog (fail hard on a wedged main thread). Null unless enabled. */
   private livenessWatchdog: import('./runtime/liveness-watchdog.js').LivenessWatchdog | null = null;
@@ -422,10 +422,12 @@ export class AgentFramework {
       // Already registered
     }
 
+    // The legacy single-map checkpoint state (TURN_CHECKPOINTS_ID) is no longer
+    // registered for new stores — it's read-only fallback data in old ones.
     try {
-      store.registerState({ id: TURN_CHECKPOINTS_ID, strategy: 'snapshot' });
-    } catch {
-      // Already registered
+      store.registerState({ id: TURN_CHECKPOINTS_TREE_ID, strategy: 'tree' });
+    } catch (error) {
+      if (!isStateExistsError(error)) throw error;
     }
 
     // Process logging config (default: disabled)
@@ -2273,44 +2275,69 @@ export class AgentFramework {
   }
 
   /**
-   * Checkpoints live in one state slot per agent (`framework/turn-checkpoints/<name>`)
-   * rather than a single Record<agentName, TurnCheckpoint[]> map. Subagent names are
-   * unique per spawn and nothing evicted departed keys, so the map grew without bound
-   * in agents-ever-spawned — and the whole map was rewritten on every turn of every
-   * agent. A per-agent slot write is O(MAX_TURN_CHECKPOINTS), independent of fleet
-   * history. The legacy map state (TURN_CHECKPOINTS_ID) is kept as a read-only
-   * fallback for stores written before the split.
+   * Checkpoints live in one Tree state (TURN_CHECKPOINTS_TREE_ID) keyed by agent
+   * name, each key pointing at a JSON blob of that agent's ≤MAX_TURN_CHECKPOINTS
+   * list. This kills two unbounded-in-agents-ever dimensions at once:
+   *
+   *  - the original single Record<agentName, list> map was rewritten whole on
+   *    every turn of every agent and never evicted a departed subagent's key;
+   *  - the intermediate design (one state slot per agent) fixed the writes but
+   *    leaked a permanent chronicle state *registration* per spawn — chronicle
+   *    has no deregistration, and the state index is rewritten and fsynced on
+   *    every sync tick, so per-tick cost grew with fleet history anyway.
+   *
+   * A tree gives per-key O(entry) writes, real key removal (treeRemove), and
+   * exactly one registration for the life of the store. The legacy map state
+   * (TURN_CHECKPOINTS_ID) is kept as a read-only fallback for stores written
+   * before the split; eviction tombstones legacy keys so a reused agent name
+   * can't inherit a dead agent's checkpoints through the fallback.
    */
-  private ensureCheckpointSlot(agentName: string): string {
-    const id = `${TURN_CHECKPOINTS_ID}/${agentName}`;
-    if (!this.registeredCheckpointSlots.has(id)) {
-      try {
-        this.store.registerState({ id, strategy: 'snapshot' });
-      } catch {
-        // Already registered
-      }
-      this.registeredCheckpointSlots.add(id);
+  private legacyCheckpointKeys: Set<string> | null = null;
+
+  private hasLegacyCheckpoints(agentName: string): boolean {
+    if (!this.legacyCheckpointKeys) {
+      const legacy = this.store.getStateJson(TURN_CHECKPOINTS_ID);
+      this.legacyCheckpointKeys = new Set(
+        legacy && typeof legacy === 'object' ? Object.keys(legacy) : []
+      );
     }
-    return id;
+    return this.legacyCheckpointKeys.has(agentName);
   }
 
   private getTurnCheckpoints(agentName: string): TurnCheckpoint[] {
-    const slot = this.store.getStateJson(this.ensureCheckpointSlot(agentName));
-    if (Array.isArray(slot)) return [...slot];
-    const legacy = this.store.getStateJson(TURN_CHECKPOINTS_ID);
-    if (!legacy || typeof legacy !== 'object') return [];
-    const allCheckpoints = legacy as Record<string, TurnCheckpoint[]>;
-    return Array.isArray(allCheckpoints[agentName]) ? [...allCheckpoints[agentName]] : [];
+    const entry = this.store.treeGet(TURN_CHECKPOINTS_TREE_ID, agentName);
+    if (entry) {
+      const blob = this.store.getBlob(entry.blobHash);
+      if (!blob) return [];
+      try {
+        const parsed = JSON.parse(blob.toString());
+        return Array.isArray(parsed) ? parsed : [];
+      } catch {
+        return [];
+      }
+    }
+    if (!this.hasLegacyCheckpoints(agentName)) return [];
+    const legacy = this.store.getStateJson(TURN_CHECKPOINTS_ID) as
+      | Record<string, TurnCheckpoint[]>
+      | null;
+    const list = legacy?.[agentName];
+    return Array.isArray(list) ? [...list] : [];
   }
 
   private saveTurnCheckpoints(agentName: string, checkpoints: TurnCheckpoint[]): void {
-    this.store.setStateJson(this.ensureCheckpointSlot(agentName), checkpoints);
+    const bytes = Buffer.from(JSON.stringify(checkpoints));
+    const blobHash = this.store.storeBlob(bytes, 'application/json');
+    this.store.treeSet(TURN_CHECKPOINTS_TREE_ID, agentName, {
+      blobHash,
+      size: bytes.length,
+      mode: 0o644,
+    });
   }
 
   /**
-   * Drop a departed agent's checkpoint slot and turn/redo bookkeeping. Without
-   * this, spawn-and-dispose agents leave a slot (and in-memory map entries)
-   * behind for the life of the store/session.
+   * Drop a departed agent's checkpoint tree key and turn/redo bookkeeping.
+   * Without this, spawn-and-dispose agents leave a key (and in-memory map
+   * entries) behind for the life of the store/session.
    */
   private evictTurnCheckpoints(agentName: string): void {
     this.turnCounters.delete(agentName);
@@ -2319,10 +2346,18 @@ export class AgentFramework {
     // spawn-and-dispose fleets would grow them for the session's life.
     this.staleWarnAt.delete(agentName);
     this.lastInferenceAt.delete(agentName);
-    const id = this.ensureCheckpointSlot(agentName);
-    const slot = this.store.getStateJson(id);
-    if (Array.isArray(slot) && slot.length > 0) {
-      this.store.setStateJson(id, []);
+    const entry = this.store.treeGet(TURN_CHECKPOINTS_TREE_ID, agentName);
+    if (this.hasLegacyCheckpoints(agentName)) {
+      // A bare treeRemove would resurrect the legacy map's list through the
+      // fallback next time this name is reused — shadow it with an empty
+      // tombstone instead. size <= 2 ⇔ the blob is already "[]".
+      if (!entry || entry.size > 2) {
+        this.saveTurnCheckpoints(agentName, []);
+      }
+      return;
+    }
+    if (entry) {
+      this.store.treeRemove(TURN_CHECKPOINTS_TREE_ID, agentName);
     }
   }
 

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -2333,6 +2333,9 @@ export class AgentFramework {
   async runUntilIdle(): Promise<void> {
     while (
       !this.queue.isEmpty ||
+      // Direct inference requests (e.g. runEphemeralToCompletion) bypass the
+      // event queue — without this the loop can exit before they're drained.
+      this.pendingRequests.length > 0 ||
       this.activeStreams.size > 0 ||
       Array.from(this.agents.values()).some((a) => a.state.status !== 'idle')
     ) {

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -298,6 +298,7 @@ export class AgentFramework {
   // Undo/redo state
   private turnCounters: Map<string, number> = new Map(); // agentName → next turnIndex
   private redoStacks: Map<string, RedoEntry[]> = new Map(); // agentName → redo entries
+  private registeredCheckpointSlots: Set<string> = new Set(); // per-agent checkpoint state ids
 
   /** Liveness watchdog (fail hard on a wedged main thread). Null unless enabled. */
   private livenessWatchdog: import('./runtime/liveness-watchdog.js').LivenessWatchdog | null = null;
@@ -1038,6 +1039,7 @@ export class AgentFramework {
         clearInterval(completionWatchdog);
         this.offTrace(traceListener);
         this.agents.delete(agent.name);
+        this.evictTurnCheckpoints(agent.name);
       };
 
       // Watchdog: if inference never starts within 30s, the agent is a zombie.
@@ -2270,18 +2272,58 @@ export class AgentFramework {
     this.saveTurnCheckpoints(agentName, checkpoints);
   }
 
+  /**
+   * Checkpoints live in one state slot per agent (`framework/turn-checkpoints/<name>`)
+   * rather than a single Record<agentName, TurnCheckpoint[]> map. Subagent names are
+   * unique per spawn and nothing evicted departed keys, so the map grew without bound
+   * in agents-ever-spawned — and the whole map was rewritten on every turn of every
+   * agent. A per-agent slot write is O(MAX_TURN_CHECKPOINTS), independent of fleet
+   * history. The legacy map state (TURN_CHECKPOINTS_ID) is kept as a read-only
+   * fallback for stores written before the split.
+   */
+  private ensureCheckpointSlot(agentName: string): string {
+    const id = `${TURN_CHECKPOINTS_ID}/${agentName}`;
+    if (!this.registeredCheckpointSlots.has(id)) {
+      try {
+        this.store.registerState({ id, strategy: 'snapshot' });
+      } catch {
+        // Already registered
+      }
+      this.registeredCheckpointSlots.add(id);
+    }
+    return id;
+  }
+
   private getTurnCheckpoints(agentName: string): TurnCheckpoint[] {
-    const data = this.store.getStateJson(TURN_CHECKPOINTS_ID);
-    if (!data || typeof data !== 'object') return [];
-    const allCheckpoints = data as Record<string, TurnCheckpoint[]>;
+    const slot = this.store.getStateJson(this.ensureCheckpointSlot(agentName));
+    if (Array.isArray(slot)) return [...slot];
+    const legacy = this.store.getStateJson(TURN_CHECKPOINTS_ID);
+    if (!legacy || typeof legacy !== 'object') return [];
+    const allCheckpoints = legacy as Record<string, TurnCheckpoint[]>;
     return Array.isArray(allCheckpoints[agentName]) ? [...allCheckpoints[agentName]] : [];
   }
 
   private saveTurnCheckpoints(agentName: string, checkpoints: TurnCheckpoint[]): void {
-    const data = this.store.getStateJson(TURN_CHECKPOINTS_ID);
-    const allCheckpoints = (data && typeof data === 'object' ? data : {}) as Record<string, TurnCheckpoint[]>;
-    allCheckpoints[agentName] = checkpoints;
-    this.store.setStateJson(TURN_CHECKPOINTS_ID, allCheckpoints);
+    this.store.setStateJson(this.ensureCheckpointSlot(agentName), checkpoints);
+  }
+
+  /**
+   * Drop a departed agent's checkpoint slot and turn/redo bookkeeping. Without
+   * this, spawn-and-dispose agents leave a slot (and in-memory map entries)
+   * behind for the life of the store/session.
+   */
+  private evictTurnCheckpoints(agentName: string): void {
+    this.turnCounters.delete(agentName);
+    this.redoStacks.delete(agentName);
+    // Diagnostics maps are also keyed by agent name and never evicted —
+    // spawn-and-dispose fleets would grow them for the session's life.
+    this.staleWarnAt.delete(agentName);
+    this.lastInferenceAt.delete(agentName);
+    const id = this.ensureCheckpointSlot(agentName);
+    const slot = this.store.getStateJson(id);
+    if (Array.isArray(slot) && slot.length > 0) {
+      this.store.setStateJson(id, []);
+    }
   }
 
   /**
@@ -2823,6 +2865,7 @@ export class AgentFramework {
     this.agents.delete(agentName);
     this.agentConfigs.delete(agentName);
     this.conversationAgentHomes.delete(agentName);
+    this.evictTurnCheckpoints(agentName);
     this.emitTrace({
       type: 'mcpl:conversation-disposed',
       agentName,
@@ -3955,11 +3998,11 @@ export class AgentFramework {
       }
     }
 
-    // Append to the inference log state
-    const data = this.store.getStateJson(INFERENCE_LOG_ID);
-    const entries = Array.isArray(data) ? data : [];
-    entries.push(entryToStore);
-    this.store.setStateJson(INFERENCE_LOG_ID, entries);
+    // Append one record per inference. A read-modify-write via setStateJson
+    // would emit a whole-array Set — record size then grows with accumulated
+    // history (O(n²) aggregate disk) and the append_log strategy registered
+    // for this state never sees an append.
+    this.store.appendToStateJson(INFERENCE_LOG_ID, entryToStore);
   }
 
   private logProcessEvent(event: ProcessEvent, responses: ModuleProcessResponse[]): void {
@@ -3979,11 +4022,8 @@ export class AgentFramework {
       entryToStore.responses = { blobId };
     }
 
-    // Append to the process log state
-    const data = this.store.getStateJson(PROCESS_LOG_ID);
-    const entries = Array.isArray(data) ? data : [];
-    entries.push(entryToStore);
-    this.store.setStateJson(PROCESS_LOG_ID, entries);
+    // Append one record per event — same rationale as logInference.
+    this.store.appendToStateJson(PROCESS_LOG_ID, entryToStore);
   }
 
   /**

--- a/src/module-registry.ts
+++ b/src/module-registry.ts
@@ -28,6 +28,16 @@ import type { Agent } from './agent.js';
 const MODULE_STATE_PREFIX = 'modules/';
 
 /**
+ * True when a registerState failure means "this state id already exists" —
+ * the one failure that is safe to swallow on an idempotent re-registration.
+ * Anything else (closed store, IO error) must propagate: swallowing it defers
+ * the real error to a later write with far worse context.
+ */
+export function isStateExistsError(err: unknown): boolean {
+  return err instanceof Error && err.message.includes('State already exists');
+}
+
+/**
  * Hard ceiling for a single module's gatherContext budget, regardless of the
  * `contextTimeoutMs` it declares. gatherContext runs on the critical path of
  * every inference turn, so an unbounded self-declared budget would let one
@@ -468,6 +478,10 @@ class ModuleContextImpl implements ModuleContext {
     this.store.setStateJson(this.stateId, fullState);
   }
 
+  /** Log-state names this context has registered (registerLogState is
+   *  contract-required in start(), so this is populated before any use). */
+  private registeredLogStates = new Set<string>();
+
   private logStateId(name: string): string {
     if (!name || name === 'state' || name.includes('/')) {
       throw new Error(
@@ -475,6 +489,23 @@ class ModuleContextImpl implements ModuleContext {
       );
     }
     return `${MODULE_STATE_PREFIX}${this.moduleName}/${name}`;
+  }
+
+  /**
+   * Like logStateId, but only for names that went through registerLogState.
+   * Chronicle happily appends to an unregistered state — it just never gets a
+   * snapshot strategy, so every reconstruction replays the full op chain from
+   * record one. A forgotten registration or a typo'd name in one call site
+   * must be an immediate, attributable error, not a silent O(n²)-read trap.
+   */
+  private registeredLogStateId(name: string): string {
+    if (!this.registeredLogStates.has(name)) {
+      throw new Error(
+        `Module log state '${name}' is not registered for module '${this.moduleName}' — ` +
+        `call registerLogState('${name}') in start() before using it`
+      );
+    }
+    return this.logStateId(name);
   }
 
   registerLogState(
@@ -489,26 +520,28 @@ class ModuleContextImpl implements ModuleContext {
         deltaSnapshotEvery: opts?.deltaSnapshotEvery ?? 100,
         fullSnapshotEvery: opts?.fullSnapshotEvery ?? 20,
       });
-    } catch {
-      // Already registered (previous run)
+    } catch (err) {
+      if (!isStateExistsError(err)) throw err;
+      // Already registered (previous run) — idempotent path.
     }
+    this.registeredLogStates.add(name);
   }
 
   appendToLog<T>(name: string, item: T): void {
-    this.store.appendToStateJson(this.logStateId(name), item);
+    this.store.appendToStateJson(this.registeredLogStateId(name), item);
   }
 
   editLogItem<T>(name: string, index: number, item: T): void {
-    this.store.editStateItem(this.logStateId(name), index, Buffer.from(JSON.stringify(item)));
+    this.store.editStateItem(this.registeredLogStateId(name), index, Buffer.from(JSON.stringify(item)));
   }
 
   getLog<T>(name: string): T[] {
-    const data = this.store.getStateJson(this.logStateId(name));
+    const data = this.store.getStateJson(this.registeredLogStateId(name));
     return Array.isArray(data) ? (data as T[]) : [];
   }
 
   getLogLength(name: string): number {
-    return this.store.getStateLen(this.logStateId(name)) ?? 0;
+    return this.store.getStateLen(this.registeredLogStateId(name)) ?? 0;
   }
 
   getModule<T extends Module>(name: string): T | null {

--- a/src/module-registry.ts
+++ b/src/module-registry.ts
@@ -468,6 +468,49 @@ class ModuleContextImpl implements ModuleContext {
     this.store.setStateJson(this.stateId, fullState);
   }
 
+  private logStateId(name: string): string {
+    if (!name || name === 'state' || name.includes('/')) {
+      throw new Error(
+        `Invalid module log state name '${name}': must be non-empty, not 'state', and contain no '/'`
+      );
+    }
+    return `${MODULE_STATE_PREFIX}${this.moduleName}/${name}`;
+  }
+
+  registerLogState(
+    name: string,
+    opts?: { deltaSnapshotEvery?: number; fullSnapshotEvery?: number }
+  ): void {
+    const id = this.logStateId(name);
+    try {
+      this.store.registerState({
+        id,
+        strategy: 'append_log',
+        deltaSnapshotEvery: opts?.deltaSnapshotEvery ?? 100,
+        fullSnapshotEvery: opts?.fullSnapshotEvery ?? 20,
+      });
+    } catch {
+      // Already registered (previous run)
+    }
+  }
+
+  appendToLog<T>(name: string, item: T): void {
+    this.store.appendToStateJson(this.logStateId(name), item);
+  }
+
+  editLogItem<T>(name: string, index: number, item: T): void {
+    this.store.editStateItem(this.logStateId(name), index, Buffer.from(JSON.stringify(item)));
+  }
+
+  getLog<T>(name: string): T[] {
+    const data = this.store.getStateJson(this.logStateId(name));
+    return Array.isArray(data) ? (data as T[]) : [];
+  }
+
+  getLogLength(name: string): number {
+    return this.store.getStateLen(this.logStateId(name)) ?? 0;
+  }
+
   getModule<T extends Module>(name: string): T | null {
     return this.registry.getModule<T>(name);
   }

--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -110,8 +110,51 @@ export interface ModuleContext {
 
   /**
    * Set persistent state for this module.
+   *
+   * This rewrites the module's full state object every call — appropriate for
+   * small, bounded state only. For accumulating collections (registries,
+   * corpora, histories) use a log state (`registerLogState`/`appendToLog`)
+   * instead: a setState of an ever-growing object makes every persisted record
+   * proportional to accumulated content, i.e. O(n²) aggregate disk.
    */
   setState<T>(state: T): void;
+
+  /**
+   * Register an auxiliary append-log state for this module, stored as
+   * `modules/<module>/<name>`. Idempotent — safe to call on every start().
+   * Items are appended with `appendToLog` (one O(item) record per append) and
+   * point-edited with `editLogItem`; Chronicle's append_log snapshot cadence
+   * handles consolidation. `name` must not be 'state' (reserved for the main
+   * snapshot state) and must not contain '/'.
+   */
+  registerLogState(
+    name: string,
+    opts?: { deltaSnapshotEvery?: number; fullSnapshotEvery?: number }
+  ): void;
+
+  /**
+   * Append one item to a log state registered via registerLogState.
+   * Record size is O(item), independent of accumulated log length.
+   */
+  appendToLog<T>(name: string, item: T): void;
+
+  /**
+   * Overwrite the item at `index` in a log state. Indices are stable —
+   * appends assign the next index and nothing is ever removed.
+   */
+  editLogItem<T>(name: string, index: number, item: T): void;
+
+  /**
+   * Read the full contents of a log state (empty array if never written).
+   * Intended for one-shot reconstruction at start(); keep hot-path reads
+   * against the in-memory copy.
+   */
+  getLog<T>(name: string): T[];
+
+  /**
+   * Number of items in a log state (0 if never written).
+   */
+  getLogLength(name: string): number;
 
   /**
    * Process queue for pushing events from external listeners.

--- a/test/inference-failure-observability.test.ts
+++ b/test/inference-failure-observability.test.ts
@@ -10,6 +10,7 @@ import { AgentFramework } from '../src/framework.js';
 function makeHarness() {
   const fw = Object.create(AgentFramework.prototype) as any;
   fw.consecutiveInferenceFailures = new Map<string, number>();
+  fw.lastInferenceAt = new Map<string, unknown>();
   fw.inferenceFailureEscalationThreshold = 3;
   fw.exhaustionRewinds = new Map<string, number>();
   fw.rewindEpisode = new Map();

--- a/test/inference-failure-observability.test.ts
+++ b/test/inference-failure-observability.test.ts
@@ -10,7 +10,6 @@ import { AgentFramework } from '../src/framework.js';
 function makeHarness() {
   const fw = Object.create(AgentFramework.prototype) as any;
   fw.consecutiveInferenceFailures = new Map<string, number>();
-  fw.lastInferenceAt = new Map<string, unknown>();
   fw.inferenceFailureEscalationThreshold = 3;
   fw.exhaustionRewinds = new Map<string, number>();
   fw.rewindEpisode = new Map();

--- a/test/state-scaling-e2e.test.ts
+++ b/test/state-scaling-e2e.test.ts
@@ -30,8 +30,10 @@ import { MockMembrane, createMockResponse } from './helpers/mock-membrane.js';
 
 const SLOPE_LIMIT = 0.3;
 const MIN_RECORDS_FOR_FIT = 8;
-/** ≥ MAX_TURN_CHECKPOINTS × generous per-checkpoint size; a whole-map rewrite
- *  under fleet load blows far past this. */
+/** Bounded-by-design families get a hard per-record ceiling instead of a
+ *  slope fit: the checkpoint tree's ops are O(key) and its periodic
+ *  consolidation snapshots are O(live keys) — both far under this, while a
+ *  whole-map rewrite under fleet load blows past it. */
 const CAPPED_MAX_RECORD_BYTES = 16 * 1024;
 const CAPPED_FAMILIES = [/^framework\/turn-checkpoints\//];
 
@@ -166,11 +168,28 @@ describe('whole-store scaling sweep (e2e)', () => {
     const processLog = families.get('framework/process-log') ?? [];
     assert.ok(inferenceLog.length >= TURNS, `inference log exercised (${inferenceLog.length} records)`);
     assert.ok(processLog.length >= TURNS, `process log exercised (${processLog.length} records)`);
-    const checkpointSlots = [...families.keys()].filter((id) => id.startsWith('framework/turn-checkpoints/'));
-    assert.ok(checkpointSlots.length >= SPAWNS, `per-agent checkpoint slots exercised (${checkpointSlots.length})`);
+    const checkpointTree = families.get('framework/turn-checkpoints/tree') ?? [];
+    assert.ok(checkpointTree.length >= TURNS + SPAWNS, `checkpoint tree exercised (${checkpointTree.length} records)`);
 
-    // The sweep: every family, classified, no exemptions beyond the rules.
+    // Disposal actually removed the scouts' keys — the tree stays O(live
+    // agents), and no per-agent state registration leaked into chronicle's
+    // state index (which is rewritten + fsynced on every sync tick).
+    for (let s = 0; s < SPAWNS; s++) {
+      assert.strictEqual(
+        store.treeGet('framework/turn-checkpoints/tree', `e2e-scout-${s}`),
+        null,
+        `disposed scout ${s} evicted from checkpoint tree`
+      );
+    }
+    assert.ok(store.treeGet('framework/turn-checkpoints/tree', 'assistant'), 'persistent agent keeps its checkpoints');
+    const stateCount = store.listStates().length;
+    const checkpointStates = store.listStates().filter((s: { id: string }) => s.id.startsWith('framework/turn-checkpoints')).length;
+    assert.strictEqual(checkpointStates, 1, `exactly one checkpoint state registered (index has ${stateCount} states total)`);
+
+    // The sweep: every family, classified, no exemptions beyond the rules —
+    // and no silent caps: families too small for a slope fit are listed.
     const violations: string[] = [];
+    const skipped: string[] = [];
     for (const [stateId, sizes] of families) {
       if (CAPPED_FAMILIES.some((re) => re.test(stateId))) {
         const max = Math.max(...sizes);
@@ -179,7 +198,10 @@ describe('whole-store scaling sweep (e2e)', () => {
         }
         continue;
       }
-      if (sizes.length < MIN_RECORDS_FOR_FIT) continue;
+      if (sizes.length < MIN_RECORDS_FOR_FIT) {
+        skipped.push(`${stateId} (${sizes.length})`);
+        continue;
+      }
       const slope = logLogSlope(sizes);
       if (slope >= SLOPE_LIMIT) {
         violations.push(
@@ -187,6 +209,12 @@ describe('whole-store scaling sweep (e2e)', () => {
           `(${sizes[0]} B → ${sizes[sizes.length - 1]} B) — superlinear growth`
         );
       }
+    }
+    if (skipped.length > 0) {
+      console.log(
+        `[state-scaling-e2e] ${skipped.length} families below the ${MIN_RECORDS_FOR_FIT}-record fit threshold ` +
+        `(unaudited by the slope gate): ${skipped.join(', ')}`
+      );
     }
     assert.deepStrictEqual(violations, [], `superlinear state families:\n  ${violations.join('\n  ')}`);
 

--- a/test/state-scaling-e2e.test.ts
+++ b/test/state-scaling-e2e.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Whole-store scaling sweep (scaling campaign Finding 2, end-to-end gate).
+ *
+ * The unit gates in state-scaling.test.ts pin the four known writers by
+ * calling them directly. This test validates the REGIME instead: it drives a
+ * synthetic workload through the framework's public surface — external
+ * messages with tool rounds, ephemeral spawn-and-dispose cycles, process
+ * logging on — then sweeps EVERY state family the store accumulated and
+ * asserts none of them grows superlinearly. A quadratic writer added anywhere
+ * (the way logProcessEvent silently duplicated logInference's bug) fails this
+ * test the day it's introduced, without anyone having to know to test it.
+ *
+ * Family classification:
+ *   - capped families (per-agent turn-checkpoint slots) legitimately ramp to
+ *     a fixed cap and plateau — small-N slope fits are noisy on that shape
+ *     (a ramp-heavy window fits as "rising"), so they get a hard max-record-
+ *     size bound instead, which is the stronger invariant anyway.
+ *   - everything else with enough records gets a log-log slope fit of
+ *     bytes-per-record vs index; flat ≈ healthy, ≈1 ≈ quadratic aggregate.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { tmpdir } from 'node:os';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import type { Module, ModuleContext, ProcessEvent, ProcessState, EventResponse, ToolDefinition, ToolCall, ToolResult } from '../src/index.js';
+import { AgentFramework } from '../src/index.js';
+import { MockMembrane, createMockResponse } from './helpers/mock-membrane.js';
+
+const SLOPE_LIMIT = 0.3;
+const MIN_RECORDS_FOR_FIT = 8;
+/** ≥ MAX_TURN_CHECKPOINTS × generous per-checkpoint size; a whole-map rewrite
+ *  under fleet load blows far past this. */
+const CAPPED_MAX_RECORD_BYTES = 16 * 1024;
+const CAPPED_FAMILIES = [/^framework\/turn-checkpoints\//];
+
+/** OLS slope of ln(bytes) on ln(index) — same fit latency.mjs uses. */
+function logLogSlope(sizes: number[]): number {
+  const pts = sizes.map((y, i) => ({ x: i + 1, y })).filter((p) => p.y > 0);
+  const lx = pts.map((p) => Math.log(p.x));
+  const ly = pts.map((p) => Math.log(p.y));
+  const mx = lx.reduce((a, b) => a + b, 0) / lx.length;
+  const my = ly.reduce((a, b) => a + b, 0) / ly.length;
+  let num = 0, den = 0;
+  for (let i = 0; i < lx.length; i++) {
+    num += (lx[i] - mx) * (ly[i] - my);
+    den += (lx[i] - mx) ** 2;
+  }
+  return den === 0 ? 0 : num / den;
+}
+
+/** All state_update payload sizes in append order, grouped by state id. */
+function sweepStateFamilies(store: { getRecordIdsByType(t: string): string[]; getRecord(id: string): { payload: Buffer } | null }): Map<string, number[]> {
+  const families = new Map<string, number[]>();
+  for (const id of store.getRecordIdsByType('state_update')) {
+    const record = store.getRecord(id);
+    if (!record) continue;
+    const update = JSON.parse(record.payload.toString()) as { state_id: string };
+    let sizes = families.get(update.state_id);
+    if (!sizes) families.set(update.state_id, (sizes = []));
+    sizes.push(record.payload.length);
+  }
+  return families;
+}
+
+/** Minimal module providing one tool, so turns exercise real tool rounds. */
+class EchoModule implements Module {
+  readonly name = 'echo';
+  async start(_ctx: ModuleContext): Promise<void> {}
+  async stop(): Promise<void> {}
+  getTools(): ToolDefinition[] {
+    return [{
+      name: 'echo',
+      description: 'Echo the input back',
+      inputSchema: { type: 'object', properties: { message: { type: 'string' } } },
+    }];
+  }
+  async handleToolCall(call: ToolCall): Promise<ToolResult> {
+    return { success: true, data: (call.input as { message?: string }).message ?? '' };
+  }
+  async onProcess(event: ProcessEvent, _state: ProcessState): Promise<EventResponse> {
+    if (event.type === 'external-message') {
+      return {
+        addMessages: [{
+          participant: 'User',
+          content: [{ type: 'text', text: String(event.content) }],
+        }],
+        requestInference: true,
+      };
+    }
+    return {};
+  }
+}
+
+describe('whole-store scaling sweep (e2e)', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'af-scaling-e2e-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('no state family grows superlinearly under a synthetic fleet workload', async () => {
+    const membrane = new MockMembrane();
+    const framework = await AgentFramework.create({
+      storePath: join(tempDir, 'e2e.chronicle'),
+      membrane: membrane.asMembrane(),
+      agents: [{ name: 'assistant', model: 'test-model', systemPrompt: 'You are a test assistant.' }],
+      modules: [new EchoModule()],
+      // Exercise the process log — it's registered append_log and had the
+      // same Set-rewrite bug as the inference log.
+      processLogging: { persist: true },
+    });
+
+    // Phase 1: persistent-agent turns, each with one tool round. Every turn
+    // writes: turn checkpoint, process log entries, inference log entry,
+    // message appends — the production write set.
+    const TURNS = 40;
+    for (let t = 0; t < TURNS; t++) {
+      membrane.pushResponse(createMockResponse([
+        { type: 'text', text: `Working on request ${t}.` },
+        { type: 'tool_use', id: `call-${t}`, name: 'echo--echo', input: { message: `payload ${t}` } },
+      ], 'tool_use'));
+      membrane.pushResponse(createMockResponse([
+        { type: 'text', text: `Done with request ${t}.` },
+      ]));
+
+      framework.pushEvent({
+        type: 'external-message',
+        source: 'e2e',
+        content: `Request number ${t}, please handle it.`,
+        metadata: {},
+      });
+      await framework.runUntilIdle();
+    }
+
+    // Phase 2: spawn-and-dispose ephemeral agents — the fleet regime that
+    // grew the old checkpoint map without bound.
+    const SPAWNS = 12;
+    for (let s = 0; s < SPAWNS; s++) {
+      membrane.pushResponse(createMockResponse([
+        { type: 'text', text: `Scout ${s} reporting: nothing to see.` },
+      ]));
+      const { agent, contextManager, cleanup } = await framework.createEphemeralAgent({
+        name: `e2e-scout-${s}`,
+        model: 'test-model',
+        systemPrompt: 'You are a scout.',
+      });
+      contextManager.addMessage('user', [{ type: 'text', text: `Scout task ${s}` }]);
+      const run = framework.runEphemeralToCompletion(agent, contextManager);
+      await framework.runUntilIdle();
+      await run;
+      cleanup();
+    }
+
+    const store = framework.getStore();
+    const families = sweepStateFamilies(store);
+
+    // The workload must actually have exercised the families this test
+    // exists to watch — otherwise a routing change could green-wash it.
+    const inferenceLog = families.get('framework/inference-log') ?? [];
+    const processLog = families.get('framework/process-log') ?? [];
+    assert.ok(inferenceLog.length >= TURNS, `inference log exercised (${inferenceLog.length} records)`);
+    assert.ok(processLog.length >= TURNS, `process log exercised (${processLog.length} records)`);
+    const checkpointSlots = [...families.keys()].filter((id) => id.startsWith('framework/turn-checkpoints/'));
+    assert.ok(checkpointSlots.length >= SPAWNS, `per-agent checkpoint slots exercised (${checkpointSlots.length})`);
+
+    // The sweep: every family, classified, no exemptions beyond the rules.
+    const violations: string[] = [];
+    for (const [stateId, sizes] of families) {
+      if (CAPPED_FAMILIES.some((re) => re.test(stateId))) {
+        const max = Math.max(...sizes);
+        if (max > CAPPED_MAX_RECORD_BYTES) {
+          violations.push(`${stateId}: capped family record hit ${max} B (limit ${CAPPED_MAX_RECORD_BYTES})`);
+        }
+        continue;
+      }
+      if (sizes.length < MIN_RECORDS_FOR_FIT) continue;
+      const slope = logLogSlope(sizes);
+      if (slope >= SLOPE_LIMIT) {
+        violations.push(
+          `${stateId}: bytes/record slope ${slope.toFixed(2)} over ${sizes.length} records ` +
+          `(${sizes[0]} B → ${sizes[sizes.length - 1]} B) — superlinear growth`
+        );
+      }
+    }
+    assert.deepStrictEqual(violations, [], `superlinear state families:\n  ${violations.join('\n  ')}`);
+
+    await framework.stop();
+  });
+});

--- a/test/state-scaling.test.ts
+++ b/test/state-scaling.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Regression gates for the set-rewrite quadratic-states fixes (2026-07-08
+ * scaling campaign, Finding 2): persisted record size must be independent of
+ * accumulated content.
+ *
+ * Families covered:
+ *   - framework/inference-log        — appended, not Set-rewritten
+ *   - framework/turn-checkpoints/*   — per-agent slots, not one global map
+ *   - modules/<name>/<log>           — ModuleContext log-state API
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { tmpdir } from 'node:os';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { JsStore } from '@animalabs/chronicle';
+import type { Module, ModuleContext, ProcessEvent, ProcessState, EventResponse, ToolDefinition, ToolCall, ToolResult } from '../src/index.js';
+import { AgentFramework } from '../src/index.js';
+import { MockMembrane } from './helpers/mock-membrane.js';
+
+const INFERENCE_LOG_ID = 'framework/inference-log';
+const TURN_CHECKPOINTS_ID = 'framework/turn-checkpoints';
+
+/**
+ * Payload sizes of all state_update records for states matching `match`,
+ * in append order.
+ */
+function stateUpdateSizes(store: JsStore, match: (stateId: string) => boolean): number[] {
+  const sizes: number[] = [];
+  for (const id of store.getRecordIdsByType('state_update')) {
+    const record = store.getRecord(id);
+    if (!record) continue;
+    const update = JSON.parse(record.payload.toString()) as { state_id: string };
+    if (match(update.state_id)) sizes.push(record.payload.length);
+  }
+  return sizes;
+}
+
+/** Assert the record family isn't growing: last record ≈ first record. */
+function assertFlat(sizes: number[], label: string, tolerance = 1.5): void {
+  assert.ok(sizes.length >= 2, `${label}: expected ≥2 records, got ${sizes.length}`);
+  const first = sizes[0];
+  const last = sizes[sizes.length - 1];
+  assert.ok(
+    last <= first * tolerance,
+    `${label}: record size grew ${first} → ${last} bytes over ${sizes.length} records — ` +
+    `looks like accumulated content is being rewritten per update`
+  );
+}
+
+describe('state scaling regression gates', () => {
+  let tempDir: string;
+  let membrane: MockMembrane;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'af-state-scaling-'));
+    membrane = new MockMembrane();
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  async function createFramework(storePath: string) {
+    return AgentFramework.create({
+      storePath,
+      membrane: membrane.asMembrane(),
+      agents: [{ name: 'assistant', model: 'test-model', systemPrompt: 'test' }],
+      modules: [],
+    });
+  }
+
+  it('inference log: Nth record size is independent of N', async () => {
+    const storePath = join(tempDir, 'inference.chronicle');
+    const framework = await createFramework(storePath);
+    const store = framework.getStore();
+
+    const N = 30;
+    for (let i = 0; i < N; i++) {
+      (framework as any).logInference({
+        timestamp: Date.now(),
+        agentName: 'assistant',
+        requestId: `req-${i}`,
+        success: true,
+        durationMs: 100,
+        request: { i },
+        response: { ok: true },
+      });
+    }
+
+    const entries = store.getStateJson(INFERENCE_LOG_ID);
+    assert.strictEqual(entries.length, N, 'all entries readable back');
+
+    const sizes = stateUpdateSizes(store, (id) => id === INFERENCE_LOG_ID);
+    assertFlat(sizes, INFERENCE_LOG_ID);
+
+    await framework.stop();
+  });
+
+  it('inference log: appends compose with a legacy Set-written array', async () => {
+    const storePath = join(tempDir, 'legacy-log.chronicle');
+
+    // Write the state the old way: whole-array Set, as pre-fix stores did.
+    {
+      const store = JsStore.openOrCreate({ path: storePath });
+      store.registerState({
+        id: INFERENCE_LOG_ID,
+        strategy: 'append_log',
+        deltaSnapshotEvery: 100,
+        fullSnapshotEvery: 20,
+      });
+      store.setStateJson(INFERENCE_LOG_ID, [
+        { timestamp: 1, agentName: 'old', requestId: 'legacy-0', success: true },
+        { timestamp: 2, agentName: 'old', requestId: 'legacy-1', success: false },
+      ]);
+      store.close();
+    }
+
+    const framework = await createFramework(storePath);
+    (framework as any).logInference({
+      timestamp: 3,
+      agentName: 'assistant',
+      requestId: 'new-0',
+      success: true,
+      durationMs: 5,
+    });
+
+    const entries = framework.getStore().getStateJson(INFERENCE_LOG_ID);
+    assert.strictEqual(entries.length, 3);
+    assert.strictEqual(entries[0].requestId, 'legacy-0');
+    assert.strictEqual(entries[2].requestId, 'new-0');
+
+    await framework.stop();
+  });
+
+  it('turn checkpoints: record size is independent of agents-ever-spawned', async () => {
+    const storePath = join(tempDir, 'checkpoints.chronicle');
+    const framework = await createFramework(storePath);
+    const store = framework.getStore();
+
+    // M spawn-and-dispose subagents, several turns each.
+    const M = 25;
+    for (let m = 0; m < M; m++) {
+      const name = `spawn-task-d1-${1000 + m}`;
+      for (let turn = 0; turn < 3; turn++) {
+        (framework as any).recordTurnCheckpoint(name);
+      }
+      (framework as any).evictTurnCheckpoints(name);
+    }
+    // A persistent agent keeps taking turns throughout.
+    for (let turn = 0; turn < 5; turn++) {
+      (framework as any).recordTurnCheckpoint('assistant');
+    }
+
+    const sizes = stateUpdateSizes(store, (id) => id.startsWith(`${TURN_CHECKPOINTS_ID}/`));
+    // Every write is one agent's ≤MAX_TURN_CHECKPOINTS list: flat across the
+    // whole run even though M unique agents came and went.
+    assertFlat(sizes, `${TURN_CHECKPOINTS_ID}/*`, 4);
+
+    // Disposal wrote an empty list, so no slot still holds a dead agent's data.
+    for (let m = 0; m < M; m++) {
+      const slot = store.getStateJson(`${TURN_CHECKPOINTS_ID}/spawn-task-d1-${1000 + m}`);
+      assert.deepStrictEqual(slot, [], 'disposed agent slot is empty');
+    }
+    assert.strictEqual((framework as any).getTurnCheckpoints('assistant').length, 5);
+
+    await framework.stop();
+  });
+
+  it('turn checkpoints: legacy single-map stores are readable and migrate on save', async () => {
+    const storePath = join(tempDir, 'legacy-checkpoints.chronicle');
+
+    {
+      const store = JsStore.openOrCreate({ path: storePath });
+      store.registerState({ id: TURN_CHECKPOINTS_ID, strategy: 'snapshot' });
+      store.setStateJson(TURN_CHECKPOINTS_ID, {
+        assistant: [
+          { agentName: 'assistant', turnIndex: 0, sequenceBefore: 1, branchName: 'main', timestamp: 1 },
+        ],
+      });
+      store.close();
+    }
+
+    const framework = await createFramework(storePath);
+
+    // Legacy entry visible through the fallback read...
+    const before = (framework as any).getTurnCheckpoints('assistant');
+    assert.strictEqual(before.length, 1);
+    assert.strictEqual(before[0].turnIndex, 0);
+
+    // ...and the first new turn migrates the list into the per-agent slot.
+    (framework as any).recordTurnCheckpoint('assistant');
+    const slot = framework.getStore().getStateJson(`${TURN_CHECKPOINTS_ID}/assistant`);
+    assert.strictEqual(slot.length, 2);
+    assert.strictEqual(slot[0].turnIndex, 0);
+
+    await framework.stop();
+  });
+
+  it('module log states: append/edit records are O(item), state is reconstructable', async () => {
+    const storePath = join(tempDir, 'module-log.chronicle');
+
+    let capturedCtx: ModuleContext | null = null;
+    const logModule: Module = {
+      name: 'logtest',
+      async start(ctx: ModuleContext) {
+        capturedCtx = ctx;
+        ctx.registerLogState('log');
+      },
+      async stop() {},
+      getTools(): ToolDefinition[] { return []; },
+      async handleToolCall(_call: ToolCall): Promise<ToolResult> {
+        return { success: true };
+      },
+      async onProcess(_event: ProcessEvent, _state: ProcessState): Promise<EventResponse> {
+        return {};
+      },
+    };
+
+    const framework = await AgentFramework.create({
+      storePath,
+      membrane: membrane.asMembrane(),
+      agents: [{ name: 'assistant', model: 'test-model', systemPrompt: 'test' }],
+      modules: [logModule],
+    });
+    const ctx = capturedCtx!;
+    const store = framework.getStore();
+
+    const N = 30;
+    for (let i = 0; i < N; i++) {
+      ctx.appendToLog('log', { id: `item-${i}`, content: 'x'.repeat(50) });
+    }
+    assert.strictEqual(ctx.getLogLength('log'), N);
+
+    // Point-edit keeps the record O(item), not O(log).
+    ctx.editLogItem('log', 3, { id: 'item-3', content: 'edited' });
+    const items = ctx.getLog<{ id: string; content: string }>('log');
+    assert.strictEqual(items.length, N);
+    assert.strictEqual(items[3].content, 'edited');
+    assert.strictEqual(items[4].id, 'item-4');
+
+    const sizes = stateUpdateSizes(store, (id) => id === 'modules/logtest/log');
+    assertFlat(sizes, 'modules/logtest/log');
+
+    // Idempotent re-registration must not throw (restart path).
+    ctx.registerLogState('log');
+    // Reserved / invalid names are rejected.
+    assert.throws(() => ctx.registerLogState('state'));
+    assert.throws(() => ctx.appendToLog('nested/name', {}));
+
+    await framework.stop();
+  });
+});

--- a/test/state-scaling.test.ts
+++ b/test/state-scaling.test.ts
@@ -21,6 +21,7 @@ import { MockMembrane } from './helpers/mock-membrane.js';
 
 const INFERENCE_LOG_ID = 'framework/inference-log';
 const TURN_CHECKPOINTS_ID = 'framework/turn-checkpoints';
+const TURN_CHECKPOINTS_TREE_ID = 'framework/turn-checkpoints/tree';
 
 /**
  * Payload sizes of all state_update records for states matching `match`,
@@ -134,7 +135,7 @@ describe('state scaling regression gates', () => {
     await framework.stop();
   });
 
-  it('turn checkpoints: record size is independent of agents-ever-spawned', async () => {
+  it('turn checkpoints: record size and state count independent of agents-ever-spawned', async () => {
     const storePath = join(tempDir, 'checkpoints.chronicle');
     const framework = await createFramework(storePath);
     const store = framework.getStore();
@@ -153,22 +154,31 @@ describe('state scaling regression gates', () => {
       (framework as any).recordTurnCheckpoint('assistant');
     }
 
-    const sizes = stateUpdateSizes(store, (id) => id.startsWith(`${TURN_CHECKPOINTS_ID}/`));
-    // Every write is one agent's ≤MAX_TURN_CHECKPOINTS list: flat across the
-    // whole run even though M unique agents came and went.
-    assertFlat(sizes, `${TURN_CHECKPOINTS_ID}/*`, 4);
+    // Every write is one tree op (path + blob hash): flat across the whole
+    // run even though M unique agents came and went.
+    const sizes = stateUpdateSizes(store, (id) => id === TURN_CHECKPOINTS_TREE_ID);
+    assertFlat(sizes, TURN_CHECKPOINTS_TREE_ID, 4);
 
-    // Disposal wrote an empty list, so no slot still holds a dead agent's data.
+    // Disposal removed the key outright — the tree holds only live agents...
     for (let m = 0; m < M; m++) {
-      const slot = store.getStateJson(`${TURN_CHECKPOINTS_ID}/spawn-task-d1-${1000 + m}`);
-      assert.deepStrictEqual(slot, [], 'disposed agent slot is empty');
+      assert.strictEqual(
+        store.treeGet(TURN_CHECKPOINTS_TREE_ID, `spawn-task-d1-${1000 + m}`),
+        null,
+        'disposed agent key removed from checkpoint tree'
+      );
     }
     assert.strictEqual((framework as any).getTurnCheckpoints('assistant').length, 5);
+
+    // ...and no per-agent state registration leaked into the state index —
+    // chronicle has no deregistration and rewrites + fsyncs the index on
+    // every sync tick, so index entries must not scale with spawns-ever.
+    const checkpointStates = store.listStates().filter((s: { id: string }) => s.id.startsWith(TURN_CHECKPOINTS_ID));
+    assert.strictEqual(checkpointStates.length, 1, 'exactly one checkpoint state registered');
 
     await framework.stop();
   });
 
-  it('turn checkpoints: legacy single-map stores are readable and migrate on save', async () => {
+  it('turn checkpoints: legacy single-map stores are readable, migrate on save, and evict without ghosts', async () => {
     const storePath = join(tempDir, 'legacy-checkpoints.chronicle');
 
     {
@@ -178,22 +188,39 @@ describe('state scaling regression gates', () => {
         assistant: [
           { agentName: 'assistant', turnIndex: 0, sequenceBefore: 1, branchName: 'main', timestamp: 1 },
         ],
+        'spawn-ghost-d1-1234': [
+          { agentName: 'spawn-ghost-d1-1234', turnIndex: 3, sequenceBefore: 9, branchName: 'main', timestamp: 2 },
+        ],
       });
       store.close();
     }
 
     const framework = await createFramework(storePath);
+    const store = framework.getStore();
 
     // Legacy entry visible through the fallback read...
     const before = (framework as any).getTurnCheckpoints('assistant');
     assert.strictEqual(before.length, 1);
     assert.strictEqual(before[0].turnIndex, 0);
 
-    // ...and the first new turn migrates the list into the per-agent slot.
+    // ...and the first new turn migrates the list into the tree.
     (framework as any).recordTurnCheckpoint('assistant');
-    const slot = framework.getStore().getStateJson(`${TURN_CHECKPOINTS_ID}/assistant`);
-    assert.strictEqual(slot.length, 2);
-    assert.strictEqual(slot[0].turnIndex, 0);
+    const entry = store.treeGet(TURN_CHECKPOINTS_TREE_ID, 'assistant');
+    assert.ok(entry, 'tree entry created on first save');
+    const migrated = (framework as any).getTurnCheckpoints('assistant');
+    assert.strictEqual(migrated.length, 2);
+    assert.strictEqual(migrated[0].turnIndex, 0);
+
+    // Evicting an agent whose checkpoints live only in the legacy map writes
+    // an empty tombstone — a later agent reusing the name must NOT inherit
+    // the dead agent's checkpoints through the fallback.
+    (framework as any).evictTurnCheckpoints('spawn-ghost-d1-1234');
+    assert.deepStrictEqual((framework as any).getTurnCheckpoints('spawn-ghost-d1-1234'), []);
+    // Idempotent: a second evict doesn't rewrite the tombstone (blob "[]" is
+    // content-addressed, but the tree op record would still be new).
+    const recordsBefore = store.getRecordIdsByType('state_update').length;
+    (framework as any).evictTurnCheckpoints('spawn-ghost-d1-1234');
+    assert.strictEqual(store.getRecordIdsByType('state_update').length, recordsBefore);
 
     await framework.stop();
   });
@@ -248,6 +275,12 @@ describe('state scaling regression gates', () => {
     // Reserved / invalid names are rejected.
     assert.throws(() => ctx.registerLogState('state'));
     assert.throws(() => ctx.appendToLog('nested/name', {}));
+    // Writes to a never-registered name fail immediately — chronicle would
+    // accept the append but never snapshot the state, turning a typo into a
+    // silent full-chain-replay-on-restore trap.
+    assert.throws(() => ctx.appendToLog('lgo', { oops: true }), /not registered/);
+    assert.throws(() => ctx.editLogItem('lgo', 0, {}), /not registered/);
+    assert.strictEqual(ctx.getLogLength('log'), N, 'registered log still intact');
 
     await framework.stop();
   });


### PR DESCRIPTION
## What

Three framework states were persisted by rewriting their full accumulated value on every update, making each record O(history) and aggregate disk O(n²) in update count. All were found by retro-benchmarking evacuated production stores (log-log slope of bytes-per-record vs update index; flat ≈ healthy, ≈1 ≈ quadratic aggregate):

| state | prod evidence | fix |
|---|---|---|
| `framework/inference-log` | slope **0.98** in three prod stores — registered `append_log`, but the writer did `getStateJson → push → setStateJson`, defeating the strategy with a whole-array `Set` per inference | one `appendToStateJson` per entry |
| `framework/process-log` | identical bug, same writer pattern | identical fix |
| `framework/turn-checkpoints` | slope **0.86–0.94** — one `Record<agentName, list>` map rewritten on every turn of every agent; keys are per-spawn-unique subagent names and were never evicted, so the map grew without bound in agents-ever-spawned | one Tree state (`framework/turn-checkpoints/tree`) keyed by agent name — per-key O(entry) writes, keys **removed** on disposal, exactly one state registration for the life of the store (a slot-per-agent design would leak a permanent registration per spawn into the state index, which is rewritten + fsynced every sync tick); legacy map kept as read-only fallback, migrated per agent on first save, with eviction tombstones so a reused name can't inherit a dead agent's checkpoints |

Plus the enabler: `ModuleContext` only offered full-object `setState`, which funnels modules into the same pattern (a downstream module's corpus measured **93.4 MB — a third of a 278 MB prod store**). New granular log-state API: `registerLogState` / `appendToLog` / `editLogItem` / `getLog` / `getLogLength`, backed by chronicle's `append_log` primitives, with a registered-name guard — chronicle accepts appends to unregistered states but never snapshots them, so a forgotten `registerLogState` or typo'd name is an immediate error instead of a silent full-chain-replay-on-restore trap. `registerState` catches rethrow anything that isn't the typed "State already exists". Agent disposal also clears the per-agent `lastInferenceAt` / `staleWarnAt` diagnostics maps, which had the same unbounded-in-agent-names shape (in-memory only).

## Compatibility

- Appending after a legacy `Set`-written array is defined chronicle behavior — pinned by a fixture-style test (open old-layout store, append new way, read back).
- Old checkpoint maps stay readable through the fallback path; each agent's first new checkpoint migrates its list into its own slot.
- `runUntilIdle()` now also drains `pendingRequests` — direct inference requests (`runEphemeralToCompletion`) bypass the event queue, and the helper could previously return while one was still waiting.

## Tests

- `test/state-scaling.test.ts` — unit gates: Nth record size independent of N for each fixed writer, plus both legacy-store compat paths.
- `test/state-scaling-e2e.test.ts` — regime gate: drives a synthetic fleet workload through the public surface (40 external-message turns with tool rounds, 12 ephemeral spawn-and-dispose cycles, process logging on), then sweeps **every** state family in the store and asserts none grows superlinearly (slope < 0.3; capped families get a hard max-record-size bound). A quadratic writer added anywhere fails CI the day it lands, including in states this PR has never heard of.

Suite: 254/254 green on top of current main (post-#54). The e2e sweep also asserts exactly one checkpoint state is ever registered, and lists (rather than silently skips) families below its slope-fit threshold.

## Before / after (identical synthetic workload, pre-fix build vs this branch)

Totals are the whole store directory on disk — records, content-addressed blobs, and the state index all count, so the tree-backed checkpoints can't hide bytes in blob storage. Both runs finish with the same 31 registered states (a slot-per-agent design would have left 44).

| family (state-update records) | before | after | |
|---|---|---|---|
| `framework/inference-log` | 17.36 MB | 0.51 MB | **34×** — last record alone: 499 KB → 2.2 KB |
| `framework/process-log` | 7.31 MB | 0.24 MB | **31×** |
| `framework/turn-checkpoints` | 368 KB | 18 KB | tree ops; checkpoint payloads in blobs, counted in the total below |
| `messages` (control, untouched) | 192 KB | 192 KB | within 0.1% |
| **whole store on disk** | **25.5 MB** | **1.28 MB** | **19.8×** |

The gap widens with session length — "before" grows per-record, "after" doesn't.

📉 **Interactive charts** (bytes-per-record trajectories per family, incl. the control): **[rendered page](https://gistcdn.githack.com/Anarchid/5f80439539f96db9b0e036db6912972e/raw/quadratic-states-before-after-standalone.html)** · [source gist](https://gist.github.com/Anarchid/5f80439539f96db9b0e036db6912972e)

## Notes for review

- First commit (`1d89a96`, abort/catch-path inference-log persistence) is an older standalone fix riding along on this branch — it adds the write sites that make the append fix more valuable, but reverts independently if you want it split out.
- `logs/` added to `.gitignore`: the new `failures.log` append (from the diagnostics work on main) is cwd-relative, so `npm test` drops `logs/failures.log` in the repo root. Might be worth rooting it under a configured path in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

