### PR TITLE
release agent-framework 0.6.3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
 
@@ -49,10 +49,10 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           # node 24 ships npm >= 11.5.1, required for OIDC publishing.
           node-version: 24

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animalabs/agent-framework",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Multi-agent framework with pluggable modules, persistent state, and concurrent tool execution",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What changed

Bumps agent-framework to 0.6.3 and moves the release workflow to current GitHub actions on Node 24/npm 11.

## Why

Publish the connectome-host stack through npm trusted publishing with reproducible registry dependencies.

## Validation

Type-check; build; npm test (266 passing)