### PR TITLE
feat: machine-close provenance + explicit-open protection; ModuleContext.notifyOps (#5)

### DIFF
--- a/src/framework.ts
+++ b/src/framework.ts
@@ -62,7 +62,7 @@ import { PushHandler, type McplPushEvent } from './mcpl/push-handler.js';
 import { parseProsePrefix } from './mcpl/prose-grammar.js';
 import { ProseStreamRouter } from './mcpl/prose-stream-router.js';
 import { InferenceRouter } from './mcpl/inference-router.js';
-import { ChannelRegistry } from './mcpl/channel-registry.js';
+import { ChannelRegistry, type ChannelToolOrigin } from './mcpl/channel-registry.js';
 import { ConversationRouter } from './mcpl/conversation-router.js';
 import { safeSlice } from './safe-slice.js';
 import type { WorkspaceModule } from './modules/workspace/index.js';
@@ -722,7 +722,11 @@ export class AgentFramework {
       queryMessages: (filter) => this.queryMessages(filter),
       pushEvent: (event) => this.pushEvent(event),
       onTrace: (listener) => this.onTrace(listener),
-      callTool: (call) => this.executeToolCall(call),
+      // The ONLY entry that confers module origin — a private closure the
+      // framework hands to its own module registry. The public
+      // executeToolCall() is shared with model/ephemeral callers and always
+      // stamps agent origin (see there).
+      callTool: (call) => this.executeToolCallFrom(call, { kind: 'module' }),
       notifyOps: (kind, agentName, message, data) => this.notifyOps(kind, agentName, message, data),
     });
   }
@@ -5732,8 +5736,23 @@ export class AgentFramework {
    * Execute a tool call and return the result.
    * Routes to the appropriate handler (module registry or MCPL).
    * Used by SubagentModule to dispatch tool calls for ephemeral agents.
+   *
+   * This public entry always carries AGENT origin. Ephemeral/promise-based
+   * callers are models, and provenance must identify which internal path a
+   * call entered through — a public method shared with model callers can
+   * never confer module trust, whatever the input claims. Module origin
+   * exists only through the private closure handed to ModuleRegistry
+   * (ctx.callTool → executeToolCallFrom with {kind:'module'}). Callers that
+   * don't identify themselves fail safe to agent semantics too.
    */
   async executeToolCall(call: ToolCall): Promise<ToolResult> {
+    return this.executeToolCallFrom(call, {
+      kind: 'agent',
+      agentName: call.callerAgentName ?? '__ephemeral__',
+    });
+  }
+
+  private async executeToolCallFrom(call: ToolCall, origin: ChannelToolOrigin): Promise<ToolResult> {
     // Client-side programmatic tool calling for promise-based callers
     // (SubagentModule ephemerals). Keyed by callerAgentName so each ephemeral
     // gets its own interpreter state.
@@ -5754,17 +5773,18 @@ export class AgentFramework {
       }
     }
 
-    // Synthesized channel tools, for MODULE callers (ctx.callTool). This
-    // route was missing: when subscription-GC moved off the retired MCPL
-    // unsubscribe tool onto the generic channel_close (discord-mcpl
-    // b095a9f), module-originated closes started failing downstream as
-    // "Invalid tool name format" — the janitor has been silently broken
-    // since. The origin object is trusted dispatch context: this path
-    // alone may carry machine provenance (see handleToolClose). The
-    // agent-only synthesized verbs (think, skip_reply) are deliberately
-    // not routed here.
+    // Synthesized channel tools. This route was missing: when
+    // subscription-GC moved off the retired MCPL unsubscribe tool onto the
+    // generic channel_close (discord-mcpl b095a9f), module-originated
+    // closes started failing downstream as "Invalid tool name format" —
+    // the janitor had been silently broken since. `origin` is trusted
+    // dispatch context established at the call boundary above, not
+    // inferred from which method was used: only the ModuleRegistry closure
+    // carries module provenance (see handleToolClose). The agent-only
+    // synthesized verbs (think, skip_reply) are deliberately not routed
+    // here.
     if (call.name.startsWith('channel_') && this.channelRegistry) {
-      return this.channelRegistry.handleChannelToolCall(call.name, call.input, { kind: 'module' });
+      return this.channelRegistry.handleChannelToolCall(call.name, call.input, origin);
     }
 
     // Module tools

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -5754,6 +5754,19 @@ export class AgentFramework {
       }
     }
 
+    // Synthesized channel tools, for MODULE callers (ctx.callTool). This
+    // route was missing: when subscription-GC moved off the retired MCPL
+    // unsubscribe tool onto the generic channel_close (discord-mcpl
+    // b095a9f), module-originated closes started failing downstream as
+    // "Invalid tool name format" — the janitor has been silently broken
+    // since. The origin object is trusted dispatch context: this path
+    // alone may carry machine provenance (see handleToolClose). The
+    // agent-only synthesized verbs (think, skip_reply) are deliberately
+    // not routed here.
+    if (call.name.startsWith('channel_') && this.channelRegistry) {
+      return this.channelRegistry.handleChannelToolCall(call.name, call.input, { kind: 'module' });
+    }
+
     // Module tools
     return this.moduleRegistry.handleToolCall(call);
   }
