### PR TITLE
refactor: settle runEphemeralToCompletion from the stream driver, not trace events (adopts #55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,11 @@ framework.onTrace((event) => {
 });
 ```
 
+Trace events are observability-only. They are intended for logs, metrics, UI
+updates, and debugging, not framework-internal control flow. Internal lifecycle
+code should use state-machine signals or process events instead of consuming
+traces, so trace emit order does not become an API contract.
+
 Query raw inference logs:
 
 ```typescript

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -31,6 +31,7 @@ import type {
   ProcessEvent,
   EventResponse,
   ModuleProcessResponse,
+  AgentSettleResult,
   ToolCall,
   ToolCallEvent,
   ToolResult,
@@ -219,6 +220,18 @@ interface RewindRecord {
   discordRef?: { channelId: string; messageId: string };
 }
 
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+}
+
+interface AgentSettleProgress {
+  inferenceStarted: boolean;
+  lastActivity: number;
+  toolCallsCount: number;
+}
+
 export class AgentFramework {
   private store: JsStore;
   private ownsStore: boolean;
@@ -248,6 +261,9 @@ export class AgentFramework {
   private processLoggingBroadcast: boolean;
   private activeStreams: Map<string, Promise<void>> = new Map();
   private pendingAssistantBlocks: Map<string, ContentBlock[]> = new Map();
+  private turnEndedStreams: Set<string> = new Set();
+  private agentSettles: Map<string, Deferred<AgentSettleResult>> = new Map();
+  private agentSettleProgress: Map<string, AgentSettleProgress> = new Map();
   /** Per-agent count of consecutive exhausted inferences (reset on any success).
    *  Drives hard-down escalation — see noteInferenceExhausted. */
   private consecutiveInferenceFailures: Map<string, number> = new Map();
@@ -956,6 +972,47 @@ export class AgentFramework {
     return { agent, contextManager, cleanup };
   }
 
+  private createDeferred<T>(): Deferred<T> {
+    let resolve!: (value: T) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    return { promise, resolve, reject };
+  }
+
+  private touchAgentSettle(agentName: string, inferenceStarted = false): void {
+    const progress = this.agentSettleProgress.get(agentName);
+    if (!progress) return;
+    if (inferenceStarted) {
+      progress.inferenceStarted = true;
+    }
+    progress.lastActivity = Date.now();
+  }
+
+  private recordAgentSettleToolCalls(agentName: string, count: number): void {
+    const progress = this.agentSettleProgress.get(agentName);
+    if (!progress) return;
+    progress.toolCallsCount += count;
+    progress.lastActivity = Date.now();
+  }
+
+  private getAgentSettleToolCalls(agentName: string): number {
+    return this.agentSettleProgress.get(agentName)?.toolCallsCount ?? 0;
+  }
+
+  private settleAgent(agentName: string, result: AgentSettleResult): void {
+    const settle = this.agentSettles.get(agentName);
+    if (!settle) return;
+    this.touchAgentSettle(agentName);
+    if (result.stopReason === 'exhausted') {
+      settle.reject(new Error(result.error ?? 'Unknown error'));
+      return;
+    }
+    settle.resolve(result);
+  }
+
   /**
    * Run an ephemeral agent to completion through the framework's event loop.
    *
@@ -972,38 +1029,27 @@ export class AgentFramework {
   ): Promise<{ speech: string; toolCallsCount: number }> {
     // Register temporarily so the event loop can drive it
     this.agents.set(agent.name, agent);
+    const settle = this.createDeferred<AgentSettleResult>();
+    this.agentSettles.set(agent.name, settle);
+    this.agentSettleProgress.set(agent.name, {
+      inferenceStarted: false,
+      lastActivity: Date.now(),
+      toolCallsCount: 0,
+    });
 
-    return new Promise<{ speech: string; toolCallsCount: number }>((resolve, reject) => {
-      let speech = '';
-      let toolCallsCount = 0;
-      let settled = false;
-      let inferenceStarted = false;
-      let lastActivity = Date.now();
+    const STARTUP_TIMEOUT_MS = 30_000;
+    // After inference has started, give it 15 minutes of activity-bounded
+    // life. The stream driver refreshes the deadline as it makes progress;
+    // sustained silence trips it.
+    const COMPLETION_IDLE_TIMEOUT_MS = 15 * 60_000;
 
-      const STARTUP_TIMEOUT_MS = 30_000;
-      // After inference has started, give it 15 minutes of activity-bounded
-      // life. Each addressed trace event refreshes the deadline; only
-      // sustained silence trips it. Subagents that legitimately stream for
-      // 10+ minutes (e.g. long fork investigations) get the extra slack but
-      // stalled streams that emit `inference:completed` and then go quiet —
-      // the exact zombie shape we saw in production — are caught here.
-      const COMPLETION_IDLE_TIMEOUT_MS = 15 * 60_000;
+    let startupWatchdog: ReturnType<typeof setTimeout> | null = null;
+    let completionWatchdog: ReturnType<typeof setInterval> | null = null;
 
-      const cleanup = () => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(startupWatchdog);
-        clearInterval(completionWatchdog);
-        this.offTrace(traceListener);
-        this.agents.delete(agent.name);
-      };
-
-      // Watchdog: if inference never starts within 30s, the agent is a zombie.
-      // This catches cases where the event loop stalled, the agent was
-      // deregistered, or processInferenceRequests() skipped the request.
-      const startupWatchdog = setTimeout(() => {
-        if (!inferenceStarted && !settled) {
-          cleanup();
+    const startupTimeout = new Promise<never>((_, reject) => {
+      startupWatchdog = setTimeout(() => {
+        const progress = this.agentSettleProgress.get(agent.name);
+        if (!progress?.inferenceStarted) {
           reject(new Error(
             `Ephemeral agent "${agent.name}" failed to start inference within ` +
             `${STARTUP_TIMEOUT_MS}ms — zombie detected. The event loop may have ` +
@@ -1011,104 +1057,46 @@ export class AgentFramework {
           ));
         }
       }, STARTUP_TIMEOUT_MS);
+    });
 
-      // Completion watchdog: once inference has started, reject if no trace
-      // activity for COMPLETION_IDLE_TIMEOUT_MS. Polls every 30s. Without
-      // this, an ephemeral that loses its terminal event (e.g. due to a
-      // future ordering regression or an upstream stream drop) hangs forever
-      // and keeps its concurrency slot pinned.
-      const completionWatchdog = setInterval(() => {
-        if (settled || !inferenceStarted) return;
-        const idle = Date.now() - lastActivity;
+    const completionIdleTimeout = new Promise<never>((_, reject) => {
+      completionWatchdog = setInterval(() => {
+        const progress = this.agentSettleProgress.get(agent.name);
+        if (!progress?.inferenceStarted) return;
+        const idle = Date.now() - progress.lastActivity;
         if (idle > COMPLETION_IDLE_TIMEOUT_MS) {
-          cleanup();
           reject(new Error(
-            `Ephemeral agent "${agent.name}" stalled: no trace activity for ` +
+            `Ephemeral agent "${agent.name}" stalled: no stream-driver activity for ` +
             `${Math.round(idle / 1000)}s after inference started (threshold ` +
             `${Math.round(COMPLETION_IDLE_TIMEOUT_MS / 1000)}s). Stream likely ` +
             `dropped or terminal event was lost.`
           ));
         }
       }, 30_000);
+    });
 
-      const traceListener = (event: TraceEvent) => {
-        if (settled) return;
-        // Only track events for our ephemeral agent
-        const agentName = 'agentName' in event ? (event as { agentName: string }).agentName : null;
-        if (agentName !== agent.name) return;
-
-        // Any addressed event counts as liveness for the completion watchdog.
-        lastActivity = Date.now();
-
-        switch (event.type) {
-          case 'inference:started':
-            inferenceStarted = true;
-            break;
-          case 'inference:tokens': {
-            inferenceStarted = true;
-            const content = (event as { content?: string }).content;
-            if (content) speech += content;
-            break;
-          }
-          case 'inference:tool_calls_yielded': {
-            const calls = (event as { calls?: Array<unknown> }).calls;
-            if (calls) toolCallsCount += calls.length;
-            // Reset speech buffer — tool calls break the text
-            speech = '';
-            break;
-          }
-          case 'inference:stream_resumed':
-            speech = '';
-            break;
-          case 'inference:completed': {
-            // `inference:completed` is terminal — driveStream only emits it
-            // from `case 'complete'`, which fires after the full tool
-            // round-trip has finished and the model has stopped. Intermediate
-            // tool-cycle transitions use `inference:stream_resumed`, not
-            // `inference:completed`. So we resolve unconditionally here.
-            //
-            // Previously this branch gated on `agent.state.status === 'idle'`,
-            // which was correct in intent but order-fragile: the framework
-            // emitted `inference:completed` BEFORE calling `agent.reset()`,
-            // so synchronous listeners observed status === 'streaming' at
-            // the trace boundary. The gate failed silently and the promise
-            // hung forever — every production zombie subagent originated
-            // here. The reset+emit order has been fixed in driveStream's
-            // `case 'complete'` handler; the gate is dropped here as
-            // belt-and-suspenders.
-            cleanup();
-            resolve({ speech, toolCallsCount });
-            break;
-          }
-          case 'inference:turn_ended': {
-            // endTurn from a tool result — agent is done
-            cleanup();
-            resolve({ speech, toolCallsCount });
-            break;
-          }
-          case 'inference:exhausted': {
-            // Retries exhausted — reject only after the error policy gives up.
-            // Earlier inference:failed events are left alone so the framework
-            // retry path in driveStream/startAgentStream can restart the stream
-            // while this listener stays alive.
-            const error = (event as { error?: string }).error ?? 'Unknown error';
-            cleanup();
-            reject(new Error(error));
-            break;
-          }
-        }
-      };
-
-      this.onTrace(traceListener);
-
-      // Trigger inference
+    try {
+      // Trigger inference after the settle promise is registered.
       this.pendingRequests.push({
         agentName: agent.name,
         reason: 'ephemeral',
         source: 'subagent',
         timestamp: Date.now(),
       });
-    });
+
+      const result = await Promise.race([
+        settle.promise,
+        startupTimeout,
+        completionIdleTimeout,
+      ]);
+      return { speech: result.speech, toolCallsCount: result.toolCallsCount };
+    } finally {
+      if (startupWatchdog) clearTimeout(startupWatchdog);
+      if (completionWatchdog) clearInterval(completionWatchdog);
+      this.agentSettles.delete(agent.name);
+      this.agentSettleProgress.delete(agent.name);
+      this.agents.delete(agent.name);
+    }
   }
 
   /**
@@ -2312,6 +2300,9 @@ export class AgentFramework {
     // messages between tool_use and tool_result, causing a 400 error.
     if (event.type === 'tool-result') {
       const agent = this.agents.get(event.agentName);
+      if (agent) {
+        this.touchAgentSettle(event.agentName, true);
+      }
       if (!agent) {
         console.warn(
           `[framework] Dropping tool-result for unknown agent '${event.agentName}' (callId=${event.callId}). ` +
@@ -2386,9 +2377,15 @@ export class AgentFramework {
           if (shouldEndTurn) {
             // endTurn: messages already stored above, cancel stream, reset to idle.
             if (currentState.stream) {
-              agent.cancelStream();
+              this.turnEndedStreams.add(`${agent.name}:${agent.streamId}`);
+              currentState.stream.cancel();
             }
             agent.reset();
+            this.settleAgent(agent.name, {
+              stopReason: 'turn_ended',
+              speech: '',
+              toolCallsCount: this.getAgentSettleToolCalls(agent.name),
+            });
             this.emitTrace({ type: 'inference:turn_ended', agentName: agent.name });
           } else if (overBudget) {
             // Context budget exceeded: break the stream, let compile() compress
@@ -2472,7 +2469,7 @@ export class AgentFramework {
     const durationMs = Date.now() - startTime;
 
     // Always emit trace for observability (UI needs this)
-    this.emitTrace({ type: 'process:completed', processEvent: event, responses, durationMs });
+      this.emitTrace({ type: 'process:completed', processEvent: event, responses, durationMs });
 
     // Log to Chronicle (if enabled)
     if (this.processLoggingPersist) {
@@ -3040,6 +3037,7 @@ export class AgentFramework {
       this.activeTriggerChannels.delete(agent.name);
     }
 
+    this.touchAgentSettle(agent.name, true);
     this.emitTrace({ type: 'inference:started', agentName: agent.name });
     this.eventGate?.onInferenceStarted(agent.name);
 
@@ -3101,6 +3099,12 @@ export class AgentFramework {
         await new Promise((resolve) => setTimeout(resolve, action.delayMs));
         await this.startAgentStream(agent, trigger, attempt + 1);
       } else {
+        this.settleAgent(agent.name, {
+          stopReason: 'exhausted',
+          speech: '',
+          toolCallsCount: this.getAgentSettleToolCalls(agent.name),
+          error: err.message,
+        });
         this.emitTrace({
           type: 'inference:exhausted',
           agentName: agent.name,
@@ -3125,6 +3129,7 @@ export class AgentFramework {
     const requestId = `${agent.name}-${startTime}-${Math.random().toString(36).slice(2, 8)}`;
     const myStreamId = agent.streamId;
     let hadToolCalls = false;
+    let toolCallsCount = 0;
 
     // Typing indicator: show "<agent> is typing…" in the channel she's
     // responding to, for the whole duration of this turn. Started here (paired
@@ -3135,6 +3140,7 @@ export class AgentFramework {
 
     try {
       for await (const event of stream) {
+        this.touchAgentSettle(agent.name, true);
         switch (event.type) {
           case 'tokens':
             this.emitTrace({
@@ -3160,6 +3166,8 @@ export class AgentFramework {
 
           case 'tool-calls': {
             hadToolCalls = true;
+            toolCallsCount += event.calls.length;
+            this.recordAgentSettleToolCalls(agent.name, event.calls.length);
             this.emitTrace({
               type: 'inference:tool_calls_yielded',
               agentName: agent.name,
@@ -3259,13 +3267,15 @@ export class AgentFramework {
                 b.type === 'tool_use' || b.type === 'tool_result' ? i : last,
               -1
             );
+            const terminalContent = lastToolIdx >= 0
+              ? response.content.slice(lastToolIdx + 1)
+              : response.content;
             if (lastToolIdx >= 0) {
-              const trailingContent = response.content.slice(lastToolIdx + 1);
-              if (trailingContent.length > 0) {
-                agent.addAssistantResponse(trailingContent);
+              if (terminalContent.length > 0) {
+                agent.addAssistantResponse(terminalContent);
               }
             } else {
-              agent.addAssistantResponse(response.content);
+              agent.addAssistantResponse(terminalContent);
             }
 
             // Run afterInference hooks (no-op if no MCPL servers)
@@ -3324,17 +3334,23 @@ export class AgentFramework {
                 }
               : undefined;
 
-            // Reset agent state BEFORE emitting inference:completed so that
-            // synchronous listeners (e.g. runEphemeralToCompletion) observe
-            // status === 'idle' the moment the event fires. Previously
-            // agent.reset() ran after `await dispatchSpeech`, which meant the
-            // ephemeral-completion listener saw status === 'streaming' at the
-            // trace boundary, failed its idle gate, and the promise hung
-            // forever — every "zombie subagent" in production tracked back
-            // here. Speech dispatch happens after but doesn't depend on the
-            // status field.
+            // Reset agent state before emitting inference:completed. Traces are
+            // observability-only, but external synchronous listeners should
+            // still see the terminal state at the terminal trace boundary.
+            // Speech dispatch happens after but doesn't depend on the status
+            // field.
             agent.reset();
             this.eventGate?.onInferenceEnded(agent.name);
+            this.settleAgent(agent.name, {
+              stopReason: 'completed',
+              speech: terminalContent
+                .filter((block: ContentBlock): block is ContentBlock & { type: 'text' } => block.type === 'text')
+                .map((block) => block.text)
+                .join('\n'),
+              toolCallsCount: this.agentSettleProgress.has(agent.name)
+                ? this.getAgentSettleToolCalls(agent.name)
+                : toolCallsCount,
+            });
 
             this.emitTrace({
               type: 'inference:completed',
@@ -3570,9 +3586,8 @@ export class AgentFramework {
                 }
               }
             }
-            // NOTE: agent.reset() + onInferenceEnded() already ran above, BEFORE
-            // dispatchSpeech (main's zombie-subagent fix, PR #32 — sync listeners
-            // must see status === 'idle'). Locus routing is speech dispatch and
+            // NOTE: agent.reset() + onInferenceEnded() already ran above,
+            // BEFORE dispatchSpeech. Locus routing is speech dispatch and
             // doesn't depend on the status field, so it correctly runs after.
 
             break;
@@ -3608,6 +3623,14 @@ export class AgentFramework {
               await new Promise((resolve) => setTimeout(resolve, action.delayMs));
               await this.startAgentStream(agent, trigger, attempt + 1);
             } else {
+              this.settleAgent(agent.name, {
+                stopReason: 'exhausted',
+                speech: '',
+                toolCallsCount: this.agentSettleProgress.has(agent.name)
+                  ? this.getAgentSettleToolCalls(agent.name)
+                  : toolCallsCount,
+                error: err.message,
+              });
               this.emitTrace({
                 type: 'inference:exhausted',
                 agentName: agent.name,
@@ -3622,11 +3645,22 @@ export class AgentFramework {
           }
 
           case 'aborted': {
+            if (this.turnEndedStreams.delete(`${agent.name}:${myStreamId}`)) {
+              return;
+            }
             const reason = event.reason ?? 'unknown';
             // Only reset if this is still the active stream (a budget restart
             // may have already started a new stream, bumping streamId)
             if (agent.streamId === myStreamId) {
               agent.reset();
+              this.settleAgent(agent.name, {
+                stopReason: 'exhausted',
+                speech: '',
+                toolCallsCount: this.agentSettleProgress.has(agent.name)
+                  ? this.getAgentSettleToolCalls(agent.name)
+                  : toolCallsCount,
+                error: `Stream aborted: ${reason}`,
+              });
               this.emitTrace({
                 type: 'inference:exhausted',
                 agentName: agent.name,
@@ -3662,6 +3696,14 @@ export class AgentFramework {
         error: err.message,
         stack: err.stack,
       });
+      this.settleAgent(agent.name, {
+        stopReason: 'exhausted',
+        speech: '',
+        toolCallsCount: this.agentSettleProgress.has(agent.name)
+          ? this.getAgentSettleToolCalls(agent.name)
+          : toolCallsCount,
+        error: err.message,
+      });
       this.emitTrace({
         type: 'inference:exhausted',
         agentName: agent.name,
@@ -3673,6 +3715,7 @@ export class AgentFramework {
       // Stop the typing indicator on every exit path (complete, error,
       // exhausted, abort) so it never sticks after the turn ends.
       this.channelRegistry?.stopTyping();
+      this.turnEndedStreams.delete(`${agent.name}:${myStreamId}`);
       this.activeStreams.delete(agent.name);
       this.pendingAssistantBlocks.delete(agent.name);
 

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -3646,6 +3646,7 @@ export class AgentFramework {
 
           case 'aborted': {
             if (this.turnEndedStreams.delete(`${agent.name}:${myStreamId}`)) {
+              this.eventGate?.onInferenceEnded(agent.name);
               return;
             }
             const reason = event.reason ?? 'unknown';

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -236,7 +236,12 @@ interface Deferred<T> {
   reject: (reason?: unknown) => void;
 }
 
-interface AgentSettleProgress {
+/** Per-run state for a framework-driven ephemeral agent: the settle signal
+ *  the caller awaits plus the liveness/progress bookkeeping the watchdogs and
+ *  the stream driver share. One map entry per run — created and torn down in
+ *  runEphemeralToCompletion — so the pieces cannot desync. */
+interface EphemeralRun {
+  settle: Deferred<AgentSettleResult>;
   inferenceStarted: boolean;
   lastActivity: number;
   toolCallsCount: number;
@@ -288,9 +293,17 @@ export class AgentFramework {
   private processLoggingBroadcast: boolean;
   private activeStreams: Map<string, Promise<void>> = new Map();
   private pendingAssistantBlocks: Map<string, ContentBlock[]> = new Map();
-  private turnEndedStreams: Set<string> = new Set();
-  private agentSettles: Map<string, Deferred<AgentSettleResult>> = new Map();
-  private agentSettleProgress: Map<string, AgentSettleProgress> = new Map();
+  /** Streams the FRAMEWORK cancelled for non-terminal reasons, keyed
+   *  `${agentName}:${streamId}`: an endTurn tool result or a context-budget
+   *  restart. The membrane still delivers an `aborted` event for these, and
+   *  without the marker the abort handler would treat it as a terminal
+   *  failure — settling ephemerals with a rejection and emitting a spurious
+   *  `inference:exhausted` (which also pollutes the failure streak). Kept
+   *  separate from ephemeralRuns deliberately: endTurn/budget cancels happen
+   *  for resident agents too, and the key is per-stream, not per-agent. */
+  private frameworkCancelledStreams: Map<string, 'turn_ended' | 'budget_restart'> = new Map();
+  /** Active runEphemeralToCompletion runs, keyed by agent name. */
+  private ephemeralRuns: Map<string, EphemeralRun> = new Map();
   /** Per-agent count of consecutive exhausted inferences (reset on any success).
    *  Drives hard-down escalation — see noteInferenceExhausted. */
   private consecutiveInferenceFailures: Map<string, number> = new Map();
@@ -1210,35 +1223,42 @@ export class AgentFramework {
     return { promise, resolve, reject };
   }
 
-  private touchAgentSettle(agentName: string, inferenceStarted = false): void {
-    const progress = this.agentSettleProgress.get(agentName);
-    if (!progress) return;
+  /** Liveness ping for an active ephemeral run (no-op otherwise). */
+  private touchEphemeralRun(agentName: string, inferenceStarted = false): void {
+    const run = this.ephemeralRuns.get(agentName);
+    if (!run) return;
     if (inferenceStarted) {
-      progress.inferenceStarted = true;
+      run.inferenceStarted = true;
     }
-    progress.lastActivity = Date.now();
+    run.lastActivity = Date.now();
   }
 
-  private recordAgentSettleToolCalls(agentName: string, count: number): void {
-    const progress = this.agentSettleProgress.get(agentName);
-    if (!progress) return;
-    progress.toolCallsCount += count;
-    progress.lastActivity = Date.now();
+  private recordEphemeralToolCalls(agentName: string, count: number): void {
+    const run = this.ephemeralRuns.get(agentName);
+    if (!run) return;
+    run.toolCallsCount += count;
+    run.lastActivity = Date.now();
   }
 
-  private getAgentSettleToolCalls(agentName: string): number {
-    return this.agentSettleProgress.get(agentName)?.toolCallsCount ?? 0;
-  }
-
-  private settleAgent(agentName: string, result: AgentSettleResult): void {
-    const settle = this.agentSettles.get(agentName);
-    if (!settle) return;
-    this.touchAgentSettle(agentName);
-    if (result.stopReason === 'exhausted') {
-      settle.reject(new Error(result.error ?? 'Unknown error'));
+  /** Settle an active ephemeral run (no-op for resident agents). The tool-call
+   *  count comes from the run's own counter — the single source of truth,
+   *  which unlike a per-stream local survives budget restarts. */
+  private settleAgent(
+    agentName: string,
+    outcome: { stopReason: AgentSettleResult['stopReason']; speech: string; error?: string },
+  ): void {
+    const run = this.ephemeralRuns.get(agentName);
+    if (!run) return;
+    run.lastActivity = Date.now();
+    if (outcome.stopReason === 'exhausted') {
+      run.settle.reject(new Error(outcome.error ?? 'Unknown error'));
       return;
     }
-    settle.resolve(result);
+    run.settle.resolve({
+      stopReason: outcome.stopReason,
+      speech: outcome.speech,
+      toolCallsCount: run.toolCallsCount,
+    });
   }
 
   /**
@@ -1254,30 +1274,31 @@ export class AgentFramework {
   async runEphemeralToCompletion(
     agent: Agent,
     contextManager: ContextManager,
+    watchdogs?: { startupTimeoutMs?: number; idleTimeoutMs?: number; idlePollMs?: number },
   ): Promise<{ speech: string; toolCallsCount: number }> {
     // Register temporarily so the event loop can drive it
     this.agents.set(agent.name, agent);
-    const settle = this.createDeferred<AgentSettleResult>();
-    this.agentSettles.set(agent.name, settle);
-    this.agentSettleProgress.set(agent.name, {
+    const run: EphemeralRun = {
+      settle: this.createDeferred<AgentSettleResult>(),
       inferenceStarted: false,
       lastActivity: Date.now(),
       toolCallsCount: 0,
-    });
+    };
+    this.ephemeralRuns.set(agent.name, run);
 
-    const STARTUP_TIMEOUT_MS = 30_000;
+    const STARTUP_TIMEOUT_MS = watchdogs?.startupTimeoutMs ?? 30_000;
     // After inference has started, give it 15 minutes of activity-bounded
     // life. The stream driver refreshes the deadline as it makes progress;
     // sustained silence trips it.
-    const COMPLETION_IDLE_TIMEOUT_MS = 15 * 60_000;
+    const COMPLETION_IDLE_TIMEOUT_MS = watchdogs?.idleTimeoutMs ?? 15 * 60_000;
+    const IDLE_POLL_MS = watchdogs?.idlePollMs ?? 30_000;
 
     let startupWatchdog: ReturnType<typeof setTimeout> | null = null;
     let completionWatchdog: ReturnType<typeof setInterval> | null = null;
 
     const startupTimeout = new Promise<never>((_, reject) => {
       startupWatchdog = setTimeout(() => {
-        const progress = this.agentSettleProgress.get(agent.name);
-        if (!progress?.inferenceStarted) {
+        if (!run.inferenceStarted) {
           reject(new Error(
             `Ephemeral agent "${agent.name}" failed to start inference within ` +
             `${STARTUP_TIMEOUT_MS}ms — zombie detected. The event loop may have ` +
@@ -1289,9 +1310,8 @@ export class AgentFramework {
 
     const completionIdleTimeout = new Promise<never>((_, reject) => {
       completionWatchdog = setInterval(() => {
-        const progress = this.agentSettleProgress.get(agent.name);
-        if (!progress?.inferenceStarted) return;
-        const idle = Date.now() - progress.lastActivity;
+        if (!run.inferenceStarted) return;
+        const idle = Date.now() - run.lastActivity;
         if (idle > COMPLETION_IDLE_TIMEOUT_MS) {
           reject(new Error(
             `Ephemeral agent "${agent.name}" stalled: no stream-driver activity for ` +
@@ -1300,7 +1320,7 @@ export class AgentFramework {
             `dropped or terminal event was lost.`
           ));
         }
-      }, 30_000);
+      }, IDLE_POLL_MS);
     });
 
     try {
@@ -1313,7 +1333,7 @@ export class AgentFramework {
       });
 
       const result = await Promise.race([
-        settle.promise,
+        run.settle.promise,
         startupTimeout,
         completionIdleTimeout,
       ]);
@@ -1321,8 +1341,7 @@ export class AgentFramework {
     } finally {
       if (startupWatchdog) clearTimeout(startupWatchdog);
       if (completionWatchdog) clearInterval(completionWatchdog);
-      this.agentSettles.delete(agent.name);
-      this.agentSettleProgress.delete(agent.name);
+      this.ephemeralRuns.delete(agent.name);
       this.agents.delete(agent.name);
       // Spawn-and-dispose bookkeeping (main, d453165/fee96a7): without this,
       // ephemeral agents leave checkpoint-tree keys and diagnostics map
@@ -2618,7 +2637,7 @@ export class AgentFramework {
     if (event.type === 'tool-result') {
       const agent = this.agents.get(event.agentName);
       if (agent) {
-        this.touchAgentSettle(event.agentName, true);
+        this.touchEphemeralRun(event.agentName, true);
       }
       if (!agent) {
         console.warn(
@@ -2694,18 +2713,28 @@ export class AgentFramework {
           if (shouldEndTurn) {
             // endTurn: messages already stored above, cancel stream, reset to idle.
             if (currentState.stream) {
-              this.turnEndedStreams.add(`${agent.name}:${agent.streamId}`);
+              this.frameworkCancelledStreams.set(`${agent.name}:${agent.streamId}`, 'turn_ended');
               currentState.stream.cancel();
             }
             agent.reset();
-            this.settleAgent(agent.name, {
-              stopReason: 'turn_ended',
-              speech: '',
-              toolCallsCount: this.getAgentSettleToolCalls(agent.name),
-            });
+            // The turn is over — release the gate here, not just in the abort
+            // handler: the membrane's aborted event is asynchronous and the
+            // agent must be wakeable the moment it goes idle. (Idempotent;
+            // driveStream's finally is the backstop.)
+            this.eventGate?.onInferenceEnded(agent.name);
+            this.settleAgent(agent.name, { stopReason: 'turn_ended', speech: '' });
             this.emitTrace({ type: 'inference:turn_ended', agentName: agent.name });
           } else if (overBudget) {
-            // Context budget exceeded: break the stream, let compile() compress
+            // Context budget exceeded: break the stream, let compile() compress.
+            // Mark the cancel as framework-initiated BEFORE cancelling: the
+            // membrane delivers `aborted` before the restart bumps streamId,
+            // and without the marker the abort handler treats the restart as
+            // a terminal failure — rejecting an ephemeral's promise mid-run
+            // and emitting a spurious inference:exhausted (same race shape as
+            // endTurn above).
+            if (currentState.stream) {
+              this.frameworkCancelledStreams.set(`${agent.name}:${agent.streamId}`, 'budget_restart');
+            }
             agent.cancelStream();
             this.emitTrace({
               type: 'inference:stream_restarted',
@@ -2786,7 +2815,7 @@ export class AgentFramework {
     const durationMs = Date.now() - startTime;
 
     // Always emit trace for observability (UI needs this)
-      this.emitTrace({ type: 'process:completed', processEvent: event, responses, durationMs });
+    this.emitTrace({ type: 'process:completed', processEvent: event, responses, durationMs });
 
     // Log to Chronicle (if enabled)
     if (this.processLoggingPersist) {
@@ -3371,7 +3400,7 @@ export class AgentFramework {
       this.activeTriggerChannels.delete(agent.name);
     }
 
-    this.touchAgentSettle(agent.name, true);
+    this.touchEphemeralRun(agent.name, true);
     this.emitTrace({ type: 'inference:started', agentName: agent.name });
     this.eventGate?.onInferenceStarted(agent.name);
     this.lastInferenceAt.set(agent.name, { ...this.lastInferenceAt.get(agent.name), startedAt: Date.now() });
@@ -3439,7 +3468,6 @@ export class AgentFramework {
         this.settleAgent(agent.name, {
           stopReason: 'exhausted',
           speech: '',
-          toolCallsCount: this.getAgentSettleToolCalls(agent.name),
           error: err.message,
         });
         this.emitTrace({
@@ -3474,7 +3502,6 @@ export class AgentFramework {
     const requestId = `${agent.name}-${startTime}-${Math.random().toString(36).slice(2, 8)}`;
     const myStreamId = agent.streamId;
     let hadToolCalls = false;
-    let toolCallsCount = 0;
 
     // Typing indicator: show "<agent> is typing…" in the channel she's
     // responding to, for the whole duration of this turn. Started here (paired
@@ -3485,7 +3512,7 @@ export class AgentFramework {
 
     try {
       for await (const event of stream) {
-        this.touchAgentSettle(agent.name, true);
+        this.touchEphemeralRun(agent.name, true);
         switch (event.type) {
           case 'tokens':
             this.emitTrace({
@@ -3511,8 +3538,7 @@ export class AgentFramework {
 
           case 'tool-calls': {
             hadToolCalls = true;
-            toolCallsCount += event.calls.length;
-            this.recordAgentSettleToolCalls(agent.name, event.calls.length);
+            this.recordEphemeralToolCalls(agent.name, event.calls.length);
             this.emitTrace({
               type: 'inference:tool_calls_yielded',
               agentName: agent.name,
@@ -3692,9 +3718,6 @@ export class AgentFramework {
                 .filter((block: ContentBlock): block is ContentBlock & { type: 'text' } => block.type === 'text')
                 .map((block) => block.text)
                 .join('\n'),
-              toolCallsCount: this.agentSettleProgress.has(agent.name)
-                ? this.getAgentSettleToolCalls(agent.name)
-                : toolCallsCount,
             });
 
             this.emitTrace({
@@ -3974,9 +3997,6 @@ export class AgentFramework {
               this.settleAgent(agent.name, {
                 stopReason: 'exhausted',
                 speech: '',
-                toolCallsCount: this.agentSettleProgress.has(agent.name)
-                  ? this.getAgentSettleToolCalls(agent.name)
-                  : toolCallsCount,
                 error: err.message,
               });
               this.emitTrace({
@@ -3998,7 +4018,14 @@ export class AgentFramework {
           }
 
           case 'aborted': {
-            if (this.turnEndedStreams.delete(`${agent.name}:${myStreamId}`)) {
+            // Framework-initiated, non-terminal cancels (endTurn tool result,
+            // context-budget restart) also surface here as `aborted` — but
+            // the turn either already settled (endTurn) or a replacement
+            // stream is queued (budget restart). Neither is a failure: no
+            // reset, no settle, no spurious inference:exhausted (which would
+            // reject an ephemeral's promise mid-run and bump the failure
+            // streak). Gate release + stream teardown happen in `finally`.
+            if (this.frameworkCancelledStreams.delete(`${agent.name}:${myStreamId}`)) {
               this.eventGate?.onInferenceEnded(agent.name);
               return;
             }
@@ -4011,9 +4038,6 @@ export class AgentFramework {
               this.settleAgent(agent.name, {
                 stopReason: 'exhausted',
                 speech: '',
-                toolCallsCount: this.agentSettleProgress.has(agent.name)
-                  ? this.getAgentSettleToolCalls(agent.name)
-                  : toolCallsCount,
                 error: `Stream aborted: ${reason}`,
               });
               this.emitTrace({
@@ -4094,9 +4118,6 @@ export class AgentFramework {
       this.settleAgent(agent.name, {
         stopReason: 'exhausted',
         speech: '',
-        toolCallsCount: this.agentSettleProgress.has(agent.name)
-          ? this.getAgentSettleToolCalls(agent.name)
-          : toolCallsCount,
         error: err.message,
       });
       this.emitTrace({
@@ -4133,7 +4154,7 @@ export class AgentFramework {
       // Stop the typing indicator on every exit path (complete, error,
       // exhausted, abort) so it never sticks after the turn ends.
       this.channelRegistry?.stopTyping();
-      this.turnEndedStreams.delete(`${agent.name}:${myStreamId}`);
+      this.frameworkCancelledStreams.delete(`${agent.name}:${myStreamId}`);
       this.activeStreams.delete(agent.name);
       this.pendingAssistantBlocks.delete(agent.name);
 

--- a/src/types/framework.ts
+++ b/src/types/framework.ts
@@ -131,6 +131,16 @@ export type ErrorAction =
   | { retry: false; emit?: ProcessEvent };
 
 /**
+ * Terminal result for a framework-driven ephemeral agent run.
+ */
+export interface AgentSettleResult {
+  stopReason: 'completed' | 'turn_ended' | 'exhausted';
+  speech: string;
+  toolCallsCount: number;
+  error?: string;
+}
+
+/**
  * Framework state exposed to policies.
  */
 export interface FrameworkState {

--- a/test/ephemeral-settle.test.ts
+++ b/test/ephemeral-settle.test.ts
@@ -1,0 +1,372 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, relative } from 'node:path';
+import type { NormalizedRequest, YieldingStream } from '@animalabs/membrane';
+import type {
+  ErrorAction,
+  ErrorPolicy,
+  EventResponse,
+  Module,
+  ModuleContext,
+  ProcessEvent,
+  ProcessState,
+  ToolCall,
+  ToolDefinition,
+  ToolResult,
+} from '../src/index.js';
+import { AgentFramework } from '../src/index.js';
+import { createMockResponse, MockMembrane } from './helpers/mock-membrane.js';
+
+class EphemeralToolModule implements Module {
+  readonly name = 'test';
+  readonly calls: ToolCall[] = [];
+
+  constructor(private readonly endTurnTool = 'finish') {}
+
+  async start(_ctx: ModuleContext): Promise<void> {}
+  async stop(): Promise<void> {}
+
+  getTools(): ToolDefinition[] {
+    return [
+      {
+        name: 'echo',
+        description: 'Echo input',
+        inputSchema: {
+          type: 'object',
+          properties: { message: { type: 'string' } },
+        },
+      },
+      {
+        name: this.endTurnTool,
+        description: 'Finish the turn',
+        inputSchema: { type: 'object', properties: {} },
+      },
+    ];
+  }
+
+  async handleToolCall(call: ToolCall): Promise<ToolResult> {
+    this.calls.push(call);
+    const baseName = call.name.includes('--')
+      ? call.name.slice(call.name.lastIndexOf('--') + 2)
+      : call.name;
+    if (baseName === this.endTurnTool) {
+      return { success: true, data: { finished: true }, endTurn: true };
+    }
+    return { success: true, data: { echoed: call.input } };
+  }
+
+  async onProcess(_event: ProcessEvent, _state: ProcessState): Promise<EventResponse> {
+    return {};
+  }
+}
+
+class ThrowingMembrane extends MockMembrane {
+  readonly errors: Error[];
+
+  constructor(errors: Error[]) {
+    super();
+    this.errors = [...errors];
+  }
+
+  streamYielding(request: NormalizedRequest, _options?: unknown): YieldingStream {
+    this.calls.push(request);
+    throw this.errors.shift() ?? new Error('unexpected stream attempt');
+  }
+}
+
+class RetryOncePolicy implements ErrorPolicy {
+  maxRetries = 1;
+
+  onInferenceError(_error: Error, _agentName: string, attempt: number): ErrorAction {
+    if (attempt < this.maxRetries) {
+      return { retry: true, delayMs: 0 };
+    }
+    return { retry: false };
+  }
+}
+
+function tempStorePath(prefix: string): { tempDir: string; storePath: string } {
+  const tempDir = mkdtempSync(join(tmpdir(), prefix));
+  return { tempDir, storePath: join(tempDir, 'store.chronicle') };
+}
+
+async function createEphemeral(
+  framework: AgentFramework,
+  name = 'worker',
+) {
+  const created = await framework.createEphemeralAgent({
+    name,
+    model: 'test-model',
+    systemPrompt: 'Do the task.',
+    allowedTools: 'all',
+  });
+  created.contextManager.addMessage('user', [{ type: 'text', text: 'Run once.' }]);
+  return created;
+}
+
+async function runStartedEphemeral(
+  framework: AgentFramework,
+  agent: Awaited<ReturnType<typeof createEphemeral>>['agent'],
+  contextManager: Awaited<ReturnType<typeof createEphemeral>>['contextManager'],
+) {
+  const promise = framework.runEphemeralToCompletion(agent, contextManager);
+  framework.start();
+  return promise;
+}
+
+async function stopAndRemove(framework: AgentFramework, tempDir: string): Promise<void> {
+  await framework.stop();
+  rmSync(tempDir, { recursive: true, force: true });
+}
+
+describe('runEphemeralToCompletion settle signal', () => {
+  it('resolves plain text completion and deregisters the agent', async () => {
+    const { tempDir, storePath } = tempStorePath('ephemeral-plain-');
+    const membrane = new MockMembrane();
+    membrane.pushResponse(createMockResponse([{ type: 'text', text: 'Plain final answer' }]));
+
+    const framework = await AgentFramework.create({
+      storePath,
+      membrane: membrane.asMembrane(),
+      agents: [],
+      modules: [new EphemeralToolModule()],
+      syncIntervalMs: 0,
+    });
+
+    try {
+      const { agent, contextManager } = await createEphemeral(framework);
+      const result = await runStartedEphemeral(framework, agent, contextManager);
+
+      assert.deepStrictEqual(result, {
+        speech: 'Plain final answer',
+        toolCallsCount: 0,
+      });
+      assert.strictEqual(framework.getAgent(agent.name), null);
+    } finally {
+      await stopAndRemove(framework, tempDir);
+    }
+  });
+
+  it('resolves after tool rounds with final speech and dispatched call count', async () => {
+    const { tempDir, storePath } = tempStorePath('ephemeral-tools-');
+    const membrane = new MockMembrane();
+    const tools = new EphemeralToolModule();
+
+    membrane.pushResponse(createMockResponse([
+      { type: 'text', text: 'Using the first tool.' },
+      { type: 'tool_use', id: 'call_1', name: 'test--echo', input: { message: 'one' } },
+    ], 'tool_use'));
+    membrane.pushResponse(createMockResponse([
+      { type: 'text', text: 'Using the second tool.' },
+      { type: 'tool_use', id: 'call_2', name: 'test--echo', input: { message: 'two' } },
+    ], 'tool_use'));
+    membrane.pushResponse(createMockResponse([
+      { type: 'text', text: 'Post-tool final answer' },
+    ]));
+
+    const framework = await AgentFramework.create({
+      storePath,
+      membrane: membrane.asMembrane(),
+      agents: [],
+      modules: [tools],
+      syncIntervalMs: 0,
+    });
+
+    try {
+      const { agent, contextManager } = await createEphemeral(framework);
+      const result = await runStartedEphemeral(framework, agent, contextManager);
+
+      assert.deepStrictEqual(result, {
+        speech: 'Post-tool final answer',
+        toolCallsCount: 2,
+      });
+      assert.strictEqual(tools.calls.length, 2);
+      assert.strictEqual(framework.getAgent(agent.name), null);
+    } finally {
+      await stopAndRemove(framework, tempDir);
+    }
+  });
+
+  it('resolves through the endTurn tool-result path', async () => {
+    const { tempDir, storePath } = tempStorePath('ephemeral-endturn-');
+    const membrane = new MockMembrane();
+    const tools = new EphemeralToolModule();
+
+    membrane.pushResponse(createMockResponse([
+      { type: 'tool_use', id: 'call_finish', name: 'test--finish', input: {} },
+    ], 'tool_use'));
+
+    const framework = await AgentFramework.create({
+      storePath,
+      membrane: membrane.asMembrane(),
+      agents: [],
+      modules: [tools],
+      syncIntervalMs: 0,
+    });
+
+    try {
+      const { agent, contextManager } = await createEphemeral(framework);
+      const result = await runStartedEphemeral(framework, agent, contextManager);
+
+      assert.deepStrictEqual(result, {
+        speech: '',
+        toolCallsCount: 1,
+      });
+      assert.strictEqual(tools.calls.length, 1);
+      assert.strictEqual(framework.getAgent(agent.name), null);
+    } finally {
+      await stopAndRemove(framework, tempDir);
+    }
+  });
+
+  it('rejects only after error policy exhausts retries', async () => {
+    const { tempDir, storePath } = tempStorePath('ephemeral-errors-');
+    const membrane = new ThrowingMembrane([
+      new Error('temporary failure'),
+      new Error('final failure'),
+    ]);
+
+    const framework = await AgentFramework.create({
+      storePath,
+      membrane: membrane.asMembrane(),
+      agents: [],
+      modules: [new EphemeralToolModule()],
+      errorPolicy: new RetryOncePolicy(),
+      syncIntervalMs: 0,
+    });
+
+    try {
+      const { agent, contextManager } = await createEphemeral(framework);
+      const run = runStartedEphemeral(framework, agent, contextManager);
+
+      await assert.rejects(run, /final failure/);
+      assert.strictEqual(membrane.calls.length, 2, 'the retry attempt should run before settling');
+      assert.strictEqual(framework.getAgent(agent.name), null);
+    } finally {
+      await stopAndRemove(framework, tempDir);
+    }
+  });
+
+  it('does not register a trace listener for completion control flow', async () => {
+    const { tempDir, storePath } = tempStorePath('ephemeral-trace-spy-');
+    const membrane = new MockMembrane();
+    membrane.pushResponse(createMockResponse([{ type: 'text', text: 'Trace independent' }]));
+
+    const framework = await AgentFramework.create({
+      storePath,
+      membrane: membrane.asMembrane(),
+      agents: [],
+      modules: [new EphemeralToolModule()],
+      syncIntervalMs: 0,
+    });
+
+    let onTraceCalls = 0;
+    const originalOnTrace = framework.onTrace.bind(framework);
+    framework.onTrace = ((listener: Parameters<typeof framework.onTrace>[0]) => {
+      onTraceCalls++;
+      return originalOnTrace(listener);
+    }) as typeof framework.onTrace;
+
+    try {
+      const { agent, contextManager } = await createEphemeral(framework);
+      const result = await runStartedEphemeral(framework, agent, contextManager);
+
+      assert.strictEqual(result.speech, 'Trace independent');
+      assert.strictEqual(onTraceCalls, 0);
+      assert.strictEqual(framework.getAgent(agent.name), null);
+    } finally {
+      await stopAndRemove(framework, tempDir);
+    }
+  });
+
+  it('startup watchdog rejects and deregisters when inference never starts', async () => {
+    const { tempDir, storePath } = tempStorePath('ephemeral-startup-');
+    const membrane = new MockMembrane();
+    const framework = await AgentFramework.create({
+      storePath,
+      membrane: membrane.asMembrane(),
+      agents: [],
+      modules: [new EphemeralToolModule()],
+      syncIntervalMs: 0,
+    });
+
+    const originalSetTimeout = globalThis.setTimeout;
+    const originalSetInterval = globalThis.setInterval;
+    const originalClearTimeout = globalThis.clearTimeout;
+    const originalClearInterval = globalThis.clearInterval;
+    let startupCallback: (() => void) | null = null;
+
+    globalThis.setTimeout = ((
+      callback: (...args: unknown[]) => void,
+      delay?: number,
+      ...args: unknown[]
+    ): ReturnType<typeof setTimeout> => {
+      if (delay === 30_000 && typeof callback === 'function') {
+        startupCallback = () => callback(...args);
+      }
+      return 1 as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout;
+    globalThis.setInterval = ((
+      _callback: (...args: unknown[]) => void,
+      _delay?: number,
+      ..._args: unknown[]
+    ): ReturnType<typeof setInterval> => 2 as unknown as ReturnType<typeof setInterval>) as typeof setInterval;
+    globalThis.clearTimeout = ((_timeout?: ReturnType<typeof setTimeout>) => undefined) as typeof clearTimeout;
+    globalThis.clearInterval = ((_interval?: ReturnType<typeof setInterval>) => undefined) as typeof clearInterval;
+
+    try {
+      const { agent, contextManager } = await createEphemeral(framework);
+      const run = framework.runEphemeralToCompletion(agent, contextManager);
+      const rejection = assert.rejects(run, /failed to start inference/);
+
+      assert.ok(startupCallback, 'startup watchdog should be registered');
+      (startupCallback as () => void)();
+
+      await rejection;
+      assert.strictEqual(framework.getAgent(agent.name), null);
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+      globalThis.setInterval = originalSetInterval;
+      globalThis.clearTimeout = originalClearTimeout;
+      globalThis.clearInterval = originalClearInterval;
+      await stopAndRemove(framework, tempDir);
+    }
+  });
+});
+
+describe('trace control-flow guard', () => {
+  it('does not use this.onTrace inside src control flow', () => {
+    const root = process.cwd();
+    const srcRoot = join(root, 'src');
+    const allowed = new Set([
+      'src/framework.ts:onTrace: (listener) => this.onTrace(listener),',
+    ]);
+    const matches: string[] = [];
+
+    const visit = (dir: string) => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const path = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          visit(path);
+          continue;
+        }
+        if (!entry.isFile() || !path.endsWith('.ts')) continue;
+
+        const rel = relative(root, path);
+        const lines = readFileSync(path, 'utf8').split('\n');
+        lines.forEach((line, index) => {
+          if (!line.includes('this.onTrace(')) return;
+          const key = `${rel}:${line.trim()}`;
+          if (!allowed.has(key)) {
+            matches.push(`${rel}:${index + 1}: ${line.trim()}`);
+          }
+        });
+      }
+    };
+
+    visit(srcRoot);
+    assert.deepStrictEqual(matches, []);
+  });
+});

--- a/test/ephemeral-settle.test.ts
+++ b/test/ephemeral-settle.test.ts
@@ -17,7 +17,7 @@ import type {
   ToolResult,
 } from '../src/index.js';
 import { AgentFramework } from '../src/index.js';
-import { createMockResponse, MockMembrane } from './helpers/mock-membrane.js';
+import { createMockResponse, MockMembrane, MockYieldingStream } from './helpers/mock-membrane.js';
 
 class EphemeralToolModule implements Module {
   readonly name = 'test';
@@ -292,45 +292,80 @@ describe('runEphemeralToCompletion settle signal', () => {
       syncIntervalMs: 0,
     });
 
-    const originalSetTimeout = globalThis.setTimeout;
-    const originalSetInterval = globalThis.setInterval;
-    const originalClearTimeout = globalThis.clearTimeout;
-    const originalClearInterval = globalThis.clearInterval;
-    let startupCallback: (() => void) | null = null;
-
-    globalThis.setTimeout = ((
-      callback: (...args: unknown[]) => void,
-      delay?: number,
-      ...args: unknown[]
-    ): ReturnType<typeof setTimeout> => {
-      if (delay === 30_000 && typeof callback === 'function') {
-        startupCallback = () => callback(...args);
-      }
-      return 1 as unknown as ReturnType<typeof setTimeout>;
-    }) as typeof setTimeout;
-    globalThis.setInterval = ((
-      _callback: (...args: unknown[]) => void,
-      _delay?: number,
-      ..._args: unknown[]
-    ): ReturnType<typeof setInterval> => 2 as unknown as ReturnType<typeof setInterval>) as typeof setInterval;
-    globalThis.clearTimeout = ((_timeout?: ReturnType<typeof setTimeout>) => undefined) as typeof clearTimeout;
-    globalThis.clearInterval = ((_interval?: ReturnType<typeof setInterval>) => undefined) as typeof clearInterval;
-
     try {
       const { agent, contextManager } = await createEphemeral(framework);
-      const run = framework.runEphemeralToCompletion(agent, contextManager);
-      const rejection = assert.rejects(run, /failed to start inference/);
+      // Framework deliberately NOT started: the inference request is queued
+      // but nothing drives it, so the (injected, short) startup watchdog is
+      // the only thing that can end the run.
+      const run = framework.runEphemeralToCompletion(agent, contextManager, {
+        startupTimeoutMs: 50,
+      });
 
-      assert.ok(startupCallback, 'startup watchdog should be registered');
-      (startupCallback as () => void)();
-
-      await rejection;
+      await assert.rejects(run, /failed to start inference/);
       assert.strictEqual(framework.getAgent(agent.name), null);
     } finally {
-      globalThis.setTimeout = originalSetTimeout;
-      globalThis.setInterval = originalSetInterval;
-      globalThis.clearTimeout = originalClearTimeout;
-      globalThis.clearInterval = originalClearInterval;
+      await stopAndRemove(framework, tempDir);
+    }
+  });
+
+  it('a context-budget restart mid-run neither rejects nor loses the tool count', async () => {
+    const { tempDir, storePath } = tempStorePath('ephemeral-budget-');
+    // Serve exactly one queued response per stream: the budget restart opens
+    // a SECOND stream, and the stock mock hands all remaining responses to
+    // the first one.
+    class SequentialStreamMembrane extends MockMembrane {
+      private streamIdx = 0;
+      streamYielding(request: NormalizedRequest, _options?: unknown): YieldingStream {
+        this.calls.push(request);
+        const stream = new MockYieldingStream(this.responses.slice(this.streamIdx, ++this.streamIdx));
+        this.lastStream = stream;
+        return stream;
+      }
+    }
+    const membrane = new SequentialStreamMembrane();
+    const tools = new EphemeralToolModule();
+
+    // Stream 1: a tool round whose usage event (10 input tokens) exceeds the
+    // agent's maxStreamTokens below → after the tool result lands, the
+    // framework cancels the stream and queues a context_budget_restart.
+    membrane.pushResponse(createMockResponse([
+      { type: 'text', text: 'Working…' },
+      { type: 'tool_use', id: 'call_1', name: 'test--echo', input: { message: 'one' } },
+    ], 'tool_use'));
+    // Stream 2 (post-restart): the final answer.
+    membrane.pushResponse(createMockResponse([
+      { type: 'text', text: 'Recovered final answer' },
+    ]));
+
+    const framework = await AgentFramework.create({
+      storePath,
+      membrane: membrane.asMembrane(),
+      agents: [],
+      modules: [tools],
+      syncIntervalMs: 0,
+    });
+
+    try {
+      const created = await framework.createEphemeralAgent({
+        name: 'worker',
+        model: 'test-model',
+        systemPrompt: 'Do the task.',
+        allowedTools: 'all',
+        maxStreamTokens: 5,
+      });
+      created.contextManager.addMessage('user', [{ type: 'text', text: 'Run once.' }]);
+
+      // Without the framework-cancel marker, the restart's aborted event
+      // settles the run as exhausted ("Stream aborted: user") instead.
+      const result = await runStartedEphemeral(framework, created.agent, created.contextManager);
+
+      assert.deepStrictEqual(result, {
+        speech: 'Recovered final answer',
+        toolCallsCount: 1,
+      });
+      assert.strictEqual(membrane.calls.length, 2, 'restart should open a second stream');
+      assert.strictEqual(framework.getAgent(created.agent.name), null);
+    } finally {
       await stopAndRemove(framework, tempDir);
     }
   });
@@ -340,9 +375,13 @@ describe('trace control-flow guard', () => {
   it('does not use this.onTrace inside src control flow', () => {
     const root = process.cwd();
     const srcRoot = join(root, 'src');
-    const allowed = new Set([
-      'src/framework.ts:onTrace: (listener) => this.onTrace(listener),',
-    ]);
+    // Structural allowance, not an exact source line (which breaks on any
+    // reformat and turns the guard into a boy-who-cried-wolf): re-EXPOSING
+    // the subscription API — forwarding a caller-supplied listener, as the
+    // ModuleContext plumbing does — is fine. What the guard forbids is the
+    // framework subscribing its OWN listener to drive control flow.
+    const isSubscriptionPlumbing = (line: string) =>
+      /onTrace:\s*\([^)]*\)\s*=>\s*this\.onTrace\(/.test(line);
     const matches: string[] = [];
 
     const visit = (dir: string) => {
@@ -358,10 +397,8 @@ describe('trace control-flow guard', () => {
         const lines = readFileSync(path, 'utf8').split('\n');
         lines.forEach((line, index) => {
           if (!line.includes('this.onTrace(')) return;
-          const key = `${rel}:${line.trim()}`;
-          if (!allowed.has(key)) {
-            matches.push(`${rel}:${index + 1}: ${line.trim()}`);
-          }
+          if (isSubscriptionPlumbing(line)) return;
+          matches.push(`${rel}:${index + 1}: ${line.trim()}`);
         });
       }
     };


### PR DESCRIPTION
Adopts mvanhorn's #55 (both original commits included as-authored: 81cedd8, 25e16b2) and takes it the rest of the way per the 2026-07-13 review — the maintainer-push to the fork branch was refused (403), hence this superseding PR.

## Original summary (from #55)

`runEphemeralToCompletion` now settles from a framework-owned signal resolved by the stream driver, instead of subscribing to `inference:completed` / `inference:turn_ended` / `inference:exhausted` on the trace bus. Trace emit order is no longer load-bearing for ephemeral control flow. Closes #33.

## Taken the rest of the way (review items)

1. *(fixed by the author in 25e16b2)* endTurn abort path releases the event gate; additionally the endTurn branch now releases the gate eagerly next to `agent.reset()`, matching every other reset site, instead of relying on the abort handler / `finally` backstop.
2. **Merged current main** (post-0.6.4, includes #58): conflicts resolved in the merge commit, preserving main's `evictTurnCheckpoints` spawn-and-dispose cleanup and the gate-`finally` from 9948607. Suite is fully green on the merge target: **292/292** (the "3 pre-existing MCPL failures" from the original description were the fixture-packaging gap, since fixed by `pretest`).
3. **Trace-behavior change, called out explicitly:** `inference:turn_ended` is no longer followed by a spurious `inference:exhausted`, and a context-budget restart no longer emits one either (see 4). Consumers that treated that trailing event as the terminal signal for an endTurn'd agent must treat `inference:turn_ended` as terminal in its own right. Our in-house consumer (connectome-host's agent-tree reducer) is already fixed: anima-research/connectome-host@f44542f. Side benefit: framework-initiated cancels no longer feed `noteInferenceExhausted`, so they stop polluting the consecutive-failure streak and `failures.log`.
4. **Cancel-guard extended to the budget-restart path**: the marker is now `frameworkCancelledStreams: Map<streamKey, 'turn_ended' | 'budget_restart'>` — both framework-initiated, non-terminal cancels are recognized by the abort handler, so an ephemeral that merely crosses its context budget mid-run is no longer rejected while the framework restarts its stream. Regression test included (restart resolves with the post-restart speech and the tool count survives across streams).
5. **Per-run state consolidated**: `agentSettles` + `agentSettleProgress` → one `ephemeralRuns: Map<string, EphemeralRun>`; `settleAgent` fills `toolCallsCount` from the run's own counter, and the unreachable `: toolCallsCount` ternary arms plus the local counter feeding them are gone. The cancel marker stays a separate map deliberately: endTurn/budget cancels happen for resident agents too, and its key is per-stream, not per-agent.
6. Whitespace-only reindent reverted.
7. **Tests hardened**: the startup-watchdog test injects a short timeout via a new optional `watchdogs` parameter on `runEphemeralToCompletion` (no more global-timer monkey-patching keyed to the literal 30_000ms); the trace-guard allowlist is a structural subscription-plumbing pattern instead of an exact source line.

## Testing

- `npm run build`: clean
- Full suite on the merge result: **292/292** (was 284 on main; +8 from `ephemeral-settle.test.ts` incl. the new budget-restart regression)

Closes #33. Supersedes #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)