### PR TITLE
fix: persist verbatim XML tool-call text on stored tool_use blocks

### DIFF
--- a/src/framework.ts
+++ b/src/framework.ts
@@ -4776,13 +4776,30 @@ export class AgentFramework {
                 (b) => b.type !== 'tool_result'
               );
             } else {
-              // Fallback (older membrane / XML tool mode): preamble + calls
+              // Fallback (older membrane / XML tool mode): preamble + calls.
+              // XML mode: persist the verbatim generation on each tool_use
+              // (membrane#36 round-trip fidelity). context.rawText is the
+              // parser's fullMatch — the exact <function_calls> block the
+              // model wrote (plus the harness-appended close tag), shared by
+              // every call in the round; the anthropic-xml formatter replays
+              // it byte-identically instead of reconstructing. Guarded by
+              // shape so a native-path fallback can never attach non-XML.
+              const rawText = event.context.rawText;
+              const rawXml = rawText && /^<(antml:)?function_calls>/.test(rawText)
+                ? rawText
+                : undefined;
               assistantBlocks = [];
               if (event.context.preamble) {
                 assistantBlocks.push({ type: 'text', text: event.context.preamble });
               }
               for (const c of event.calls) {
-                assistantBlocks.push({ type: 'tool_use', id: c.id, name: c.name, input: c.input as Record<string, unknown> });
+                assistantBlocks.push({
+                  type: 'tool_use',
+                  id: c.id,
+                  name: c.name,
+                  input: c.input as Record<string, unknown>,
+                  ...(rawXml ? { rawXml } : {}),
+                });
               }
             }
             this.pendingAssistantBlocks.set(agent.name, assistantBlocks);


### PR DESCRIPTION
Companion to antra-tess/membrane#36 (fixed by antra-tess/membrane#37).

Membrane now carries the raw `<function_calls>` generation on parsed `tool_use` blocks (`rawXml`) and replays it byte-identically in prefill/XML mode. But XML-mode tool rounds are persisted by the framework's preamble+calls fallback (`roundContent` only exists on the native-tools path), which rebuilt blocks from `{id, name, input}` and dropped the raw text — so every **new** call would still be stored legacy-shaped and replay as a canonical reconstruction (correct syntax, but not the agent's actual bytes: parameter order and whitespace normalized).

This attaches `event.context.rawText` — the parser's `fullMatch`, i.e. the exact block the model wrote plus the harness-appended `</function_calls>` — as `rawXml` on each persisted `tool_use`. Shape-guarded (`/^<(antml:)?function_calls>/`) so a native-path fallback can never attach non-XML.

Deploy note: keep (Rhys/Ash/Evander) wants this after merge; Rhys's two existing calls were already backfilled store-side from his response captures on 2026-07-26.

Tests: 412 pass / 0 fail; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)