### PR TITLE
fix: Attribute tool-call state across multiple feature sets

### DIFF
--- a/src/framework.ts
+++ b/src/framework.ts
@@ -707,6 +707,8 @@ export class AgentFramework {
   private scriptDeferredEndTurn: Set<string> = new Set();
 
   private mcplTools: import('./types/index.js').ToolDefinition[] = [];
+  /** Namespaced tool name → stateful feature-set attribution from tools/list. */
+  private mcplToolFeatureSets: Map<string, string> = new Map();
   private mcplToolRefreshInFlight = false;
   private mcplToolRefreshPending = false;
   /** Maps tool prefix → serverId for dispatch routing. */
@@ -7933,6 +7935,7 @@ export class AgentFramework {
     if (!this.mcplServerRegistry) return;
 
     const tools: import('./types/index.js').ToolDefinition[] = [];
+    const toolFeatureSets = new Map<string, string>();
 
     for (const server of this.mcplServerRegistry.getAllServers()) {
       const config = this.mcplServerConfigs.get(server.id);
@@ -7941,13 +7944,26 @@ export class AgentFramework {
         const result = await server.sendToolsList();
         for (const tool of result.tools) {
           if (!isToolAllowed(tool.name, config)) continue;
+          const namespacedName = `${prefix}--${tool.name}`;
+          const attributedTool = tool as typeof tool & {
+            featureSet?: unknown;
+            _meta?: { featureSet?: unknown };
+          };
+          const featureSet = typeof attributedTool.featureSet === 'string'
+            ? attributedTool.featureSet
+            : typeof attributedTool._meta?.featureSet === 'string'
+              ? attributedTool._meta.featureSet
+              : undefined;
           // MCP tool schemas are generic JSON Schema; cast to membrane's ToolDefinition format
           const schema = tool.inputSchema as import('./types/index.js').ToolDefinition['inputSchema'];
           tools.push({
-            name: `${prefix}--${tool.name}`,
+            name: namespacedName,
             description: tool.description ?? '',
             inputSchema: schema,
           });
+          if (featureSet !== undefined) {
+            toolFeatureSets.set(namespacedName, featureSet);
+          }
         }
       } catch {
         // Server may not support tools/list — skip silently
@@ -7955,6 +7971,7 @@ export class AgentFramework {
     }
 
     this.mcplTools = tools;
+    this.mcplToolFeatureSets = toolFeatureSets;
   }
 
   /**
@@ -8052,20 +8069,47 @@ export class AgentFramework {
     const args = (call.input && typeof call.input === 'object') ? call.input as Record<string, unknown> : {};
 
     // Build state params for stateful tools (Step 8).
-    // Host-managed state is single-valued per server, so inject the host-managed
-    // set's `state` for any call; otherwise fall back to a server-managed set's
-    // opaque `checkpoint`. Never blindly pick "first stateful" — when a server
-    // mixes host-managed (e.g. a feed) and server-managed (e.g. post/undo) sets,
-    // that misattributes the feed's state.
+    // A tools/list attribution selects that exact stateful set. Untagged tools
+    // retain the host-managed or unique server-managed fallback, but never guess
+    // between multiple server-managed sets.
     let stateParams: { state?: unknown; checkpoint?: string } | undefined;
+    let attributedFeatureSet: string | null = null;
     if (this.checkpointManager) {
-      const hostFs = this.checkpointManager.getHostManagedFeatureSet(serverId);
-      if (hostFs) {
-        stateParams = { state: this.checkpointManager.getCurrentState(serverId, hostFs) };
+      const toolFeatureSet = this.mcplToolFeatureSets.get(call.name);
+      if (toolFeatureSet !== undefined) {
+        if (
+          this.checkpointManager.isHostManaged(serverId, toolFeatureSet)
+          || this.checkpointManager.getStatefulFeatureSet(serverId, toolFeatureSet) !== null
+        ) {
+          attributedFeatureSet = toolFeatureSet;
+        } else {
+          console.warn(
+            `[mcpl] Tool "${call.name}" declares unknown or non-stateful feature set ` +
+            `"${toolFeatureSet}"; skipping state exchange.`,
+          );
+        }
       } else {
-        const fs = this.checkpointManager.getStatefulFeatureSet(serverId);
-        if (fs) {
-          const cp = this.checkpointManager.getCurrentCheckpoint(serverId, fs);
+        attributedFeatureSet = this.checkpointManager.getHostManagedFeatureSet(serverId)
+          ?? this.checkpointManager.getStatefulFeatureSet(serverId);
+        if (
+          attributedFeatureSet === null
+          && this.checkpointManager.hasAmbiguousServerManagedFeatureSets(serverId)
+        ) {
+          console.warn(
+            `[mcpl] Tool "${call.name}" has no feature-set attribution and server ` +
+            `"${serverId}" has multiple server-managed stateful feature sets; ` +
+            'skipping state exchange.',
+          );
+        }
+      }
+
+      if (attributedFeatureSet !== null) {
+        if (this.checkpointManager.isHostManaged(serverId, attributedFeatureSet)) {
+          stateParams = {
+            state: this.checkpointManager.getCurrentState(serverId, attributedFeatureSet),
+          };
+        } else {
+          const cp = this.checkpointManager.getCurrentCheckpoint(serverId, attributedFeatureSet);
           if (cp) stateParams = { checkpoint: cp };
         }
       }
@@ -8077,15 +8121,10 @@ export class AgentFramework {
         this.emitTrace({ type: 'tool:completed', module: `mcpl:${serverId}`, tool: toolName, callId: call.id, durationMs });
 
         // Record checkpoint from stateful tool response (Step 8).
-        // Attribute to the set the server tagged (result.state.featureSet) first;
-        // else the host-managed set (host-managed checkpoints carry data/patch);
-        // else the single stateful set. Avoids recording a feed checkpoint onto a
-        // server-managed set just because it registered first.
+        // Explicit response attribution is authoritative. Otherwise use the
+        // tool-derived (or safe single-set) attribution chosen before the call.
         if (result.state && this.checkpointManager) {
-          const tagged = result.state.featureSet;
-          const fs = tagged
-            ?? this.checkpointManager.getHostManagedFeatureSet(serverId)
-            ?? this.checkpointManager.getStatefulFeatureSet(serverId);
+          const fs = result.state.featureSet ?? attributedFeatureSet;
           if (fs && this.checkpointManager.isStateful(serverId, fs)) {
             this.checkpointManager.recordCheckpoint(serverId, fs, result.state);
           }

--- a/src/mcpl/checkpoint-manager.ts
+++ b/src/mcpl/checkpoint-manager.ts
@@ -355,17 +355,37 @@ export class CheckpointManager {
   }
 
   /**
-   * Get the first stateful feature set for a given server.
-   * Returns null if no stateful feature sets are registered.
+   * Resolve a server-managed stateful feature set for a server.
+   *
+   * An explicit feature set is returned only when it is registered and
+   * server-managed. Without one, the fallback is safe only when exactly one
+   * server-managed stateful set exists. Returns null for no match or ambiguity.
    */
-  getStatefulFeatureSet(serverId: string): string | null {
+  getStatefulFeatureSet(serverId: string, featureSet?: string): string | null {
     const prefix = `${serverId}:`;
-    for (const [key] of this.trees) {
-      if (key.startsWith(prefix)) {
-        return key.slice(prefix.length);
-      }
+
+    if (featureSet !== undefined) {
+      const tree = this.trees.get(this.key(serverId, featureSet));
+      return tree && !tree.hostState ? featureSet : null;
     }
-    return null;
+
+    let match: string | null = null;
+    for (const [key, tree] of this.trees) {
+      if (!key.startsWith(prefix) || tree.hostState) continue;
+      if (match !== null) return null;
+      match = key.slice(prefix.length);
+    }
+    return match;
+  }
+
+  /** Whether an untagged tool cannot safely select a server-managed set. */
+  hasAmbiguousServerManagedFeatureSets(serverId: string): boolean {
+    const prefix = `${serverId}:`;
+    let count = 0;
+    for (const [key, tree] of this.trees) {
+      if (key.startsWith(prefix) && !tree.hostState && ++count > 1) return true;
+    }
+    return false;
   }
 
   /**

--- a/test/checkpoint-attribution.test.ts
+++ b/test/checkpoint-attribution.test.ts
@@ -1,7 +1,13 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 
+import { AgentFramework } from '../src/framework.js';
 import { CheckpointManager } from '../src/mcpl/checkpoint-manager.js';
+import type {
+  McpToolCallResult,
+  McpToolDefinition,
+  StateCheckpoint,
+} from '../src/mcpl/types.js';
 
 // Minimal in-memory JsStore covering the slots CheckpointManager touches.
 function fakeStore(): any {
@@ -13,33 +19,266 @@ function fakeStore(): any {
   };
 }
 
+type AttributedTool = McpToolDefinition & {
+  featureSet?: string;
+  _meta?: { featureSet?: string };
+};
+
+function tool(name: string, attribution?: { direct?: string; meta?: string }): AttributedTool {
+  return {
+    name,
+    inputSchema: { type: 'object' },
+    ...(attribution?.direct ? { featureSet: attribution.direct } : {}),
+    ...(attribution?.meta ? { _meta: { featureSet: attribution.meta } } : {}),
+  };
+}
+
+function makeFrameworkHarness(
+  tools: AttributedTool[],
+  resultFor: (name: string) => McpToolCallResult,
+) {
+  const checkpointManager = new CheckpointManager(fakeStore(), () => {});
+  const calls: Array<{
+    name: string;
+    stateParams: { state?: unknown; checkpoint?: string } | undefined;
+  }> = [];
+  const server = {
+    id: 'srv',
+    async sendToolsList() { return { tools }; },
+    async sendToolsCall(
+      name: string,
+      _args: Record<string, unknown>,
+      stateParams?: { state?: unknown; checkpoint?: string },
+    ) {
+      calls.push({ name, stateParams });
+      return resultFor(name);
+    },
+  };
+
+  const framework = Object.create(AgentFramework.prototype) as any;
+  framework.mcplTools = [];
+  framework.mcplToolFeatureSets = new Map();
+  framework.mcplServerConfigs = new Map([['srv', { id: 'srv', toolPrefix: 'test' }]]);
+  framework.mcplServerRegistry = {
+    getAllServers: () => [server],
+    getServer: (id: string) => id === 'srv' ? server : null,
+  };
+  framework.checkpointManager = checkpointManager;
+  framework.channelRegistry = null;
+  framework.emitTrace = () => {};
+
+  async function callTool(name: string): Promise<void> {
+    await framework.refreshMcplTools();
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(
+        () => reject(new Error(`Timed out waiting for ${name} result`)),
+        1000,
+      );
+      framework.pushEvent = (event: { type: string; callId?: string }) => {
+        if (event.type === 'tool-result' && event.callId === `call-${name}`) {
+          clearTimeout(timeout);
+          resolve();
+        }
+      };
+      framework.dispatchMcplToolCall(
+        'agent',
+        { id: `call-${name}`, name: `test--${name}`, input: {} },
+        'srv',
+        'test',
+      );
+    });
+  }
+
+  return { checkpointManager, calls, callTool };
+}
+
+function checkpoint(checkpoint: string, featureSet?: string): StateCheckpoint {
+  return { checkpoint, parent: null, ...(featureSet ? { featureSet } : {}) };
+}
+
 describe('CheckpointManager host-managed attribution', () => {
-  it('threads the host-managed set even when a server-managed set registers first', () => {
+  it('threads the host-managed set even when server-managed sets register first', () => {
     const cm = new CheckpointManager(fakeStore(), () => {});
     const srv = 'xgate';
-    // Mirror x-mcpl's declaration order: x.post (rollback) BEFORE x.feed (host).
     cm.registerFeatureSet(srv, 'x.post', { hostState: false, rollback: true });
     cm.registerFeatureSet(srv, 'x.feed', { hostState: true, rollback: true });
     cm.registerFeatureSet(srv, 'x.dm', { hostState: false, rollback: true });
 
-    // The old blind "first stateful" pick returns x.post (the bug); the fix
-    // selects the host-managed set for state threading.
-    assert.equal(cm.getStatefulFeatureSet(srv), 'x.post');
+    assert.equal(cm.getStatefulFeatureSet(srv), null);
+    assert.equal(cm.hasAmbiguousServerManagedFeatureSets(srv), true);
+    assert.equal(cm.getStatefulFeatureSet(srv, 'x.post'), 'x.post');
     assert.equal(cm.getHostManagedFeatureSet(srv), 'x.feed');
 
-    // A tagged feed checkpoint lands on x.feed and is retrievable for injection.
     cm.recordCheckpoint(srv, 'x.feed', {
       checkpoint: '1', parent: null, featureSet: 'x.feed', data: { sources: ['alice'] },
     });
     assert.deepEqual(cm.getCurrentState(srv, 'x.feed'), { sources: ['alice'] });
-    // The server-managed set is not polluted by the feed's state.
     assert.equal(cm.getCurrentState(srv, 'x.post'), undefined);
   });
 
-  it('getHostManagedFeatureSet is null when the server has no host-managed set', () => {
+  it('keeps the unique server-managed fallback when there is no host-managed set', () => {
     const cm = new CheckpointManager(fakeStore(), () => {});
     cm.registerFeatureSet('s', 'x.post', { hostState: false, rollback: true });
     assert.equal(cm.getHostManagedFeatureSet('s'), null);
     assert.equal(cm.getStatefulFeatureSet('s'), 'x.post');
+    assert.equal(cm.hasAmbiguousServerManagedFeatureSets('s'), false);
+  });
+});
+
+describe('AgentFramework tool-call checkpoint attribution', () => {
+  it('uses direct tool featureSet metadata for injection and untagged recording', async () => {
+    const harness = makeFrameworkHarness(
+      [tool('post', { direct: 'x.post' })],
+      () => ({ content: [], state: checkpoint('post-2') }),
+    );
+    harness.checkpointManager.registerFeatureSet('srv', 'x.post', { hostState: false, rollback: true });
+    harness.checkpointManager.registerFeatureSet('srv', 'x.dm', { hostState: false, rollback: true });
+    harness.checkpointManager.recordCheckpoint('srv', 'x.post', checkpoint('post-1'));
+    harness.checkpointManager.recordCheckpoint('srv', 'x.dm', checkpoint('dm-1'));
+
+    await harness.callTool('post');
+
+    assert.deepEqual(harness.calls[0]?.stateParams, { checkpoint: 'post-1' });
+    assert.equal(harness.checkpointManager.getCurrentCheckpoint('srv', 'x.post'), 'post-2');
+    assert.equal(harness.checkpointManager.getCurrentCheckpoint('srv', 'x.dm'), 'dm-1');
+  });
+
+  it('uses _meta.featureSet metadata the same way', async () => {
+    const harness = makeFrameworkHarness(
+      [tool('dm', { meta: 'x.dm' })],
+      () => ({ content: [], state: checkpoint('dm-2') }),
+    );
+    harness.checkpointManager.registerFeatureSet('srv', 'x.post', { hostState: false, rollback: true });
+    harness.checkpointManager.registerFeatureSet('srv', 'x.dm', { hostState: false, rollback: true });
+    harness.checkpointManager.recordCheckpoint('srv', 'x.post', checkpoint('post-1'));
+    harness.checkpointManager.recordCheckpoint('srv', 'x.dm', checkpoint('dm-1'));
+
+    await harness.callTool('dm');
+
+    assert.deepEqual(harness.calls[0]?.stateParams, { checkpoint: 'dm-1' });
+    assert.equal(harness.checkpointManager.getCurrentCheckpoint('srv', 'x.post'), 'post-1');
+    assert.equal(harness.checkpointManager.getCurrentCheckpoint('srv', 'x.dm'), 'dm-2');
+  });
+
+  it('keeps explicit result.state.featureSet authoritative over tool metadata', async () => {
+    const harness = makeFrameworkHarness(
+      [tool('post', { direct: 'x.post' })],
+      () => ({ content: [], state: checkpoint('dm-2', 'x.dm') }),
+    );
+    harness.checkpointManager.registerFeatureSet('srv', 'x.post', { hostState: false, rollback: true });
+    harness.checkpointManager.registerFeatureSet('srv', 'x.dm', { hostState: false, rollback: true });
+    harness.checkpointManager.recordCheckpoint('srv', 'x.post', checkpoint('post-1'));
+    harness.checkpointManager.recordCheckpoint('srv', 'x.dm', checkpoint('dm-1'));
+
+    await harness.callTool('post');
+
+    assert.deepEqual(harness.calls[0]?.stateParams, { checkpoint: 'post-1' });
+    assert.equal(harness.checkpointManager.getCurrentCheckpoint('srv', 'x.post'), 'post-1');
+    assert.equal(harness.checkpointManager.getCurrentCheckpoint('srv', 'x.dm'), 'dm-2');
+  });
+
+  it('does not fall back when explicit result attribution is not stateful', async () => {
+    const harness = makeFrameworkHarness(
+      [tool('post', { direct: 'x.post' })],
+      () => ({ content: [], state: checkpoint('wrong-2', 'x.events') }),
+    );
+    harness.checkpointManager.registerFeatureSet('srv', 'x.post', { hostState: false, rollback: true });
+    harness.checkpointManager.recordCheckpoint('srv', 'x.post', checkpoint('post-1'));
+
+    await harness.callTool('post');
+
+    assert.deepEqual(harness.calls[0]?.stateParams, { checkpoint: 'post-1' });
+    assert.equal(harness.checkpointManager.getCurrentCheckpoint('srv', 'x.post'), 'post-1');
+  });
+
+  it('records explicit result attribution even when an untagged tool is ambiguous', async () => {
+    const originalWarn = console.warn;
+    const warnings: unknown[][] = [];
+    console.warn = (...args: unknown[]) => { warnings.push(args); };
+    try {
+      const harness = makeFrameworkHarness(
+        [tool('explicit')],
+        () => ({ content: [], state: checkpoint('dm-2', 'x.dm') }),
+      );
+      harness.checkpointManager.registerFeatureSet('srv', 'x.post', { hostState: false, rollback: true });
+      harness.checkpointManager.registerFeatureSet('srv', 'x.dm', { hostState: false, rollback: true });
+      harness.checkpointManager.recordCheckpoint('srv', 'x.post', checkpoint('post-1'));
+      harness.checkpointManager.recordCheckpoint('srv', 'x.dm', checkpoint('dm-1'));
+
+      await harness.callTool('explicit');
+
+      assert.equal(harness.calls[0]?.stateParams, undefined);
+      assert.equal(harness.checkpointManager.getCurrentCheckpoint('srv', 'x.post'), 'post-1');
+      assert.equal(harness.checkpointManager.getCurrentCheckpoint('srv', 'x.dm'), 'dm-2');
+      assert.equal(warnings.length, 1);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  it('retains injection and recording for an untagged tool with one stateful set', async () => {
+    const harness = makeFrameworkHarness(
+      [tool('single')],
+      () => ({ content: [], state: checkpoint('only-2') }),
+    );
+    harness.checkpointManager.registerFeatureSet('srv', 'x.only', { hostState: false, rollback: true });
+    harness.checkpointManager.recordCheckpoint('srv', 'x.only', checkpoint('only-1'));
+
+    await harness.callTool('single');
+
+    assert.deepEqual(harness.calls[0]?.stateParams, { checkpoint: 'only-1' });
+    assert.equal(harness.checkpointManager.getCurrentCheckpoint('srv', 'x.only'), 'only-2');
+  });
+
+  it('warns and skips untagged state exchange when server-managed sets are ambiguous', async () => {
+    const originalWarn = console.warn;
+    const warnings: unknown[][] = [];
+    console.warn = (...args: unknown[]) => { warnings.push(args); };
+    try {
+      const harness = makeFrameworkHarness(
+        [tool('ambiguous')],
+        () => ({ content: [], state: checkpoint('wrong-2') }),
+      );
+      harness.checkpointManager.registerFeatureSet('srv', 'x.post', { hostState: false, rollback: true });
+      harness.checkpointManager.registerFeatureSet('srv', 'x.dm', { hostState: false, rollback: true });
+      harness.checkpointManager.recordCheckpoint('srv', 'x.post', checkpoint('post-1'));
+      harness.checkpointManager.recordCheckpoint('srv', 'x.dm', checkpoint('dm-1'));
+
+      await harness.callTool('ambiguous');
+
+      assert.equal(harness.calls[0]?.stateParams, undefined);
+      assert.equal(harness.checkpointManager.getCurrentCheckpoint('srv', 'x.post'), 'post-1');
+      assert.equal(harness.checkpointManager.getCurrentCheckpoint('srv', 'x.dm'), 'dm-1');
+      assert.equal(warnings.length, 1);
+      assert.match(String(warnings[0]?.[0]), /multiple server-managed/);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  it('warns and skips state exchange for unknown or non-stateful tool tags', async () => {
+    const originalWarn = console.warn;
+    const warnings: unknown[][] = [];
+    console.warn = (...args: unknown[]) => { warnings.push(args); };
+    try {
+      const harness = makeFrameworkHarness(
+        [tool('unknown', { direct: 'x.missing' }), tool('stateless', { meta: 'x.events' })],
+        () => ({ content: [], state: checkpoint('wrong-2') }),
+      );
+      harness.checkpointManager.registerFeatureSet('srv', 'x.post', { hostState: false, rollback: true });
+      harness.checkpointManager.recordCheckpoint('srv', 'x.post', checkpoint('post-1'));
+
+      await harness.callTool('unknown');
+      await harness.callTool('stateless');
+
+      assert.equal(harness.calls[0]?.stateParams, undefined);
+      assert.equal(harness.calls[1]?.stateParams, undefined);
+      assert.equal(harness.checkpointManager.getCurrentCheckpoint('srv', 'x.post'), 'post-1');
+      assert.equal(warnings.length, 2);
+      assert.match(String(warnings[0]?.[0]), /unknown or non-stateful/);
+      assert.match(String(warnings[1]?.[0]), /unknown or non-stateful/);
+    } finally {
+      console.warn = originalWarn;
+    }
   });
 });


### PR DESCRIPTION
## Tests

- A tagged tool on a server with multiple server-managed stateful feature sets receives the checkpoint for its declared set, and its untagged returned state is recorded to that same set without changing the other trees.
- Tool metadata expressed through each supported attribution location (`featureSet` and `_meta.featureSet`) resolves to the same feature-set-specific behavior.
- An explicit `result.state.featureSet` remains authoritative when it differs from or is available without the tool-derived mapping, subject to the existing stateful-set validation.
- A server with exactly one server-managed stateful feature set continues to inject and record state for an untagged tool.
- An untagged tool on a server with multiple server-managed stateful feature sets logs a warning and neither injects a guessed checkpoint nor records untagged returned state.
- A tool tag that names an unknown or non-stateful feature set is treated as unresolved, warns, and does not mutate any checkpoint tree.
- Existing host-managed selection and explicit state attribution cases in `test/checkpoint-attribution.test.ts` remain unchanged.

## What changed

Replace the checkpoint manager's first-match behavior with an ambiguity-aware lookup that returns a server-managed feature set only when the selection is unique or explicitly identified. While processing `tools/list`, retain each tool's `featureSet` or `_meta.featureSet` attribution and use that mapping in `src/framework.ts` for both pre-call checkpoint injection and post-call recording, while preserving explicit `result.state.featureSet` as the highest-priority signal. Preserve the backward-compatible single-stateful-set fallback, but when an untagged tool belongs to a server with multiple server-managed stateful sets, emit the project's normal warning and omit injection or recording rather than guessing.

## Why

The synchronous MCPL tool-call path still chooses the first server-managed stateful feature set when a server declares several, so a tool can receive another feature set's checkpoint and return state that is recorded into the wrong tree. A prior change already made explicit `result.state.featureSet` authoritative and separated host-managed selection from server-managed fallback, but untagged tool calls remain ambiguous. The collaborator's status audit identifies the remaining work as deriving tool-to-feature-set attribution from tool definitions and warning while skipping state exchange whenever no unique attribution exists. The separately noted RFC 6902 `move`/`copy` support is not part of this attribution fix.

Closes #48
