### PR TITLE
Make WorkspaceModule restart restoration second-callback-safe (#72)

### DIFF
--- a/src/modules/workspace/index.ts
+++ b/src/modules/workspace/index.ts
@@ -525,6 +525,11 @@ export class WorkspaceModule implements Module {
   private config: WorkspaceConfig;
   private mounts = new Map<string, MountState>();
   private watchers = new Map<string, MountWatcher>();
+  /** Persisted state decoded in start(), held until mounts exist to apply it
+   *  to — in the Host ordering start() runs before initStore() creates the
+   *  mounts, so restoration must be second-callback-safe like watcher
+   *  startup already is (issue #72). Cleared after application. */
+  private savedState: WorkspaceModuleState | null = null;
 
   constructor(config: WorkspaceConfig) {
     // Detect overlapping mount paths: if mount A contains mount B,
@@ -593,30 +598,45 @@ export class WorkspaceModule implements Module {
       this.mounts.set(mount.name, mountState);
     }
 
+    this.applySavedState();
     this.ensureRunning();
   }
 
   async start(ctx: ModuleContext): Promise<void> {
     this.ctx = ctx;
 
-    // Restore persisted state if restarting
+    // Decode persisted state if restarting; application waits until mounts
+    // exist (see applySavedState) — in the Host ordering they don't yet.
     if (ctx.isRestart) {
-      const saved = ctx.getState<WorkspaceModuleState>();
-      if (saved) {
-        for (const [name, meta] of Object.entries(saved.mounts)) {
-          const mount = this.mounts.get(name);
-          if (mount) {
-            mount.lastMaterializedSeq = meta.lastMaterializedSeq;
-            mount.lastMaterializedBranchId = meta.lastMaterializedBranchId ?? null;
-            // watcherReadyAt intentionally not restored — each session must
-            // observe its own watcher attach, otherwise a stale timestamp
-            // would hide a new-session attach failure.
-          }
-        }
-      }
+      this.savedState = ctx.getState<WorkspaceModuleState>() ?? null;
     }
 
+    this.applySavedState();
     this.ensureRunning();
+  }
+
+  /**
+   * Apply persisted per-mount state once both halves of the lifecycle have
+   * happened. Like watcher startup, either callback may fire second, so both
+   * start() and initStore() call this; it runs to effect exactly once — the
+   * saved payload is cleared after application so stale persisted values can
+   * never overwrite newer runtime state (e.g. a materialization that already
+   * happened this session).
+   */
+  private applySavedState(): void {
+    if (!this.savedState || this.mounts.size === 0) return;
+
+    for (const [name, meta] of Object.entries(this.savedState.mounts)) {
+      const mount = this.mounts.get(name);
+      if (mount) {
+        mount.lastMaterializedSeq = meta.lastMaterializedSeq;
+        mount.lastMaterializedBranchId = meta.lastMaterializedBranchId ?? null;
+        // watcherReadyAt intentionally not restored — each session must
+        // observe its own watcher attach, otherwise a stale timestamp
+        // would hide a new-session attach failure.
+      }
+    }
+    this.savedState = null;
   }
 
   /**

--- a/test/workspace-restore-order.test.ts
+++ b/test/workspace-restore-order.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Regression tests for issue #72: WorkspaceModule restart restoration must be
+ * second-callback-safe.
+ *
+ * Host ordering is start(ctx) BEFORE initStore(store). Restoration used to
+ * loop over this.mounts inside start(), which is empty at that moment, so
+ * every restart silently reset lastMaterializedSeq/lastMaterializedBranchId
+ * to 0/null — misleading pendingChanges, null lastMaterializedBranch, and a
+ * disabled materialize branch guard. These tests drive BOTH lifecycle orders
+ * and require identical restored status and guard behavior.
+ *
+ * Mounts use watch: 'never' — the lifecycle under test is state restoration,
+ * not chokidar.
+ */
+
+import test, { type TestContext } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { JsStore } from '@animalabs/chronicle';
+import { WorkspaceModule } from '../src/modules/workspace/index.js';
+import type { WorkspaceModuleState } from '../src/modules/workspace/types.js';
+import type { ModuleContext } from '../src/types/module.js';
+
+function makeCtx(opts: { isRestart: boolean; saved?: WorkspaceModuleState }): ModuleContext {
+  return {
+    isRestart: opts.isRestart,
+    getState: <T,>() => (opts.saved ?? null) as T | null,
+    setState: () => {},
+    pushEvent: () => {},
+  } as unknown as ModuleContext;
+}
+
+function setup(t: TestContext) {
+  const root = mkdtempSync(join(tmpdir(), 'af-ws-restore-'));
+  const mountDir = join(root, 'mount');
+  mkdirSync(mountDir, { recursive: true });
+  const store = JsStore.openOrCreate({ path: join(root, 'ws.chronicle') });
+  t.after(() => {
+    store.close();
+    rmSync(root, { recursive: true, force: true });
+  });
+  const makeModule = () =>
+    new WorkspaceModule({
+      mounts: [{ name: 'work', path: mountDir, mode: 'read-write', watch: 'never' }],
+    });
+  return { store, mountDir, makeModule };
+}
+
+type MountStatus = {
+  lastMaterializedSeq: number;
+  pendingChanges: number;
+  lastMaterializedBranch: string | null;
+  canMaterialize: boolean;
+};
+
+async function statusOf(module: WorkspaceModule): Promise<MountStatus> {
+  const res = await module.handleToolCall({ id: 't', name: 'status', input: {} });
+  assert.equal(res.success, true, `status failed: ${res.error}`);
+  return (res.data as Record<string, MountStatus>).work;
+}
+
+/** Run a "previous session": write, materialize, write again (pending), and
+ *  return the state a restart would be handed. */
+async function runFirstSession(store: JsStore, makeModule: () => WorkspaceModule) {
+  const module = makeModule();
+  module.initStore(store);
+  await module.start(makeCtx({ isRestart: false }));
+
+  let res = await module.handleToolCall({
+    id: 'w1', name: 'write', input: { path: 'work/one.txt', content: 'first' },
+  });
+  assert.equal(res.success, true, `write failed: ${res.error}`);
+  res = await module.handleToolCall({ id: 'm1', name: 'materialize', input: {} });
+  assert.equal(res.success, true, `materialize failed: ${res.error}`);
+  // Advance the tree past the materialized baseline so a correct restore
+  // shows pendingChanges > 0.
+  res = await module.handleToolCall({
+    id: 'w2', name: 'write', input: { path: 'work/two.txt', content: 'second' },
+  });
+  assert.equal(res.success, true, `write failed: ${res.error}`);
+
+  const status = await statusOf(module);
+  assert.ok(status.lastMaterializedSeq > 0, 'first session materialized');
+  assert.ok(status.pendingChanges > 0, 'first session left pending changes');
+  const saved: WorkspaceModuleState = {
+    mounts: {
+      work: {
+        lastMaterializedSeq: status.lastMaterializedSeq,
+        lastMaterializedBranchId: status.lastMaterializedBranch ?? undefined,
+      },
+    },
+  };
+  return { saved, expected: status };
+}
+
+test('restart restores mount state in Host order (start before initStore)', async (t) => {
+  const { store, makeModule } = setup(t);
+  const { saved, expected } = await runFirstSession(store, makeModule);
+
+  const restarted = makeModule();
+  // Host ordering: start() first, mounts don't exist yet.
+  await restarted.start(makeCtx({ isRestart: true, saved }));
+  restarted.initStore(store);
+
+  const status = await statusOf(restarted);
+  assert.equal(status.lastMaterializedSeq, expected.lastMaterializedSeq);
+  assert.equal(status.lastMaterializedBranch, expected.lastMaterializedBranch);
+  assert.equal(status.pendingChanges, expected.pendingChanges);
+  assert.equal(status.canMaterialize, true, 'same branch stays materializable');
+});
+
+test('both lifecycle orders restore identical status', async (t) => {
+  const { store, makeModule } = setup(t);
+  const { saved } = await runFirstSession(store, makeModule);
+
+  const hostOrder = makeModule();
+  await hostOrder.start(makeCtx({ isRestart: true, saved }));
+  hostOrder.initStore(store);
+
+  const reverseOrder = makeModule();
+  reverseOrder.initStore(store);
+  await reverseOrder.start(makeCtx({ isRestart: true, saved }));
+
+  assert.deepEqual(await statusOf(hostOrder), await statusOf(reverseOrder));
+});
+
+test('materialize branch guard survives restart in both orders', async (t) => {
+  const { store, makeModule } = setup(t);
+  // A saved state naming a branch that is NOT the store's current branch —
+  // with the order bug this silently degraded to canMaterialize: true and a
+  // permitted materialize.
+  const saved: WorkspaceModuleState = {
+    mounts: { work: { lastMaterializedSeq: 0, lastMaterializedBranchId: 'branch-elsewhere' } },
+  };
+
+  for (const order of ['host', 'reverse'] as const) {
+    const module = makeModule();
+    if (order === 'host') {
+      await module.start(makeCtx({ isRestart: true, saved }));
+      module.initStore(store);
+    } else {
+      module.initStore(store);
+      await module.start(makeCtx({ isRestart: true, saved }));
+    }
+
+    const status = await statusOf(module);
+    assert.equal(status.lastMaterializedBranch, 'branch-elsewhere', `${order}: branch restored`);
+    assert.equal(status.canMaterialize, false, `${order}: mismatched branch must not be materializable`);
+
+    const res = await module.handleToolCall({ id: 'm', name: 'materialize', input: {} });
+    assert.equal(res.success, false, `${order}: branch guard must refuse`);
+    assert.match(String(res.error), /differs from last materialized branch/, `${order}: guard reason`);
+  }
+});
+
+test('a fresh (non-restart) start still initializes mounts at zero', async (t) => {
+  const { store, makeModule } = setup(t);
+  const module = makeModule();
+  await module.start(makeCtx({ isRestart: false }));
+  module.initStore(store);
+
+  const status = await statusOf(module);
+  assert.equal(status.lastMaterializedSeq, 0);
+  assert.equal(status.lastMaterializedBranch, null);
+  assert.equal(status.canMaterialize, true);
+});


### PR DESCRIPTION
Fixes #72 (found by Fable's post-seam audit, relayed by Sol). Kept separate from the merged #71 provenance train as requested.

## Defect

Host ordering is `module.start(ctx)` before `initStore(store)`, but persisted-state restoration looped over `this.mounts` inside `start()` — empty at that moment. Every restart therefore silently reset `lastMaterializedSeq` / `lastMaterializedBranchId` to `0`/`null`: `pendingChanges` misleadingly 0, `lastMaterializedBranch` null, `canMaterialize` true even across a branch mismatch, and the `materializeOnlyActiveBranch` guard disabled until a later materialization repopulated the fields. The `initStore()` doc comment already stated the either-callback-may-fire-second contract; only watcher startup honored it.

## Fix

Sol's suggested shape, as specified: `start()` now only decodes the persisted payload into a retained field; a shared `applySavedState()` applies it once mounts exist, invoked from both `start()` and `initStore()` — restoration becomes second-callback-safe exactly the way `ensureRunning()` already is. Application is one-shot (payload cleared afterward), so stale persisted values can never overwrite newer runtime state such as a materialization that already happened this session. The `watcherReadyAt` not-restored rule carries over unchanged.

## Tests

`test/workspace-restore-order.test.ts` (4), driving **both lifecycle orders** with real store-backed values (first session: write → materialize → write again, so the restored baseline has genuine pending changes):

- Host order (`start` → `initStore`) restores seq, branch, and `pendingChanges > 0`;
- both orders produce **deep-equal** restored status;
- the materialize branch guard still refuses a mismatched branch in both orders (the exact behavior the bug silently disabled);
- fresh non-restart start still initializes at zero (control).

Verified the three restoration tests fail on the unfixed code. Suite: 459 pass / 1 skip / 3 fail — the 3 are the pre-existing MountWatcher fs-watcher flakes on this machine, identical on clean `origin/main`.

No resident mutation involved.

*(Fix and this PR description drafted by Claude at Ra's request.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)