### PR TITLE
workspace grep: accept a FILE path, not just a directory prefix

### DIFF
--- a/src/modules/workspace/index.ts
+++ b/src/modules/workspace/index.ts
@@ -905,8 +905,20 @@ export class WorkspaceModule implements Module {
         mount.initialSyncDone = true;
       }
 
-      const prefix = relativePath ? relativePath + '/' : undefined;
-      const entries = store.treeList(mount.treeStateId, prefix);
+      // If `path` points at a single FILE, grep just that file. Otherwise treat
+      // `path` as a directory prefix (the original behaviour). Previously a file
+      // path produced an empty prefix like "notes.md/" and matched nothing, so
+      // grepping a specific file silently returned zero results.
+      let entries: Array<{ path: string; blobHash: string }>;
+      const fileNode = relativePath
+        ? (store.treeGet(mount.treeStateId, relativePath) as { blobHash?: string } | null)
+        : null;
+      if (fileNode && fileNode.blobHash) {
+        entries = [{ path: relativePath, blobHash: fileNode.blobHash }];
+      } else {
+        const prefix = relativePath ? relativePath + '/' : undefined;
+        entries = store.treeList(mount.treeStateId, prefix);
+      }
 
       for (const entry of entries) {
         if (fileGlob && !fileGlob.test(entry.path)) continue;


### PR DESCRIPTION
### Problem
`handleGrep` builds `prefix = relativePath + '/'` and `treeList`s it, so `path` only works as a **directory** scope. Grepping a specific file — e.g. `claude/notes.md` — produces the prefix `notes.md/`, matches nothing in the tree, and **silently returns zero matches** (no error, just an empty result), which reads as "no hits" rather than "wrong query shape."

### Fix
If `relativePath` resolves to a file in the tree (`treeGet` returns a `blobHash`), grep just that file. Otherwise keep the existing directory-prefix behaviour.

- Single-file `path` → greps that file.
- Directory `path` and no-`path` (all-mounts) searches → **unchanged**.

+14 / −2 in `src/modules/workspace/index.ts`.

### Verification
Zero-API, against a read-only external mount: a file-path query went **0 → 1 hit**; directory and no-path searches were unchanged.

### Context
Found while running multi-agent rooms on top of `@animalabs/agent-framework`, where agents grep specific files (e.g. a shared notes file) and were getting empty results. Happy to adjust naming/approach if you'd prefer a different shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)