### PR TITLE
Alert on context maintenance failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animalabs/agent-framework",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Multi-agent framework with pluggable modules, persistent state, and concurrent tool execution",
   "repository": {
     "type": "git",

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -732,9 +732,16 @@ export class AgentFramework {
   private startQueuedMaintenance(): void {
     if (this.maintenancePass || !this.running) return;
     const pass = this.runQueuedMaintenance().catch((error) => {
+      const reason = error instanceof Error ? error.message : String(error);
       console.error(
         '[context-maintenance] pass failed:',
-        error instanceof Error ? error.message : error,
+        reason,
+      );
+      this.opsAlert(
+        'context-maintenance-failed',
+        'framework',
+        reason,
+        { data: { scope: 'pass' } },
       );
     });
     this.maintenancePass = pass;
@@ -789,6 +796,18 @@ export class AgentFramework {
         } catch (error) {
           record.error = error instanceof Error ? error.message : String(error);
           console.error(`[context-maintenance] agent=${agent.name} failed:`, record.error);
+          this.opsAlert(
+            'context-maintenance-failed',
+            agent.name,
+            record.error,
+            {
+              data: {
+                scope: 'agent',
+                ...(record.pendingBefore ? { pending: record.pendingBefore } : {}),
+                ...(record.progressBefore ? { progress: record.progressBefore } : {}),
+              },
+            },
+          );
         } finally {
           const pending = cm.getPendingWork()?.description;
           record.finishedAt = Date.now();

--- a/test/maintenance-timer.test.ts
+++ b/test/maintenance-timer.test.ts
@@ -48,6 +48,26 @@ class QueuedStrategy implements ContextStrategy {
   }
 }
 
+class FailingStrategy implements ContextStrategy {
+  readonly name = 'failing-maintenance-test';
+
+  checkReadiness(): ReadinessState {
+    return { ready: false, description: 'compression blocked' };
+  }
+
+  async tick(_ctx: StrategyContext): Promise<void> {
+    throw new Error('provider rejected maintenance request');
+  }
+
+  select(
+    _store: MessageStoreView,
+    _log: ContextLogView,
+    _budget: TokenBudget,
+  ): ContextEntry[] {
+    return [];
+  }
+}
+
 class ToolModule implements Module {
   readonly name = 'maintenance-tools';
 
@@ -141,6 +161,57 @@ describe('queued context maintenance timer', () => {
       framework.start();
       await new Promise(resolve => setTimeout(resolve, 40));
       assert.equal(strategy.ticks, 0);
+    } finally {
+      await framework.stop();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('routes a maintenance failure through the ops-alert pipeline', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'af-maintenance-alert-'));
+    const framework = await AgentFramework.create({
+      storePath: join(dir, 'store'),
+      membrane,
+      agents: [{
+        name: 'agent',
+        model: 'test-model',
+        systemPrompt: 'test',
+        strategy: new FailingStrategy(),
+      }],
+      modules: [],
+      syncIntervalMs: 0,
+      maintenanceIntervalMs: 10,
+    });
+    const alerts: Array<{
+      kind: string;
+      agentName: string;
+      message: string;
+      data?: Record<string, unknown>;
+    }> = [];
+    (framework as any).opsAlert = (
+      kind: string,
+      agentName: string,
+      message: string,
+      opts?: { data?: Record<string, unknown> },
+    ) => alerts.push({ kind, agentName, message, data: opts?.data });
+
+    try {
+      framework.start();
+      await waitFor(() => alerts.length > 0);
+      assert.deepEqual(alerts[0], {
+        kind: 'context-maintenance-failed',
+        agentName: 'agent',
+        message: 'provider rejected maintenance request',
+        data: {
+          scope: 'agent',
+          pending: 'compression blocked',
+        },
+      });
+      await waitFor(() => framework.getContextMaintenanceSnapshot().history.length > 0);
+      assert.equal(
+        framework.getContextMaintenanceSnapshot().history[0].agents[0].error,
+        'provider rejected maintenance request',
+      );
     } finally {
       await framework.stop();
       rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
## What changed

- Route per-agent context-maintenance failures through the unified ops-alert pipeline.
- Route unexpected whole-pass maintenance failures through the same pipeline.
- Include safe scope and progress metadata in the alert.
- Add regression coverage and bump `@animalabs/agent-framework` to 0.6.5.

## Why

Maintenance errors previously stopped the affected maintenance pass but only reached stderr. They did not create a durable failure record, emit `ops:alert`, or reach the configured webhook.

## Impact

Maintenance failures now create `failures.log` records and observer traces on every occurrence, with webhook delivery cooldown-throttled by agent and kind.

## Validation

- `npm run typecheck`
- Maintenance-alert focused test passed
- Full suite passed once with 274 tests; a pre-existing macOS workspace-watcher timing test was flaky on subsequent parallel reruns and passed in isolation
- `npm pack --dry-run`
- Sol restarted healthy with maintenance ready