@@ -8114,7 +8127,7 @@ export class AgentFramework {
     this.emitTrace({ type: 'tool:started', module: 'channels', tool: call.name, callId: call.id, input: call.input });
     const startTime = Date.now();
 
-    this.channelRegistry!.handleChannelToolCall(call.name, call.input)
+    this.channelRegistry!.handleChannelToolCall(call.name, call.input, { kind: 'agent', agentName })
       .then((result) => {
         const durationMs = Date.now() - startTime;
         this.emitTrace({ type: 'tool:completed', module: 'channels', tool: call.name, callId: call.id, durationMs });

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -723,6 +723,7 @@ export class AgentFramework {
       pushEvent: (event) => this.pushEvent(event),
       onTrace: (listener) => this.onTrace(listener),
       callTool: (call) => this.executeToolCall(call),
+      notifyOps: (kind, agentName, message, data) => this.notifyOps(kind, agentName, message, data),
     });
   }
 

--- a/src/mcpl/channel-registry.ts
+++ b/src/mcpl/channel-registry.ts
@@ -337,6 +337,21 @@ interface ChannelRegistryOptions {
 // ChannelRegistry
 // ============================================================================
 
+/**
+ * Who is actually making a channel tool call, as established by the
+ * framework's own dispatch — model-origin calls come through
+ * dispatchToolCall (which knows the agent), module calls come through
+ * ModuleContext.callTool. Tool INPUT can claim anything; this cannot.
+ */
+export type ChannelToolOrigin =
+  | { kind: 'module'; moduleName?: string }
+  | { kind: 'agent'; agentName: string };
+
+/** The machine decision sources a module-origin channel_close may record.
+ *  Closed on purpose: honest provenance means a small, auditable vocabulary,
+ *  not arbitrary self-description. */
+export const MACHINE_CLOSE_SOURCES = new Set(['subscription-gc', 'housekeeping']);
+
 export class ChannelRegistry {
   private serverRegistry: McplServerRegistry;
   private featureSetManager: FeatureSetManager;
@@ -855,8 +870,20 @@ export class ChannelRegistry {
 
   /**
    * Handle a call to one of the synthesized channel tools.
+   *
+   * `origin` is TRUSTED DISPATCH CONTEXT, supplied by the framework's own
+   * routing (dispatchChannelToolCall for model-origin calls, executeToolCall
+   * for module ctx.callTool) — never derived from tool input. Machine
+   * provenance on channel_close is honored only for module origin; a
+   * model-origin call carrying the same fields is recorded as the agent
+   * decision it actually is. Absent origin is treated as agent-origin (the
+   * untrusted-safe default).
    */
-  async handleChannelToolCall(toolName: string, input: unknown): Promise<ToolResult> {
+  async handleChannelToolCall(
+    toolName: string,
+    input: unknown,
+    origin?: ChannelToolOrigin,
+  ): Promise<ToolResult> {
     switch (toolName) {
       case 'channel_list':
         return this.handleToolList();
@@ -870,12 +897,15 @@ export class ChannelRegistry {
         });
 
       case 'channel_close':
-        return this.handleToolClose(input as {
-          channelId: string;
-          serverId?: string;
-          source?: string;
-          overrideExplicitOpen?: boolean;
-        });
+        return this.handleToolClose(
+          input as {
+            channelId: string;
+            serverId?: string;
+            source?: string;
+            overrideExplicitOpen?: boolean;
+          },
+          origin,
+        );
 
       case 'channel_decline':
         return this.handleToolDecline(input as {
@@ -1593,19 +1623,25 @@ export class ChannelRegistry {
     }
   }
 
-  private async handleToolClose(input: {
-    channelId: string;
-    serverId?: string;
-    /** Machine callers (housekeeping modules) name themselves here so the
-     *  durable record carries honest provenance — e.g. 'subscription-gc'.
-     *  Undeclared in the agent-facing schema; absent = an agent/operator
-     *  decision, recorded as 'agent-tool' exactly as before. */
-    source?: string;
-    /** A machine close aimed at an explicitly-opened channel is refused
-     *  unless the caller certifies an explicit idle lease (an agent-set
-     *  per-channel budget is consent to close at that budget). */
-    overrideExplicitOpen?: boolean;
-  }): Promise<ToolResult> {
+  private async handleToolClose(
+    input: {
+      channelId: string;
+      serverId?: string;
+      /** Machine callers name their decision source ('subscription-gc',
+       *  'housekeeping') so the durable record carries honest provenance.
+       *  Honored ONLY for module-origin dispatch — tool input is untrusted,
+       *  so a model-origin call carrying this field is still recorded as
+       *  'agent-tool' (the resident may close their own channel; they may
+       *  not attribute the act to housekeeping). */
+      source?: string;
+      /** A machine close aimed at an explicitly-opened channel is refused
+       *  unless the caller certifies an explicit idle lease (a configured
+       *  per-channel budget is consent to close at that budget). Module
+       *  origin only, like `source`. */
+      overrideExplicitOpen?: boolean;
+    },
+    origin?: ChannelToolOrigin,
+  ): Promise<ToolResult> {
     const resolved = this.resolveToolChannelEntry(input.channelId, input.serverId);
     const entry = resolved.entry;
     if (!entry) {
@@ -1624,15 +1660,32 @@ export class ChannelRegistry {
       };
     }
 
-    const closeSource =
-      typeof input.source === 'string' && input.source.length > 0 ? input.source : 'agent-tool';
+    // Provenance comes from trusted dispatch, not from self-description:
+    // only module-origin calls may record a machine source, and only from
+    // the closed vocabulary. Agent-origin (or origin-less — the safe
+    // default for any legacy caller) records 'agent-tool' and has its
+    // machine fields ignored entirely.
+    const isModuleOrigin = origin?.kind === 'module';
+    let closeSource = 'agent-tool';
+    if (isModuleOrigin && input.source !== undefined) {
+      if (!MACHINE_CLOSE_SOURCES.has(input.source)) {
+        return {
+          success: false,
+          isError: true,
+          error:
+            `Unknown machine close source '${input.source}'. Machine closes must use one of: ` +
+            `${[...MACHINE_CLOSE_SOURCES].join(', ')}.`,
+        };
+      }
+      closeSource = input.source;
+    }
 
     // Housekeeping must not override stated intent (issue #5: GC closes wore
     // the agent's badge and reset explicitly-opened doors). A machine-sourced
     // close of a channel whose current desired state is an agent/operator
     // 'open' is refused — structurally, so the caller can stand down rather
     // than retry — unless it certifies an explicit idle lease.
-    if (closeSource !== 'agent-tool' && !input.overrideExplicitOpen) {
+    if (isModuleOrigin && closeSource !== 'agent-tool' && !input.overrideExplicitOpen) {
       const current = this.desiredStates.get(this.lifecycleKey(entry.serverId, input.channelId));
       if (current?.state === 'open' && current.source === 'agent-tool') {
         return {

--- a/src/mcpl/channel-registry.ts
+++ b/src/mcpl/channel-registry.ts
@@ -872,8 +872,9 @@ export class ChannelRegistry {
    * Handle a call to one of the synthesized channel tools.
    *
    * `origin` is TRUSTED DISPATCH CONTEXT, supplied by the framework's own
-   * routing (dispatchChannelToolCall for model-origin calls, executeToolCall
-   * for module ctx.callTool) — never derived from tool input. Machine
+   * routing (dispatchChannelToolCall and the public executeToolCall for
+   * model-origin calls, the framework's private ModuleRegistry closure for
+   * module ctx.callTool) — never derived from tool input. Machine
    * provenance on channel_close is honored only for module origin; a
    * model-origin call carrying the same fields is recorded as the agent
    * decision it actually is. Absent origin is treated as agent-origin (the

--- a/src/mcpl/channel-registry.ts
+++ b/src/mcpl/channel-registry.ts
@@ -870,7 +870,12 @@ export class ChannelRegistry {
         });
 
       case 'channel_close':
-        return this.handleToolClose(input as { channelId: string; serverId?: string });
+        return this.handleToolClose(input as {
+          channelId: string;
+          serverId?: string;
+          source?: string;
+          overrideExplicitOpen?: boolean;
+        });
 
       case 'channel_decline':
         return this.handleToolDecline(input as {
@@ -1588,7 +1593,19 @@ export class ChannelRegistry {
     }
   }
 
-  private async handleToolClose(input: { channelId: string; serverId?: string }): Promise<ToolResult> {
+  private async handleToolClose(input: {
+    channelId: string;
+    serverId?: string;
+    /** Machine callers (housekeeping modules) name themselves here so the
+     *  durable record carries honest provenance — e.g. 'subscription-gc'.
+     *  Undeclared in the agent-facing schema; absent = an agent/operator
+     *  decision, recorded as 'agent-tool' exactly as before. */
+    source?: string;
+    /** A machine close aimed at an explicitly-opened channel is refused
+     *  unless the caller certifies an explicit idle lease (an agent-set
+     *  per-channel budget is consent to close at that budget). */
+    overrideExplicitOpen?: boolean;
+  }): Promise<ToolResult> {
     const resolved = this.resolveToolChannelEntry(input.channelId, input.serverId);
     const entry = resolved.entry;
     if (!entry) {
@@ -1607,7 +1624,30 @@ export class ChannelRegistry {
       };
     }
 
-    this.setDesiredState(entry.serverId, input.channelId, 'closed', 'agent-tool');
+    const closeSource =
+      typeof input.source === 'string' && input.source.length > 0 ? input.source : 'agent-tool';
+
+    // Housekeeping must not override stated intent (issue #5: GC closes wore
+    // the agent's badge and reset explicitly-opened doors). A machine-sourced
+    // close of a channel whose current desired state is an agent/operator
+    // 'open' is refused — structurally, so the caller can stand down rather
+    // than retry — unless it certifies an explicit idle lease.
+    if (closeSource !== 'agent-tool' && !input.overrideExplicitOpen) {
+      const current = this.desiredStates.get(this.lifecycleKey(entry.serverId, input.channelId));
+      if (current?.state === 'open' && current.source === 'agent-tool') {
+        return {
+          success: false,
+          isError: false,
+          error:
+            `Channel ${input.channelId} was explicitly opened (source: agent-tool); ` +
+            `a '${closeSource}' close does not override stated intent. Machine closes ` +
+            `of explicit opens require an explicit idle lease (overrideExplicitOpen).`,
+          data: { refusal: 'explicit-open', channelId: input.channelId },
+        };
+      }
+    }
+
+    this.setDesiredState(entry.serverId, input.channelId, 'closed', closeSource);
     this.stopTyping(input.channelId);
 
     const server = this.serverRegistry.getServer(entry.serverId);

--- a/src/module-registry.ts
+++ b/src/module-registry.ts
@@ -75,6 +75,15 @@ export class ModuleRegistry {
   private pushEventFn: (event: ProcessEvent) => void;
   private onTraceFn: (listener: TraceEventListener) => () => void;
   private callToolFn: (call: ToolCall) => Promise<ToolResult>;
+  /** Framework ops-alert channel, surfaced to modules via
+   *  ModuleContext.notifyOps. Readonly-public so ModuleContextImpl can
+   *  delegate without another positional constructor parameter. */
+  readonly notifyOpsFn?: (
+    kind: string,
+    agentName: string,
+    message: string,
+    data?: Record<string, unknown>,
+  ) => void;
 
   constructor(
     store: JsStore,
@@ -89,6 +98,7 @@ export class ModuleRegistry {
       pushEvent: (event: ProcessEvent) => void;
       onTrace: (listener: TraceEventListener) => () => void;
       callTool: (call: ToolCall) => Promise<ToolResult>;
+      notifyOps?: (kind: string, agentName: string, message: string, data?: Record<string, unknown>) => void;
     }
   ) {
     this.store = store;
@@ -102,6 +112,7 @@ export class ModuleRegistry {
     this.pushEventFn = options.pushEvent;
     this.onTraceFn = options.onTrace;
     this.callToolFn = options.callTool;
+    this.notifyOpsFn = options.notifyOps;
   }
 
   /**
@@ -554,6 +565,10 @@ class ModuleContextImpl implements ModuleContext {
 
   callTool(call: ToolCall): Promise<ToolResult> {
     return this.callToolFn(call);
+  }
+
+  notifyOps(kind: string, agentName: string, message: string, data?: Record<string, unknown>): void {
+    this.registry.notifyOpsFn?.(kind, agentName, message, data);
   }
 
   addMessage(

--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -298,6 +298,18 @@ export interface ModuleContext {
    * leaking listeners across teardown/recreate (e.g. session switch).
    */
   onTrace(listener: TraceEventListener): () => void;
+
+  /**
+   * Raise an operator-facing ops alert through the framework's ops channel
+   * (failures.log + `ops:alert` trace + the ops webhook, when configured).
+   * For module actions that change durable state the operator would otherwise
+   * discover by surprise — e.g. subscription GC closing a channel. Keep the
+   * message privacy-minimal: identifiers and thresholds, not content.
+   *
+   * Optional so modules built against this version degrade gracefully on an
+   * older framework: call as `ctx.notifyOps?.(...)`.
+   */
+  notifyOps?(kind: string, agentName: string, message: string, data?: Record<string, unknown>): void;
 }
 
 /**

--- a/test/machine-close-provenance.test.ts
+++ b/test/machine-close-provenance.test.ts
@@ -1,0 +1,111 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { ChannelRegistry } from '../src/mcpl/channel-registry.js';
+import type { McplServerRegistry } from '../src/mcpl/server-registry.js';
+import type { FeatureSetManager } from '../src/mcpl/feature-set-manager.js';
+
+/**
+ * Machine-close provenance + explicit-open protection (issue #5): closes
+ * invoked by housekeeping modules must record their own decision source —
+ * never 'agent-tool' — and must not override a channel the resident or
+ * operator explicitly opened, unless the caller certifies an explicit idle
+ * lease. The Mythos "channel settings keep getting reset" mechanism was
+ * subscription-GC closes wearing the agent's badge.
+ */
+
+function makeRegistry() {
+  const closeCalls: Array<{ channelId?: string }> = [];
+  const mockServer = {
+    sendChannelsOpen: async () => ({}),
+    sendChannelsClose: async (params: { channelId?: string }) => {
+      closeCalls.push(params);
+      return {};
+    },
+    sendChannelsPublish: async () => ({ delivered: true }),
+  };
+  const serverRegistry = {
+    getServer: (_id: string) => mockServer,
+  } as unknown as McplServerRegistry;
+
+  const registry = new ChannelRegistry(
+    serverRegistry,
+    {} as FeatureSetManager,
+    () => {},
+    () => {},
+  );
+
+  const internals = registry as unknown as {
+    desiredStates: Map<string, { state: 'open' | 'closed'; source: string }>;
+    lifecycleKey(serverId: string, channelId: string): string;
+    setDesiredState(serverId: string, channelId: string, desired: 'open' | 'closed', source: string): void;
+  };
+  const desired = (channelId: string) =>
+    internals.desiredStates.get(internals.lifecycleKey('discord', channelId));
+
+  // Register the channel the way a live server would surface it.
+  registry.handleIncoming('discord', {
+    messages: [{
+      channelId: 'c1',
+      messageId: 'm1',
+      author: { id: 'u1', name: 'Antra' },
+      timestamp: '2026-07-28T00:00:00.000Z',
+      content: [{ type: 'text' as const, text: 'hello' }],
+      metadata: { channelName: '#commons' },
+    }],
+  });
+
+  return { registry, internals, desired, closeCalls };
+}
+
+test('a machine close of an explicitly-opened channel is refused, structurally', async () => {
+  const { registry, desired, closeCalls } = makeRegistry();
+  await registry.handleChannelToolCall('channel_open', { channelId: 'c1' });
+  assert.deepEqual(desired('c1'), { state: 'open', source: 'agent-tool' });
+
+  const result = await registry.handleChannelToolCall('channel_close', {
+    channelId: 'c1',
+    source: 'subscription-gc',
+  });
+  assert.equal(result.success, false);
+  assert.equal((result.data as { refusal?: string })?.refusal, 'explicit-open');
+  // Stated intent survives: desired state untouched, nothing sent to the server.
+  assert.deepEqual(desired('c1'), { state: 'open', source: 'agent-tool' });
+  assert.equal(closeCalls.length, 0);
+});
+
+test('an explicit idle lease lets the machine close through, with honest provenance', async () => {
+  const { registry, desired, closeCalls } = makeRegistry();
+  await registry.handleChannelToolCall('channel_open', { channelId: 'c1' });
+
+  const result = await registry.handleChannelToolCall('channel_close', {
+    channelId: 'c1',
+    source: 'subscription-gc',
+    overrideExplicitOpen: true,
+  });
+  assert.equal(result.success, true);
+  // The durable record names the janitor, not the agent.
+  assert.deepEqual(desired('c1'), { state: 'closed', source: 'subscription-gc' });
+  assert.equal(closeCalls.length, 1);
+});
+
+test('agent closes are recorded as agent-tool, exactly as before', async () => {
+  const { registry, desired } = makeRegistry();
+  await registry.handleChannelToolCall('channel_open', { channelId: 'c1' });
+  const result = await registry.handleChannelToolCall('channel_close', { channelId: 'c1' });
+  assert.equal(result.success, true);
+  assert.deepEqual(desired('c1'), { state: 'closed', source: 'agent-tool' });
+});
+
+test('machine closes of policy-opened channels proceed without a lease', async () => {
+  const { registry, internals, desired, closeCalls } = makeRegistry();
+  // A channel nobody explicitly chose — opened by delivery/policy.
+  internals.setDesiredState('discord', 'c1', 'open', 'opened-by-delivery');
+
+  const result = await registry.handleChannelToolCall('channel_close', {
+    channelId: 'c1',
+    source: 'subscription-gc',
+  });
+  assert.equal(result.success, true);
+  assert.deepEqual(desired('c1'), { state: 'closed', source: 'subscription-gc' });
+  assert.equal(closeCalls.length, 1);
+});

--- a/test/machine-close-provenance.test.ts
+++ b/test/machine-close-provenance.test.ts
@@ -57,15 +57,18 @@ function makeRegistry() {
   return { registry, internals, desired, closeCalls };
 }
 
+const MODULE_ORIGIN = { kind: 'module' as const };
+
 test('a machine close of an explicitly-opened channel is refused, structurally', async () => {
   const { registry, desired, closeCalls } = makeRegistry();
   await registry.handleChannelToolCall('channel_open', { channelId: 'c1' });
   assert.deepEqual(desired('c1'), { state: 'open', source: 'agent-tool' });
 
-  const result = await registry.handleChannelToolCall('channel_close', {
-    channelId: 'c1',
-    source: 'subscription-gc',
-  });
+  const result = await registry.handleChannelToolCall(
+    'channel_close',
+    { channelId: 'c1', source: 'subscription-gc' },
+    MODULE_ORIGIN,
+  );
   assert.equal(result.success, false);
   assert.equal((result.data as { refusal?: string })?.refusal, 'explicit-open');
   // Stated intent survives: desired state untouched, nothing sent to the server.
@@ -77,11 +80,11 @@ test('an explicit idle lease lets the machine close through, with honest provena
   const { registry, desired, closeCalls } = makeRegistry();
   await registry.handleChannelToolCall('channel_open', { channelId: 'c1' });
 
-  const result = await registry.handleChannelToolCall('channel_close', {
-    channelId: 'c1',
-    source: 'subscription-gc',
-    overrideExplicitOpen: true,
-  });
+  const result = await registry.handleChannelToolCall(
+    'channel_close',
+    { channelId: 'c1', source: 'subscription-gc', overrideExplicitOpen: true },
+    MODULE_ORIGIN,
+  );
   assert.equal(result.success, true);
   // The durable record names the janitor, not the agent.
   assert.deepEqual(desired('c1'), { state: 'closed', source: 'subscription-gc' });
@@ -91,7 +94,11 @@ test('an explicit idle lease lets the machine close through, with honest provena
 test('agent closes are recorded as agent-tool, exactly as before', async () => {
   const { registry, desired } = makeRegistry();
   await registry.handleChannelToolCall('channel_open', { channelId: 'c1' });
-  const result = await registry.handleChannelToolCall('channel_close', { channelId: 'c1' });
+  const result = await registry.handleChannelToolCall(
+    'channel_close',
+    { channelId: 'c1' },
+    { kind: 'agent', agentName: 'mythos' },
+  );
   assert.equal(result.success, true);
   assert.deepEqual(desired('c1'), { state: 'closed', source: 'agent-tool' });
 });
@@ -101,11 +108,56 @@ test('machine closes of policy-opened channels proceed without a lease', async (
   // A channel nobody explicitly chose — opened by delivery/policy.
   internals.setDesiredState('discord', 'c1', 'open', 'opened-by-delivery');
 
-  const result = await registry.handleChannelToolCall('channel_close', {
-    channelId: 'c1',
-    source: 'subscription-gc',
-  });
+  const result = await registry.handleChannelToolCall(
+    'channel_close',
+    { channelId: 'c1', source: 'subscription-gc' },
+    MODULE_ORIGIN,
+  );
   assert.equal(result.success, true);
   assert.deepEqual(desired('c1'), { state: 'closed', source: 'subscription-gc' });
   assert.equal(closeCalls.length, 1);
+});
+
+test('forged machine fields on a MODEL-origin call are ignored: agent-tool is recorded', async () => {
+  const { registry, desired, closeCalls } = makeRegistry();
+  await registry.handleChannelToolCall('channel_open', { channelId: 'c1' });
+
+  // The schema omits these fields but does not reject extras — a model can
+  // emit them. Trusted dispatch context must win over self-description.
+  const result = await registry.handleChannelToolCall(
+    'channel_close',
+    { channelId: 'c1', source: 'subscription-gc', overrideExplicitOpen: true },
+    { kind: 'agent', agentName: 'mythos' },
+  );
+  assert.equal(result.success, true);
+  // The close succeeds (the resident may close their own channel) but the
+  // record attributes it to them, not to housekeeping.
+  assert.deepEqual(desired('c1'), { state: 'closed', source: 'agent-tool' });
+  assert.equal(closeCalls.length, 1);
+});
+
+test('origin-less calls default to agent semantics (safe for legacy callers)', async () => {
+  const { registry, desired } = makeRegistry();
+  await registry.handleChannelToolCall('channel_open', { channelId: 'c1' });
+  const result = await registry.handleChannelToolCall('channel_close', {
+    channelId: 'c1',
+    source: 'subscription-gc',
+    overrideExplicitOpen: true,
+  });
+  assert.equal(result.success, true);
+  assert.deepEqual(desired('c1'), { state: 'closed', source: 'agent-tool' });
+});
+
+test('module-origin closes outside the closed source vocabulary are rejected loudly', async () => {
+  const { registry, desired } = makeRegistry();
+  await registry.handleChannelToolCall('channel_open', { channelId: 'c1' });
+  const result = await registry.handleChannelToolCall(
+    'channel_close',
+    { channelId: 'c1', source: 'gremlin-module' },
+    MODULE_ORIGIN,
+  );
+  assert.equal(result.success, false);
+  assert.equal(result.isError, true);
+  assert.match(result.error ?? '', /Unknown machine close source/);
+  assert.deepEqual(desired('c1'), { state: 'open', source: 'agent-tool' });
 });

--- a/test/module-context-integration.test.ts
+++ b/test/module-context-integration.test.ts
@@ -8,7 +8,11 @@
  *  - ctx.callTool routes synthesized channel_* tools to the ChannelRegistry
  *    with trusted module origin (the route was missing entirely — module
  *    closes failed as "Invalid tool name format" since subscription-GC moved
- *    onto the generic channel_close).
+ *    onto the generic channel_close);
+ *  - the PUBLIC executeToolCall (the promise-based entry shared with
+ *    ephemeral/model callers) stamps agent origin no matter what machine
+ *    fields the input claims — module provenance is conferred by which
+ *    internal path was used, never by which public method.
  */
 
 import { test } from 'node:test';
@@ -118,6 +122,71 @@ test('ctx.callTool routes channel_* to the ChannelRegistry with module origin', 
     assert.equal(routed[0].name, 'channel_close');
     // Trusted dispatch context, not caller-asserted input.
     assert.deepEqual(routed[0].origin, { kind: 'module' });
+  } finally {
+    await cleanup();
+  }
+});
+
+test('public executeToolCall stamps agent origin even when input forges machine fields', async () => {
+  const mod = new CtxCaptureModule();
+  const { framework, cleanup } = await makeFramework(mod);
+  try {
+    const routed: Array<{ name: string; input: unknown; origin: unknown }> = [];
+    (framework as unknown as { channelRegistry: unknown }).channelRegistry = {
+      handleChannelToolCall: async (name: string, input: unknown, origin: unknown) => {
+        routed.push({ name, input, origin });
+        return { success: true, data: { channelId: 'c1', status: 'closed' } };
+      },
+      stopAll: () => {},
+    };
+
+    // The exact spoof from review: an ephemeral/model caller entering
+    // through the shared public method, claiming GC provenance in input.
+    const result = await framework.executeToolCall({
+      id: 'ephemeral-spoof-1',
+      name: 'channel_close',
+      callerAgentName: 'ephemeral-worker',
+      input: {
+        channelId: 'c1',
+        serverId: 'discord',
+        source: 'subscription-gc',
+        overrideExplicitOpen: true,
+      },
+    });
+
+    assert.equal(result.success, true);
+    assert.equal(routed.length, 1);
+    // Agent origin from dispatch context; the forged fields ride along in
+    // input where handleToolClose ignores them for non-module origin and
+    // records 'agent-tool'.
+    assert.deepEqual(routed[0].origin, { kind: 'agent', agentName: 'ephemeral-worker' });
+  } finally {
+    await cleanup();
+  }
+});
+
+test('public executeToolCall without callerAgentName fails safe to agent semantics', async () => {
+  const mod = new CtxCaptureModule();
+  const { framework, cleanup } = await makeFramework(mod);
+  try {
+    const routed: Array<{ origin: unknown }> = [];
+    (framework as unknown as { channelRegistry: unknown }).channelRegistry = {
+      handleChannelToolCall: async (_name: string, _input: unknown, origin: unknown) => {
+        routed.push({ origin });
+        return { success: true, data: { channelId: 'c1', status: 'closed' } };
+      },
+      stopAll: () => {},
+    };
+
+    await framework.executeToolCall({
+      id: 'legacy-caller-1',
+      name: 'channel_close',
+      input: { channelId: 'c1', serverId: 'discord', source: 'housekeeping' },
+    });
+
+    assert.equal(routed.length, 1);
+    // An unidentified legacy caller is still not a module.
+    assert.deepEqual(routed[0].origin, { kind: 'agent', agentName: '__ephemeral__' });
   } finally {
     await cleanup();
   }

--- a/test/module-context-integration.test.ts
+++ b/test/module-context-integration.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Integration tests for the module-facing framework seams added for issue #5,
+ * run through the REAL ModuleContextImpl (not hand-written mocks — a detached
+ * or mis-bound method must fail here the way it would in production):
+ *
+ *  - ModuleContext.notifyOps reaches the framework ops channel (ops:alert
+ *    trace) when invoked as a method on the context object;
+ *  - ctx.callTool routes synthesized channel_* tools to the ChannelRegistry
+ *    with trusted module origin (the route was missing entirely — module
+ *    closes failed as "Invalid tool name format" since subscription-GC moved
+ *    onto the generic channel_close).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { tmpdir } from 'node:os';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import type { NormalizedRequest, NormalizedResponse } from '@animalabs/membrane';
+import type { Module, ModuleContext, ToolDefinition, ToolResult } from '../src/index.js';
+import { AgentFramework } from '../src/index.js';
+
+class CtxCaptureModule implements Module {
+  readonly name = 'ctx-capture';
+  ctx: ModuleContext | null = null;
+  async start(ctx: ModuleContext): Promise<void> {
+    this.ctx = ctx;
+  }
+  async stop(): Promise<void> {
+    this.ctx = null;
+  }
+  getTools(): ToolDefinition[] {
+    return [];
+  }
+  async handleToolCall(): Promise<ToolResult> {
+    return { success: false, error: 'no tools', isError: true };
+  }
+  async onProcess(): Promise<Record<string, never>> {
+    return {};
+  }
+}
+
+function minimalMembrane() {
+  return {
+    complete: async (_req: NormalizedRequest): Promise<NormalizedResponse> => {
+      throw new Error('not used');
+    },
+  } as unknown as import('@animalabs/membrane').Membrane;
+}
+
+async function makeFramework(module: Module) {
+  const tempDir = mkdtempSync(join(tmpdir(), 'af-ctx-integration-'));
+  const framework = await AgentFramework.create({
+    storePath: join(tempDir, 'test.chronicle'),
+    membrane: minimalMembrane(),
+    agents: [{ name: 'assistant', model: 'test-model', systemPrompt: 'test' }],
+    modules: [module],
+  });
+  return {
+    framework,
+    cleanup: async () => {
+      await framework.stop();
+      rmSync(tempDir, { recursive: true, force: true });
+    },
+  };
+}
+
+test('ctx.notifyOps reaches the ops channel through the real ModuleContextImpl', async () => {
+  const mod = new CtxCaptureModule();
+  const { framework, cleanup } = await makeFramework(mod);
+  try {
+    const alerts: Array<{ kind?: unknown; agentName?: unknown; message?: unknown }> = [];
+    framework.onTrace((e) => {
+      if (e.type === 'ops:alert') alerts.push(e as typeof alerts[number]);
+    });
+
+    assert.ok(mod.ctx, 'module received its context');
+    // Called as a METHOD on the context — the shape hosts must use. A
+    // detached `const f = ctx.notifyOps; f(...)` would lose `this` and is
+    // exactly the bug class this test exists to catch on the provider side.
+    mod.ctx!.notifyOps?.('test-kind', 'assistant', 'receipt message', { channelId: 'c1' });
+
+    assert.equal(alerts.length, 1);
+    assert.equal(alerts[0].kind, 'test-kind');
+    assert.equal(alerts[0].agentName, 'assistant');
+    assert.equal(alerts[0].message, 'receipt message');
+  } finally {
+    await cleanup();
+  }
+});
+
+test('ctx.callTool routes channel_* to the ChannelRegistry with module origin', async () => {
+  const mod = new CtxCaptureModule();
+  const { framework, cleanup } = await makeFramework(mod);
+  try {
+    // No MCPL servers in this harness, so no live ChannelRegistry — inject a
+    // capture in the private slot (test-only cast, same pattern as the
+    // registry tests' private access) to observe exactly what executeToolCall
+    // forwards.
+    const routed: Array<{ name: string; input: unknown; origin: unknown }> = [];
+    (framework as unknown as { channelRegistry: unknown }).channelRegistry = {
+      handleChannelToolCall: async (name: string, input: unknown, origin: unknown) => {
+        routed.push({ name, input, origin });
+        return { success: true, data: { channelId: 'c1', status: 'closed' } };
+      },
+      // framework.stop() walks the registry lifecycle.
+      stopAll: () => {},
+    };
+
+    const result = await mod.ctx!.callTool({
+      id: 'gc-test-1',
+      name: 'channel_close',
+      input: { channelId: 'c1', serverId: 'discord', source: 'subscription-gc' },
+    });
+
+    assert.equal(result.success, true);
+    assert.equal(routed.length, 1);
+    assert.equal(routed[0].name, 'channel_close');
+    // Trusted dispatch context, not caller-asserted input.
+    assert.deepEqual(routed[0].origin, { kind: 'module' });
+  } finally {
+    await cleanup();
+  }
+});


### PR DESCRIPTION
Framework half of the Discord issue **#5** fix (Mythos "channel settings keep resetting"), per Sol's patch shape points 1, 2, and the plumbing for 3. Companion host PR: connectome-host (GC caller side).

## The mechanism

Housekeeping closes routed through the generic `channel_close` recorded `desired = closed, source = 'agent-tool'` — a "real decision that always sticks" per the registry's own taxonomy. The durable record couldn't distinguish an agent's decision from a janitor's, so everything downstream that respects agent decisions respected the janitor.

## Changes

1. **`channel_close` accepts optional `source` + `overrideExplicitOpen`** — undeclared in the agent-facing schema (unchanged for agents); module callers only. A machine source is recorded as itself (`subscription-gc`), never `agent-tool`. Absent = agent/operator decision, recorded exactly as before.
2. **Explicit opens are protected**: a machine-sourced close of a channel whose desired state is `{open, agent-tool}` is refused *structurally* — `success: false, data: { refusal: 'explicit-open' }`, `isError: false` — so callers can stand down instead of retrying. `overrideExplicitOpen` is the lease escape hatch: the caller certifies the resident consented (e.g. an agent-set per-channel idle budget). Policy-opened / delivery-opened / unowned channels close exactly as before — the janitor keeps its job where nobody stated intent.
3. **`ModuleContext.notifyOps`** (optional member): modules can raise operator-facing ops alerts through the framework channel (failures.log + `ops:alert` trace + webhook). Declared optional so modules built against this version degrade gracefully on older frameworks (`ctx.notifyOps?.(...)`).

Version-skew safe in both directions: an older host passing no `source` gets identical behavior; a newer host against an older framework gets today's behavior (extra inputs ignored).

## Testing

4 new tests in `test/machine-close-provenance.test.ts`: refusal preserves desired state and sends nothing to the server; lease-certified close records `subscription-gc` provenance; bare agent closes unchanged; policy-opened channels close without a lease. Full suite: green except the 3 pre-existing MountWatcher/fs-watcher failures, which fail identically on clean `origin/main` on this machine (verified by stash + rebuild).

Caveat for review: our `#5` note's original Mythos attribution remains a hypothesis (no access to the data dir) — this fixes the *mechanism*, which Sol re-verified as current on 0.7.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)