### PR TITLE
Compile robustness: empty-text 400 sanitize + OverBudget deadlock breaker

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -336,6 +336,26 @@ export class Agent {
 
     let { messages, systemInjections } = await this.compileWithInjections(budget, injections);
 
+    // Sanitize: strip empty/whitespace text blocks and drop messages left with
+    // no content. The Anthropic API rejects empty text blocks with 400
+    // "messages: text content blocks must be non-empty"; when such a block
+    // reaches a live activation request the agent cannot complete ANY turn
+    // ([inference-failed] on every attempt) until the offending message ages
+    // out of the window. Empty text blocks occur naturally: tool-only turns,
+    // delivery-failure placeholders, silent/skip turns. Non-text blocks pass
+    // through unchanged, so tool pairing is unaffected. (Field-observed
+    // 2026-07-10 on a resident agent: one empty block muted the agent's live
+    // path entirely; twin of context-manager's stripEmptyTextBlocks on the
+    // compression path.)
+    messages = messages
+      .map((m) => ({
+        ...m,
+        content: m.content.filter(
+          (b: any) => !(b.type === "text" && (typeof b.text !== "string" || b.text.trim() === "")),
+        ),
+      }))
+      .filter((m) => m.content.length > 0);
+
     // Safety: ensure messages don't end with an assistant message.
     // Some models reject trailing assistant messages ("prefill not supported"),
     // and after context compression a stale assistant turn can end up last.

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -355,7 +355,9 @@ export class Agent {
       .map((m) => ({
         ...m,
         content: m.content.filter(
-          (b: any) => !(b.type === "text" && (typeof b.text !== "string" || b.text.trim() === "")),
+          // typeof guard is deliberate runtime defense: history loaded from
+          // disk can carry a non-string `text` despite what the types claim.
+          (b: ContentBlock) => !(b.type === "text" && (typeof b.text !== "string" || b.text.trim() === "")),
         ),
       }))
       .filter((m) => m.content.length > 0);

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -4304,6 +4304,29 @@ export class AgentFramework {
       }
     }
 
+    // (2b) OverBudget deadlock breaker. When compile fails with
+    // OverBudgetError ("...exceed hard budget..."), the normal compression
+    // drain never runs: it is driven by successful activity, which the
+    // over-budget state prevents - a closed loop with no internal exit.
+    // Field data (2026-07-10, resident agent): 36 minutes hard-down, zero
+    // self-rescue; only an operator raising the budget externally could
+    // break the loop. Break it here instead: kick the strategy drain
+    // directly so folding/merging frees space for the next compile.
+    // Bounded ticks, best-effort, never throws.
+    if (agent && /exceed hard budget|OverBudget/i.test(reason)) {
+      (async () => {
+        try {
+          const cm = agent.getContextManager();
+          for (let i = 0; i < 8; i++) {
+            await cm.tick();
+          }
+          console.error(`[inference-failed] drain kicked for ${agentName} (OverBudget breaker, 8 ticks)`);
+        } catch (err) {
+          console.error(`[inference-failed] drain kick failed for ${agentName}:`, err);
+        }
+      })();
+    }
+
     // (3) Hard-down escalation on repeated identical failure.
     if (streak >= this.inferenceFailureEscalationThreshold) {
       console.error(

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -303,6 +303,13 @@ export class AgentFramework {
    *  Bounds the automatic quarantine loop the same way refusalRewinds bounds
    *  the refusal loop, so the breaker can never shed the whole history. */
   private exhaustionRewinds: Map<string, number> = new Map();
+  /** Agents with an OverBudget drain kick currently in flight. The breaker in
+   *  noteInferenceExhausted fires on EVERY matching failure and the scenario it
+   *  exists for is "every activation fails, repeatedly" — without this guard,
+   *  overlapping kicks race the strategy's own pendingCompression gate and the
+   *  tick counts in the success log stop meaning anything. One kick per agent
+   *  at a time; cleared when the kick settles (success or failure). */
+  private overBudgetDrainInFlight: Set<string> = new Set();
   /** Per-agent current rewind episode: the single consolidated marker's id and
    *  how many turns have been shed so far. One marker per episode, updated in
    *  place (see updateRewindMarker); cleared when the episode ends. */
@@ -3432,13 +3439,14 @@ export class AgentFramework {
           type: 'inference:exhausted',
           agentName: agent.name,
           error: err.message,
-          // Drives the poison-history breaker. `retryable` is kept for
-          // observability, but the breaker gates on `errorType` — only an
-          // `invalid_request` (a 400-class rejection of the history itself)
-          // means retrying the same context can never succeed. auth/abort/
-          // context_length are also non-retryable but must NOT cost history.
-          retryable: err instanceof MembraneError ? err.retryable : undefined,
-          errorType: err instanceof MembraneError ? err.type : undefined,
+          // Drives the poison-history breaker (`invalid_request`: a 400-class
+          // rejection of the history itself — retrying the same context can
+          // never succeed; auth/abort/context_length are also non-retryable
+          // but must NOT cost history) and the OverBudget drain breaker
+          // (`over_budget`: compile refused to fit the hard budget — this is
+          // the site that sees it, since compile runs before the stream
+          // exists). `retryable` is kept for observability.
+          ...this.classifyInferenceError(err),
         });
         this.eventGate?.onInferenceEnded(agent.name);
         if (action.emit) {
@@ -3950,11 +3958,10 @@ export class AgentFramework {
                 agentName: agent.name,
                 error: err.message,
                 // Drives the poison-history breaker. `retryable` is kept for
-                // observability, but the breaker gates on `errorType` — only an
+                // observability, but the breakers gate on `errorType` — only an
                 // `invalid_request` (a 400-class rejection of the history
                 // itself) means retrying the same context can never succeed.
-                retryable: err instanceof MembraneError ? err.retryable : undefined,
-                errorType: err instanceof MembraneError ? err.type : undefined,
+                ...this.classifyInferenceError(err),
               });
               this.eventGate?.onInferenceEnded(agent.name);
               if (action.emit) {
@@ -4050,6 +4057,7 @@ export class AgentFramework {
         type: 'inference:exhausted',
         agentName: agent.name,
         error: err.message,
+        ...this.classifyInferenceError(err),
       });
       // Postmortem 2026-05-28 P2 #7: catch-path failures (stream itself
       // threw) were previously only visible via in-memory trace listeners.
@@ -4667,6 +4675,28 @@ export class AgentFramework {
     return streak;
   }
 
+  /**
+   * Classify a terminal inference error for the `inference:exhausted` trace.
+   * Single-sourced for every emit site: the downstream breakers (poison-history
+   * quarantine, OverBudget drain kick) gate on `errorType`, so classification
+   * drift between sites would silently disable a safety net.
+   *
+   * context-manager's OverBudgetError is recognized by `err.name`: CM does not
+   * export the class from its package root, so a cross-package `instanceof` is
+   * unavailable — but `name` is set in its constructor and survives the package
+   * boundary. Deliberately NOT a message match: the message wording belongs to
+   * CM and can be reworded without warning.
+   */
+  private classifyInferenceError(err: Error): { retryable?: boolean; errorType?: string } {
+    if (err instanceof MembraneError) {
+      return { retryable: err.retryable, errorType: err.type };
+    }
+    if (err.name === 'OverBudgetError') {
+      return { errorType: 'over_budget' };
+    }
+    return {};
+  }
+
   private noteInferenceExhausted(
     agentName: string,
     reason: string,
@@ -4708,24 +4738,36 @@ export class AgentFramework {
     }
 
     // (2b) OverBudget deadlock breaker. When compile fails with
-    // OverBudgetError ("...exceed hard budget..."), the normal compression
-    // drain never runs: it is driven by successful activity, which the
-    // over-budget state prevents - a closed loop with no internal exit.
-    // Field data (2026-07-10, resident agent): 36 minutes hard-down, zero
-    // self-rescue; only an operator raising the budget externally could
-    // break the loop. Break it here instead: kick the strategy drain
-    // directly so folding/merging frees space for the next compile.
-    // Bounded ticks, best-effort, never throws.
-    if (agent && /exceed hard budget|OverBudget/i.test(reason)) {
-      (async () => {
+    // OverBudgetError, the normal compression drain never runs: it is driven
+    // by successful activity, which the over-budget state prevents - a closed
+    // loop with no internal exit. Field data (2026-07-10, resident agent):
+    // 36 minutes hard-down, zero self-rescue; only an operator raising the
+    // budget externally could break the loop. Break it here instead: kick the
+    // strategy drain directly so folding/merging frees space for the next
+    // compile. Bounded ticks, best-effort, never throws, one kick per agent
+    // at a time (see overBudgetDrainInFlight).
+    //
+    // Gates on the classified errorType (see classifyInferenceError); the
+    // message match is only a fallback for paths that lost the Error object
+    // (e.g. a reason string that crossed a serialization boundary). It matches
+    // CM's current OverBudgetError wording and MAY rot if CM rewords it — the
+    // errorType gate is the one that's load-bearing.
+    const overBudget = errorType === 'over_budget' || /exceed hard budget/i.test(reason);
+    if (agent && overBudget && !this.overBudgetDrainInFlight.has(agentName)) {
+      this.overBudgetDrainInFlight.add(agentName);
+      void (async () => {
+        let ticks = 0;
         try {
           const cm = agent.getContextManager();
-          for (let i = 0; i < 8; i++) {
+          while (ticks < 8) {
             await cm.tick();
+            ticks++;
           }
-          console.error(`[inference-failed] drain kicked for ${agentName} (OverBudget breaker, 8 ticks)`);
+          console.error(`[inference-failed] drain kicked for ${agentName} (OverBudget breaker, ${ticks} ticks)`);
         } catch (err) {
-          console.error(`[inference-failed] drain kick failed for ${agentName}:`, err);
+          console.error(`[inference-failed] drain kick failed for ${agentName} after ${ticks} ticks:`, err);
+        } finally {
+          this.overBudgetDrainInFlight.delete(agentName);
         }
       })();
     }

--- a/test/activation-request-sanitize.test.ts
+++ b/test/activation-request-sanitize.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Live-path empty-text sanitize (PR #58, 8a89da0): the Anthropic API rejects
+ * empty text blocks with a 400, and one such block in the compiled window used
+ * to mute the agent entirely — [inference-failed] on every activation until
+ * the offending message aged out (field-observed 2026-07-10). The sanitize in
+ * buildActivationRequest strips empty/whitespace/non-string text blocks and
+ * drops messages left with no content, BEFORE the trailing-assistant check.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { Agent } from '../src/agent.js';
+import type { ContextManager } from '@animalabs/context-manager';
+import type { Membrane } from '@animalabs/membrane';
+
+/** buildActivationRequest only needs compile(); membrane is never touched. */
+function agentCompiling(messages: unknown[]): Agent {
+  const cm = {
+    compile: async () => ({ messages, systemInjections: [] }),
+  } as unknown as ContextManager;
+  return new Agent(
+    { name: 'tester', model: 'test-model', systemPrompt: 'sys' },
+    cm,
+    {} as Membrane,
+  );
+}
+
+describe('buildActivationRequest empty-text sanitize', () => {
+  it('strips empty and whitespace-only text blocks, keeps real text', async () => {
+    const agent = agentCompiling([
+      {
+        participant: 'human',
+        content: [
+          { type: 'text', text: '' },
+          { type: 'text', text: '   \n\t ' },
+          { type: 'text', text: 'hello' },
+        ],
+      },
+    ]);
+    const request = await agent.buildActivationRequest([]);
+    assert.equal(request.messages.length, 1);
+    assert.deepEqual(request.messages[0]!.content, [{ type: 'text', text: 'hello' }]);
+  });
+
+  it('strips text blocks whose `text` is not a string (untyped history from disk)', async () => {
+    const agent = agentCompiling([
+      {
+        participant: 'human',
+        content: [
+          { type: 'text', text: null },
+          { type: 'text', text: 42 },
+          { type: 'text', text: 'kept' },
+        ],
+      },
+    ]);
+    const request = await agent.buildActivationRequest([]);
+    assert.deepEqual(request.messages[0]!.content, [{ type: 'text', text: 'kept' }]);
+  });
+
+  it('drops a message left with no content at all', async () => {
+    const agent = agentCompiling([
+      { participant: 'human', content: [{ type: 'text', text: '' }] },
+      { participant: 'human', content: [{ type: 'text', text: 'still here' }] },
+    ]);
+    const request = await agent.buildActivationRequest([]);
+    assert.equal(request.messages.length, 1);
+    assert.deepEqual(request.messages[0]!.content, [{ type: 'text', text: 'still here' }]);
+  });
+
+  it('passes non-text blocks through untouched — tool pairing is unaffected', async () => {
+    const toolUse = { type: 'tool_use', id: 't1', name: 'shell', input: {} };
+    const toolResult = { type: 'tool_result', toolUseId: 't1', content: 'ok' };
+    const agent = agentCompiling([
+      { participant: 'human', content: [{ type: 'text', text: 'run it' }] },
+      // Tool-only assistant turn whose accompanying text block is empty: the
+      // exact shape that produced the field incident.
+      { participant: 'tester', content: [{ type: 'text', text: '' }, toolUse] },
+      { participant: 'user', content: [toolResult] },
+      { participant: 'human', content: [{ type: 'text', text: 'and?' }] },
+    ]);
+    const request = await agent.buildActivationRequest([]);
+    assert.equal(request.messages.length, 4);
+    assert.deepEqual(request.messages[1]!.content, [toolUse]);
+    assert.deepEqual(request.messages[2]!.content, [toolResult]);
+  });
+
+  it('runs BEFORE the trailing-assistant check: a sanitize-exposed trailing assistant still gets [Continue]', async () => {
+    const agent = agentCompiling([
+      { participant: 'human', content: [{ type: 'text', text: 'hi' }] },
+      { participant: 'tester', content: [{ type: 'text', text: 'ok' }] },
+      // Empty trailing user message: dropped by the sanitize, which leaves the
+      // assistant turn last — the [Continue] guard must see THAT shape.
+      { participant: 'human', content: [{ type: 'text', text: '  ' }] },
+    ]);
+    const request = await agent.buildActivationRequest([]);
+    assert.equal(request.messages.length, 3);
+    const last = request.messages[request.messages.length - 1]!;
+    assert.equal(last.participant, 'user');
+    assert.deepEqual(last.content, [{ type: 'text', text: '[Continue]' }]);
+  });
+});

--- a/test/overbudget-drain-breaker.test.ts
+++ b/test/overbudget-drain-breaker.test.ts
@@ -1,0 +1,168 @@
+/**
+ * OverBudget deadlock breaker (PR #58, 15befaa): when compile throws
+ * context-manager's OverBudgetError, the compression drain never runs — it is
+ * driven by successful activity, which the over-budget state prevents. A
+ * closed loop with no internal exit (field data 2026-07-10: 36 minutes
+ * hard-down, zero self-rescue). noteInferenceExhausted breaks it by kicking
+ * the strategy drain (cm.tick()) directly.
+ *
+ * The trigger is the classified errorType 'over_budget' (err.name ===
+ * 'OverBudgetError' — CM does not export the class, so no cross-package
+ * instanceof; the message-prose match is only a fallback). These tests pin
+ * that classification so a CM message rewording cannot silently kill the
+ * breaker.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AgentFramework } from '../src/framework.js';
+import { MembraneError } from '@animalabs/membrane';
+
+function makeHarness(tick: () => Promise<void>) {
+  const cm = {
+    addMessage: () => 'marker-id',
+    tick,
+  };
+
+  const fw = Object.create(AgentFramework.prototype) as any;
+  fw.consecutiveInferenceFailures = new Map();
+  fw.exhaustionRewinds = new Map();
+  fw.rewindEpisode = new Map();
+  fw.lastInferenceAt = new Map();
+  fw.overBudgetDrainInFlight = new Set();
+  fw.opsAlertLastSent = new Map();
+  fw.pendingRequests = [];
+  fw.traceListeners = [];
+  fw.inferenceFailureEscalationThreshold = 3;
+  fw.agents = new Map([['cairn', {
+    name: 'cairn',
+    refusalHandling: { maxRewinds: 3 },
+    getContextManager: () => cm,
+  }]]);
+
+  const errs: string[] = [];
+  const orig = console.error;
+  console.error = (...a: unknown[]) => { errs.push(a.join(' ')); };
+  const restore = () => { console.error = orig; };
+
+  return { fw, errs, restore };
+}
+
+/** Let the fire-and-forget drain IIFE's microtask chain run to quiescence. */
+async function settle(rounds = 3) {
+  for (let i = 0; i < rounds; i++) await new Promise((r) => setImmediate(r));
+}
+
+const OVER_BUDGET_REASON =
+  'Compile plan would exceed hard budget: head=41200 tail=8100 middle=62000 budget=100000';
+
+test('classification: err.name OverBudgetError → over_budget, regardless of message wording', () => {
+  const fw = Object.create(AgentFramework.prototype) as any;
+
+  // The load-bearing pin: classification must NOT depend on CM's message
+  // prose, which CM can reword without knowing AF gates a breaker on it.
+  const reworded = new Error('context plan no longer fits (reworded in some future CM)');
+  reworded.name = 'OverBudgetError';
+  assert.deepEqual(fw.classifyInferenceError(reworded), { errorType: 'over_budget' });
+
+  // Membrane errors keep their own typed classification.
+  const membraneErr = new MembraneError({
+    type: 'invalid_request',
+    message: '400 bad request',
+    retryable: false,
+    rawError: null,
+  });
+  assert.deepEqual(
+    fw.classifyInferenceError(membraneErr),
+    { retryable: false, errorType: 'invalid_request' },
+  );
+
+  // Anything else stays unclassified.
+  assert.deepEqual(fw.classifyInferenceError(new Error('boom')), {});
+});
+
+test('errorType over_budget kicks the drain: 8 ticks, honest success log', async () => {
+  let ticks = 0;
+  const { fw, errs, restore } = makeHarness(async () => { ticks++; });
+  try {
+    fw.noteInferenceExhausted('cairn', OVER_BUDGET_REASON, undefined, 'over_budget');
+    await settle(20);
+  } finally { restore(); }
+
+  assert.equal(ticks, 8);
+  assert.ok(
+    errs.some((e) => e.includes('drain kicked for cairn') && e.includes('8 ticks')),
+    `success log with real tick count, got: ${errs.join(' | ')}`,
+  );
+});
+
+test('message fallback: "exceed hard budget" prose kicks even without errorType', async () => {
+  let ticks = 0;
+  const { fw, restore } = makeHarness(async () => { ticks++; });
+  try {
+    fw.noteInferenceExhausted('cairn', OVER_BUDGET_REASON, undefined, undefined);
+    await settle(20);
+  } finally { restore(); }
+  assert.equal(ticks, 8);
+});
+
+test('unrelated failures never kick the drain', async () => {
+  let ticks = 0;
+  const { fw, restore } = makeHarness(async () => { ticks++; });
+  try {
+    fw.noteInferenceExhausted('cairn', '529 overloaded', true, 'server');
+    fw.noteInferenceExhausted('cairn', '400 invalid request', false, 'invalid_request');
+    fw.noteInferenceExhausted('cairn', 'weird transport error', undefined, undefined);
+    await settle(20);
+  } finally { restore(); }
+  assert.equal(ticks, 0);
+});
+
+test('overlapping kicks are suppressed: one drain per agent at a time', async () => {
+  let started = 0;
+  const gates: Array<() => void> = [];
+  const { fw, errs, restore } = makeHarness(
+    () => { started++; return new Promise<void>((r) => { gates.push(r); }); },
+  );
+  try {
+    // The scenario the breaker exists for: every activation fails, repeatedly.
+    fw.noteInferenceExhausted('cairn', OVER_BUDGET_REASON, undefined, 'over_budget');
+    fw.noteInferenceExhausted('cairn', OVER_BUDGET_REASON, undefined, 'over_budget');
+    fw.noteInferenceExhausted('cairn', OVER_BUDGET_REASON, undefined, 'over_budget');
+    await settle();
+
+    // Only ONE kick started; its first tick is still in flight.
+    assert.equal(started, 1);
+
+    // Release ticks one at a time — exactly 8 run, then the drain finishes.
+    for (let i = 0; i < 8; i++) {
+      gates[i]!();
+      await settle();
+    }
+    assert.equal(started, 8, 'exactly one drain worth of ticks, not three');
+    assert.equal(errs.filter((e) => e.includes('drain kicked for cairn')).length, 1);
+
+    // The in-flight flag was cleared: a NEW failure kicks again.
+    fw.noteInferenceExhausted('cairn', OVER_BUDGET_REASON, undefined, 'over_budget');
+    await settle();
+    assert.equal(started, 9);
+  } finally { restore(); }
+});
+
+test('a failing tick is logged with the real count and clears the in-flight flag', async () => {
+  let calls = 0;
+  const { fw, errs, restore } = makeHarness(async () => {
+    calls++;
+    if (calls === 3) throw new Error('strategy exploded');
+  });
+  try {
+    fw.noteInferenceExhausted('cairn', OVER_BUDGET_REASON, undefined, 'over_budget');
+    await settle(20);
+    assert.ok(errs.some((e) => e.includes('drain kick failed for cairn after 2 ticks')));
+    assert.equal(fw.overBudgetDrainInFlight.size, 0, 'flag cleared on failure');
+
+    // Recovery: the next failure can kick again.
+    fw.noteInferenceExhausted('cairn', OVER_BUDGET_REASON, undefined, 'over_budget');
+    await settle(20);
+    assert.ok(calls > 3, 'subsequent kick ran');
+  } finally { restore(); }
+});


### PR DESCRIPTION
Two independent fixes for ways an agent goes silently mute, both field-observed on a resident agent on 2026-07-10 (same incident day, full timeline available on request).

## 1. Strip empty text blocks from live activation requests (`agent.ts`)

The Anthropic API rejects empty text blocks with 400 `messages: text content blocks must be non-empty`. Empty blocks occur naturally in stored history (tool-only turns, delivery-failure placeholders, silent turns); one such block in the compiled window mutes the agent entirely — `[inference-failed]` on every attempt until the message ages out. Twin of context-manager's `stripEmptyTextBlocks` on the compression path. Sanitize runs before the trailing-assistant check so dropping a trailing message can't leave an assistant message last.

## 2. OverBudget deadlock breaker (`framework.ts`)

When compile throws `OverBudgetError`, the compression drain never runs: it is driven by successful activity, which the over-budget state prevents — a closed loop with no internal exit. Field data: 36 minutes hard-down, zero self-rescue, external operator intervention required. Fix: on an OverBudget-class inference failure, kick the strategy drain directly (bounded 8 ticks, best-effort, never throws) so folding/merging frees space for the next compile.

## Verification
- Both patches ran in production on a live resident agent for several hours (they are ports of the battle-tested local patches from the incident).
- `bun test`: failure count identical to main baseline (9), no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)