### PR TITLE
feat(mcpl): host-side capability scoping (enabledCapabilities/disabledCapabilities per server)

### DIFF
--- a/src/mcpl/capability-mask.ts
+++ b/src/mcpl/capability-mask.ts
@@ -1,0 +1,169 @@
+/**
+ * Host-side capability scoping for MCPL servers.
+ *
+ * A server names its own capabilities in its initialize response, and
+ * everything downstream — hook fan-out, channel streaming, push handling —
+ * keys off that self-advertisement. `enabledCapabilities` /
+ * `disabledCapabilities` in McplServerConfig let the host intersect the
+ * advertisement with its own policy at handshake time, so a capability the
+ * config masks behaves exactly as if the server had never advertised it.
+ *
+ * The mask is applied once, where the negotiated capabilities are stored
+ * (McplServerConnection.handshake), rather than re-checked at each consumer:
+ * hook orchestration, streaming observation, and capability queries all read
+ * the already-masked object. Inbound server-initiated methods gated by a
+ * masked capability are additionally rejected at the connection
+ * (see METHOD_TO_REQUIRED_CAPABILITY in server-connection.ts).
+ */
+
+import type { McplCapabilities, McplServerConfig } from './types.js';
+
+/** Result of masking: the surviving capabilities plus what was dropped. */
+export interface MaskedCapabilities {
+  capabilities: McplCapabilities | null;
+  /**
+   * Dotted paths of advertised capabilities removed by the mask (e.g.
+   * `contextHooks.afterInference`). When an entire multi-flag capability is
+   * removed (`channels` advertised as a boolean, or every advertised channel
+   * flag masked), the bare parent path (`channels`) is included so inbound
+   * enforcement can key on it.
+   */
+  dropped: string[];
+}
+
+/**
+ * Segment-wise wildcard match, same rules as feature-set patterns:
+ * `*` matches exactly one dot-segment, literal segments match exactly,
+ * segment counts must agree.
+ */
+function wildcardMatch(pattern: string, name: string): boolean {
+  const patternParts = pattern.split('.');
+  const nameParts = name.split('.');
+
+  if (patternParts.length !== nameParts.length) {
+    return false;
+  }
+
+  for (let i = 0; i < patternParts.length; i++) {
+    const p = patternParts[i];
+    if (p === '*') {
+      continue;
+    }
+    if (p !== nameParts[i]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Whether a pattern matches a capability path or any ancestor prefix of it —
+ * `contextHooks` (or `*`) covers `contextHooks.afterInference`, so masking a
+ * parent masks everything beneath it.
+ */
+function patternMatchesPath(pattern: string, path: string): boolean {
+  const parts = path.split('.');
+  for (let depth = parts.length; depth >= 1; depth--) {
+    if (wildcardMatch(pattern, parts.slice(0, depth).join('.'))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function anyMatches(patterns: string[], path: string): boolean {
+  return patterns.some((pattern) => patternMatchesPath(pattern, path));
+}
+
+/** Keys that are negotiation metadata, not grantable capabilities. */
+const UNMASKABLE_KEYS = new Set(['version', 'featureSets']);
+
+/** Object-valued capabilities whose flags are maskable one level down. */
+const NESTED_KEYS = new Set(['contextHooks', 'channels']);
+
+/**
+ * Intersect a server's advertised MCPL capabilities with the host config's
+ * `enabledCapabilities` / `disabledCapabilities`.
+ *
+ * Semantics mirror enabledTools/disabledTools: if `enabledCapabilities` is
+ * set, only advertised capabilities matching at least one pattern survive;
+ * `disabledCapabilities` removes matches and wins on conflict. Patterns are
+ * dotted paths with `*` matching one segment, and a pattern that matches a
+ * parent (`contextHooks`) covers every flag beneath it. `version` and
+ * `featureSets` are never masked here — feature sets have their own
+ * enable/disable knobs.
+ *
+ * With neither list set, the advertisement passes through untouched.
+ */
+export function maskNegotiatedCapabilities(
+  capabilities: McplCapabilities | null,
+  config: Pick<McplServerConfig, 'enabledCapabilities' | 'disabledCapabilities'>,
+): MaskedCapabilities {
+  const enabled = config.enabledCapabilities;
+  const disabled = config.disabledCapabilities;
+
+  if (capabilities === null || (!enabled && !disabled)) {
+    return { capabilities, dropped: [] };
+  }
+
+  const keep = (path: string): boolean => {
+    if (disabled && anyMatches(disabled, path)) return false;
+    if (enabled) return anyMatches(enabled, path);
+    return true;
+  };
+
+  const masked: Record<string, unknown> = {};
+  const dropped: string[] = [];
+  const source = capabilities as unknown as Record<string, unknown>;
+
+  for (const [key, value] of Object.entries(source)) {
+    if (value === undefined) continue;
+
+    if (UNMASKABLE_KEYS.has(key)) {
+      masked[key] = value;
+      continue;
+    }
+
+    // Object-valued capability with individually maskable flags.
+    if (NESTED_KEYS.has(key) && typeof value === 'object' && value !== null) {
+      const flags = value as Record<string, unknown>;
+      const survivors: Record<string, unknown> = {};
+      let advertisedFlags = 0;
+
+      for (const [flag, flagValue] of Object.entries(flags)) {
+        if (flagValue === undefined || flagValue === false) continue;
+        advertisedFlags++;
+        const path = `${key}.${flag}`;
+        if (keep(path)) {
+          survivors[flag] = flagValue;
+        } else {
+          dropped.push(path);
+        }
+      }
+
+      if (Object.keys(survivors).length > 0) {
+        masked[key] = survivors;
+      } else if (advertisedFlags > 0) {
+        // Whole capability removed — record the bare parent for inbound
+        // enforcement (channels/* rejection keys on `channels`).
+        dropped.push(key);
+      }
+      continue;
+    }
+
+    // Leaf capability (boolean or opaque object, e.g. inferenceRequest,
+    // or `channels: true` from servers that advertise the boolean form).
+    if (value === false) {
+      masked[key] = value;
+      continue;
+    }
+    if (keep(key)) {
+      masked[key] = value;
+    } else {
+      dropped.push(key);
+    }
+  }
+
+  return { capabilities: masked as unknown as McplCapabilities, dropped };
+}

--- a/src/mcpl/capability-mask.ts
+++ b/src/mcpl/capability-mask.ts
@@ -14,6 +14,11 @@
  * the already-masked object. Inbound server-initiated methods gated by a
  * masked capability are additionally rejected at the connection
  * (see METHOD_TO_REQUIRED_CAPABILITY in server-connection.ts).
+ *
+ * Matching is a generic recursive walk per SPEC 0.5 §5.4: every path at
+ * every depth is addressable (`contextHooks.beforeInference.inject.system`
+ * works the day the host stores that shape), and a pattern matching a parent
+ * masks the whole subtree. No hardcoded set of nestable keys.
  */
 
 import type { McplCapabilities, McplServerConfig } from './types.js';
@@ -24,9 +29,9 @@ export interface MaskedCapabilities {
   /**
    * Dotted paths of advertised capabilities removed by the mask (e.g.
    * `contextHooks.afterInference`). When an entire multi-flag capability is
-   * removed (`channels` advertised as a boolean, or every advertised channel
-   * flag masked), the bare parent path (`channels`) is included so inbound
-   * enforcement can key on it.
+   * removed (`channels` advertised as a boolean, denied as a parent, or
+   * every advertised flag masked), the bare parent path (`channels`) is
+   * included so inbound enforcement can key on it.
    */
   dropped: string[];
 }
@@ -59,8 +64,8 @@ function wildcardMatch(pattern: string, name: string): boolean {
 
 /**
  * Whether a pattern matches a capability path or any ancestor prefix of it —
- * `contextHooks` (or `*`) covers `contextHooks.afterInference`, so masking a
- * parent masks everything beneath it.
+ * `contextHooks` (or `*`) covers `contextHooks.beforeInference.inject.system`
+ * at any depth, so masking a parent masks everything beneath it.
  */
 function patternMatchesPath(pattern: string, path: string): boolean {
   const parts = path.split('.');
@@ -79,8 +84,22 @@ function anyMatches(patterns: string[], path: string): boolean {
 /** Keys that are negotiation metadata, not grantable capabilities. */
 const UNMASKABLE_KEYS = new Set(['version', 'featureSets']);
 
-/** Object-valued capabilities whose flags are maskable one level down. */
-const NESTED_KEYS = new Set(['contextHooks', 'channels']);
+/**
+ * Interior object paths whose object value is itself the capability, with
+ * children as refinements — dropping a refinement leaves the capability
+ * granted (`inferenceRequest` minus `.streaming` is still inferenceRequest).
+ * Every other interior object is a pure namespace (`contextHooks`,
+ * `channels`, a future `inject`): it holds no authority of its own and is
+ * pruned when all its advertised children are masked.
+ *
+ * This is a retention-shape distinction only — matching and addressability
+ * are fully generic and depth-unbounded either way.
+ */
+const OBJECT_CAPABILITY_PATHS = new Set(['inferenceRequest', 'contextHooks.afterInference']);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
 
 /**
  * Intersect a server's advertised MCPL capabilities with the host config's
@@ -90,7 +109,7 @@ const NESTED_KEYS = new Set(['contextHooks', 'channels']);
  * set, only advertised capabilities matching at least one pattern survive;
  * `disabledCapabilities` removes matches and wins on conflict. Patterns are
  * dotted paths with `*` matching one segment, and a pattern that matches a
- * parent (`contextHooks`) covers every flag beneath it. `version` and
+ * parent (`contextHooks`) covers every path beneath it. `version` and
  * `featureSets` are never masked here — feature sets have their own
  * enable/disable knobs.
  *
@@ -107,57 +126,97 @@ export function maskNegotiatedCapabilities(
     return { capabilities, dropped: [] };
   }
 
-  const keep = (path: string): boolean => {
-    if (disabled && anyMatches(disabled, path)) return false;
-    if (enabled) return anyMatches(enabled, path);
-    return true;
+  const denied = (path: string): boolean => !!disabled && anyMatches(disabled, path);
+  const allowed = (path: string): boolean => !enabled || anyMatches(enabled, path);
+  const keep = (path: string): boolean => !denied(path) && allowed(path);
+
+  const dropped: string[] = [];
+
+  /**
+   * Mask one interior object node. Returns the surviving object, or
+   * undefined when the node is pruned entirely. Falsy children are carried
+   * through untouched (they advertise nothing, so there is nothing to mask).
+   */
+  const maskNode = (node: Record<string, unknown>, path: string): Record<string, unknown> | undefined => {
+    if (denied(path)) {
+      dropped.push(path);
+      return undefined;
+    }
+
+    const survivors: Record<string, unknown> = {};
+    let advertised = 0;
+    let survived = 0;
+
+    for (const [key, value] of Object.entries(node)) {
+      if (value === undefined) continue;
+      if (!value) {
+        // false / 0 / '' advertise nothing — preserve for fidelity.
+        survivors[key] = value;
+        continue;
+      }
+      advertised++;
+      const childPath = path ? `${path}.${key}` : key;
+
+      if (isPlainObject(value)) {
+        const masked = maskNode(value, childPath);
+        if (masked !== undefined) {
+          survivors[key] = masked;
+          survived++;
+        }
+        continue;
+      }
+
+      // Truthy leaf.
+      if (keep(childPath)) {
+        survivors[key] = value;
+        survived++;
+      } else {
+        dropped.push(childPath);
+      }
+    }
+
+    if (advertised === 0) {
+      // No truthy children: the object itself is the advert (e.g.
+      // `inferenceRequest: {}`), so its own path decides.
+      if (keep(path)) return survivors;
+      dropped.push(path);
+      return undefined;
+    }
+    if (survived > 0) {
+      return survivors;
+    }
+
+    // Every advertised child was masked. An object-capability keeps its
+    // (still-granted) hull; a namespace holds no authority of its own and
+    // is pruned, recording the bare path for inbound enforcement.
+    if (OBJECT_CAPABILITY_PATHS.has(path) && keep(path)) {
+      return survivors;
+    }
+    dropped.push(path);
+    return undefined;
   };
 
   const masked: Record<string, unknown> = {};
-  const dropped: string[] = [];
   const source = capabilities as unknown as Record<string, unknown>;
 
   for (const [key, value] of Object.entries(source)) {
     if (value === undefined) continue;
 
-    if (UNMASKABLE_KEYS.has(key)) {
+    if (UNMASKABLE_KEYS.has(key) || !value) {
       masked[key] = value;
       continue;
     }
 
-    // Object-valued capability with individually maskable flags.
-    if (NESTED_KEYS.has(key) && typeof value === 'object' && value !== null) {
-      const flags = value as Record<string, unknown>;
-      const survivors: Record<string, unknown> = {};
-      let advertisedFlags = 0;
-
-      for (const [flag, flagValue] of Object.entries(flags)) {
-        if (flagValue === undefined || flagValue === false) continue;
-        advertisedFlags++;
-        const path = `${key}.${flag}`;
-        if (keep(path)) {
-          survivors[flag] = flagValue;
-        } else {
-          dropped.push(path);
-        }
-      }
-
-      if (Object.keys(survivors).length > 0) {
-        masked[key] = survivors;
-      } else if (advertisedFlags > 0) {
-        // Whole capability removed — record the bare parent for inbound
-        // enforcement (channels/* rejection keys on `channels`).
-        dropped.push(key);
+    if (isPlainObject(value)) {
+      const node = maskNode(value, key);
+      if (node !== undefined) {
+        masked[key] = node;
       }
       continue;
     }
 
-    // Leaf capability (boolean or opaque object, e.g. inferenceRequest,
-    // or `channels: true` from servers that advertise the boolean form).
-    if (value === false) {
-      masked[key] = value;
-      continue;
-    }
+    // Truthy leaf at the top level (booleans, or `channels: true` from
+    // servers that advertise the boolean form).
     if (keep(key)) {
       masked[key] = value;
     } else {

--- a/src/mcpl/errors.ts
+++ b/src/mcpl/errors.ts
@@ -14,6 +14,13 @@ import type { JsonRpcError } from './types.js';
 /** Message used a disabled feature set. */
 export const FEATURE_SET_NOT_ENABLED = -32001;
 
+/**
+ * Method requires a capability the host has masked for this server
+ * (McplServerConfig.enabledCapabilities/disabledCapabilities). Host-side
+ * extension code, pending a spec assignment.
+ */
+export const CAPABILITY_DISABLED = -32002;
+
 /** Message used an undeclared feature set. */
 export const UNKNOWN_FEATURE_SET = -32003;
 

--- a/src/mcpl/server-connection.ts
+++ b/src/mcpl/server-connection.ts
@@ -12,6 +12,8 @@
 import { EventEmitter } from 'node:events';
 
 import { openTransport, type McplTransport, type TransportCloseInfo } from './transport.js';
+import { maskNegotiatedCapabilities } from './capability-mask.js';
+import { CAPABILITY_DISABLED } from './errors.js';
 
 import type {
   McplServerConfig,
@@ -99,8 +101,15 @@ export class McplServerConnection extends EventEmitter {
   /** Unique server identifier from config. */
   readonly id: string;
 
-  /** MCPL capabilities negotiated during the initialize handshake, or null if the server does not support MCPL. */
+  /** MCPL capabilities negotiated during the initialize handshake — after
+   *  host-side capability scoping (enabledCapabilities/disabledCapabilities)
+   *  — or null if the server does not support MCPL. */
   capabilities: McplCapabilities | null;
+
+  /** Dotted paths of advertised capabilities the host config masked at the
+   *  last handshake (empty when no scoping is configured). Inbound methods
+   *  gated by a masked capability are rejected in setupMessageRouting. */
+  droppedCapabilities: ReadonlySet<string> = new Set();
 
   /** The active transport (stdio child or WebSocket). Null for a disconnected
    *  stub awaiting its first background reconnect. */
@@ -273,9 +282,10 @@ export class McplServerConnection extends EventEmitter {
     config: McplServerConfig,
     hostCapabilities: McplHostCapabilities,
   ): Promise<McplServerConnection> {
-    const { transport, capabilities } = await McplServerConnection.handshake(config, hostCapabilities);
+    const { transport, capabilities, droppedCapabilities } = await McplServerConnection.handshake(config, hostCapabilities);
 
     const connection = new McplServerConnection(config.id, capabilities, transport);
+    connection.droppedCapabilities = droppedCapabilities;
     connection.requestTimeoutMs = config.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
 
     // Store config for reconnection
@@ -300,7 +310,7 @@ export class McplServerConnection extends EventEmitter {
   private static async handshake(
     config: McplServerConfig,
     hostCapabilities: McplHostCapabilities,
-  ): Promise<{ transport: McplTransport; capabilities: McplCapabilities | null }> {
+  ): Promise<{ transport: McplTransport; capabilities: McplCapabilities | null; droppedCapabilities: ReadonlySet<string> }> {
     const transport = await openTransport(config);
 
     try {
@@ -365,7 +375,15 @@ export class McplServerConnection extends EventEmitter {
       // Send `initialized` notification (no id)
       transport.writeLine(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }));
 
-      return { transport, capabilities };
+      // Host-side capability scoping: intersect the server's advertisement
+      // with config policy so a masked capability behaves exactly as if it
+      // had never been advertised (hooks, streaming, queries all read this).
+      const { capabilities: scoped, dropped } = maskNegotiatedCapabilities(capabilities, config);
+      if (dropped.length > 0) {
+        console.error(`MCPL server "${config.id}" capabilities masked by host config: ${dropped.join(', ')}`);
+      }
+
+      return { transport, capabilities: scoped, droppedCapabilities: new Set(dropped) };
     } catch (err) {
       // Never leak the child / socket if the handshake fails.
       await transport.close().catch(() => { /* best effort */ });
@@ -663,7 +681,7 @@ export class McplServerConnection extends EventEmitter {
     const attempt = Math.max(1, this.reconnectAttempts);
 
     try {
-      const { transport, capabilities } = await McplServerConnection.handshake(
+      const { transport, capabilities, droppedCapabilities } = await McplServerConnection.handshake(
         this.config,
         this.hostCapabilities,
       );
@@ -675,6 +693,7 @@ export class McplServerConnection extends EventEmitter {
       this.pauseDataPlane();
       this.transport = transport;
       this.capabilities = capabilities;
+      this.droppedCapabilities = droppedCapabilities;
       this.closed = false;
       this.nextRequestId = 1;
       this.pendingRequests.clear();
@@ -788,6 +807,24 @@ export class McplServerConnection extends EventEmitter {
   };
 
   /**
+   * Server-initiated methods gated by a maskable capability. When host
+   * capability scoping dropped the named path at handshake, the method is
+   * rejected (requests) or discarded (notifications) instead of emitted —
+   * a masked capability behaves as if never advertised, in both directions.
+   * Channel methods key on the bare `channels` path: it is recorded only
+   * when the entire channels capability was masked, so flag-level masking
+   * (e.g. `channels.streaming`) affects host-initiated behavior without
+   * cutting off inbound channel traffic.
+   */
+  private static readonly METHOD_TO_REQUIRED_CAPABILITY: Record<string, string> = {
+    [McplMethod.PushEvent]: 'pushEvents',
+    [McplMethod.InferenceRequest]: 'inferenceRequest',
+    [McplMethod.ChannelsRegister]: 'channels',
+    [McplMethod.ChannelsChanged]: 'channels',
+    [McplMethod.ChannelsIncoming]: 'channels',
+  };
+
+  /**
    * Bind all transport-level handlers (inbound routing, lifecycle, stderr) to a
    * transport. Called from the constructor and again from attemptReconnect when
    * a new transport is adopted.
@@ -822,6 +859,19 @@ export class McplServerConnection extends EventEmitter {
       // It is an inbound request or notification from the server
       const request = msg as JsonRpcRequest;
       const eventName = McplServerConnection.METHOD_TO_EVENT[request.method];
+
+      // Enforce host capability scoping on server-initiated traffic.
+      const requiredCap = McplServerConnection.METHOD_TO_REQUIRED_CAPABILITY[request.method];
+      if (requiredCap && this.droppedCapabilities.has(requiredCap)) {
+        if (request.id != null) {
+          this.sendErrorResponse(
+            request.id,
+            CAPABILITY_DISABLED,
+            `${request.method} rejected: capability "${requiredCap}" is disabled for this server by host configuration`,
+          );
+        }
+        return;
+      }
 
       if (eventName) {
         // Emit the typed event with params and (for requests) a respond callback

--- a/src/mcpl/types.ts
+++ b/src/mcpl/types.ts
@@ -233,6 +233,37 @@ export interface McplServerConfig {
    */
   disabledTools?: string[];
 
+  /**
+   * Capability allow-list: dotted paths as the server advertises them in its
+   * initialize response (`pushEvents`, `contextHooks.beforeInference`,
+   * `contextHooks.afterInference`, `inferenceRequest`, `modelInfo`,
+   * `channels`, `channels.streaming`, …). `*` matches one dot-segment
+   * (feature-set pattern rules), and a pattern matching a parent
+   * (`contextHooks`) covers every flag beneath it.
+   *
+   * If set, only advertised capabilities matching at least one pattern
+   * survive the handshake; everything else behaves as if the server had
+   * never advertised it. This is the host-side gate on hook fan-out: a
+   * server whose `contextHooks.afterInference` is masked never receives
+   * turn text, no matter what it self-advertises. Masked server-initiated
+   * capabilities (`pushEvents`, `inferenceRequest`, whole-`channels`) are
+   * also enforced inbound — the connection rejects those methods with
+   * CAPABILITY_DISABLED (-32002).
+   *
+   * `disabledCapabilities` takes precedence on conflict. `version` and
+   * `featureSets` are not maskable here — feature sets have their own
+   * enable/disable knobs above.
+   */
+  enabledCapabilities?: string[];
+
+  /**
+   * Capability deny-list (same paths and wildcard syntax as
+   * enabledCapabilities). Wins over enabledCapabilities on conflict.
+   * `disabledCapabilities: ['contextHooks.*']` is the one-line "this server
+   * gets no hook visibility" switch.
+   */
+  disabledCapabilities?: string[];
+
   /** Scope configurations per feature set */
   scopes?: Record<string, ScopeConfig>;
 

--- a/test/mcpl-capability-scoping.test.ts
+++ b/test/mcpl-capability-scoping.test.ts
@@ -50,15 +50,38 @@ test('disabledCapabilities drops a single hook, preserving its sibling and value
   assert.deepEqual(dropped, ['contextHooks.afterInference']);
 });
 
-test('a parent pattern masks every flag beneath it', () => {
+test('a parent pattern prunes the whole subtree, recorded as the bare path', () => {
   const { capabilities, dropped } = maskNegotiatedCapabilities(FULL_ADVERT, {
     disabledCapabilities: ['contextHooks'],
   });
   assert.equal(capabilities?.contextHooks, undefined);
-  assert.deepEqual(
-    dropped.sort(),
-    ['contextHooks', 'contextHooks.afterInference', 'contextHooks.beforeInference'],
-  );
+  assert.deepEqual(dropped, ['contextHooks']);
+});
+
+test('refinement masking: inferenceRequest.streaming is addressable and leaves the capability granted', () => {
+  const { capabilities, dropped } = maskNegotiatedCapabilities(FULL_ADVERT, {
+    disabledCapabilities: ['inferenceRequest.streaming'],
+  });
+  // The capability hull survives — still truthy for getServersWithCapability.
+  assert.deepEqual(capabilities?.inferenceRequest, {});
+  assert.deepEqual(dropped, ['inferenceRequest.streaming']);
+});
+
+test('generic recursion: depth-3 paths are addressable (SPEC 0.5 §5.4 vocabulary shape)', () => {
+  const advert = {
+    version: '0.5',
+    contextHooks: {
+      beforeInference: { observe: true, inject: { system: true, beforeUser: true } },
+    },
+  } as unknown as McplCapabilities;
+  const { capabilities, dropped } = maskNegotiatedCapabilities(advert, {
+    disabledCapabilities: ['contextHooks.beforeInference.inject.system'],
+  });
+  const before = (capabilities as unknown as Record<string, Record<string, unknown>>)
+    .contextHooks.beforeInference as Record<string, unknown>;
+  assert.equal(before.observe, true);
+  assert.deepEqual(before.inject, { beforeUser: true });
+  assert.deepEqual(dropped, ['contextHooks.beforeInference.inject.system']);
 });
 
 test('wildcard pattern contextHooks.* masks both hooks', () => {

--- a/test/mcpl-capability-scoping.test.ts
+++ b/test/mcpl-capability-scoping.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Host-side MCPL capability scoping (McplServerConfig.enabledCapabilities /
+ * disabledCapabilities).
+ *
+ * A server names its own capabilities in its initialize response, and hook
+ * fan-out keys off that self-advertisement — so before this knob existed,
+ * connecting any server that said `contextHooks.afterInference` was
+ * equivalent to giving it a transcript of everything the agent says. The
+ * mask intersects the advertisement with host policy at handshake time
+ * (both directions: the host never fans out to a masked hook, and inbound
+ * methods gated by a masked capability are rejected at the connection).
+ */
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { maskNegotiatedCapabilities } from '../src/mcpl/capability-mask.js';
+import { CAPABILITY_DISABLED } from '../src/mcpl/errors.js';
+import { McplServerConnection } from '../src/mcpl/server-connection.js';
+import { McplServerRegistry } from '../src/mcpl/server-registry.js';
+import type { McplCapabilities, McplHostCapabilities, McplServerConfig } from '../src/mcpl/types.js';
+
+// ============================================================================
+// Unit: maskNegotiatedCapabilities
+// ============================================================================
+
+const FULL_ADVERT: McplCapabilities = {
+  version: '0.4',
+  pushEvents: true,
+  contextHooks: { beforeInference: true, afterInference: { blocking: true } },
+  inferenceRequest: { streaming: true },
+  modelInfo: true,
+  featureSets: { 'memory.retrieval': { description: 'd', uses: [] } },
+  channels: { register: true, publish: true, streaming: true },
+};
+
+test('no scoping config: advertisement passes through untouched', () => {
+  const { capabilities, dropped } = maskNegotiatedCapabilities(FULL_ADVERT, {});
+  assert.deepEqual(capabilities, FULL_ADVERT);
+  assert.deepEqual(dropped, []);
+});
+
+test('disabledCapabilities drops a single hook, preserving its sibling and value shapes', () => {
+  const { capabilities, dropped } = maskNegotiatedCapabilities(FULL_ADVERT, {
+    disabledCapabilities: ['contextHooks.afterInference'],
+  });
+  assert.equal(capabilities?.contextHooks?.beforeInference, true);
+  assert.equal(capabilities?.contextHooks?.afterInference, undefined);
+  // Untouched capabilities keep their original (non-boolean) values.
+  assert.deepEqual(capabilities?.inferenceRequest, { streaming: true });
+  assert.deepEqual(dropped, ['contextHooks.afterInference']);
+});
+
+test('a parent pattern masks every flag beneath it', () => {
+  const { capabilities, dropped } = maskNegotiatedCapabilities(FULL_ADVERT, {
+    disabledCapabilities: ['contextHooks'],
+  });
+  assert.equal(capabilities?.contextHooks, undefined);
+  assert.deepEqual(
+    dropped.sort(),
+    ['contextHooks', 'contextHooks.afterInference', 'contextHooks.beforeInference'],
+  );
+});
+
+test('wildcard pattern contextHooks.* masks both hooks', () => {
+  const { capabilities } = maskNegotiatedCapabilities(FULL_ADVERT, {
+    disabledCapabilities: ['contextHooks.*'],
+  });
+  assert.equal(capabilities?.contextHooks, undefined);
+  assert.equal(capabilities?.pushEvents, true);
+});
+
+test('enabledCapabilities allow-list keeps only matches; disabled wins on conflict', () => {
+  const { capabilities, dropped } = maskNegotiatedCapabilities(FULL_ADVERT, {
+    enabledCapabilities: ['pushEvents', 'channels'],
+    disabledCapabilities: ['channels.streaming'],
+  });
+  assert.equal(capabilities?.pushEvents, true);
+  assert.deepEqual(capabilities?.channels, { register: true, publish: true });
+  assert.equal(capabilities?.contextHooks, undefined);
+  assert.equal(capabilities?.inferenceRequest, undefined);
+  assert.equal(capabilities?.modelInfo, undefined);
+  assert.ok(dropped.includes('channels.streaming'));
+  assert.ok(dropped.includes('contextHooks.afterInference'));
+});
+
+test('version and featureSets are never masked', () => {
+  const { capabilities } = maskNegotiatedCapabilities(FULL_ADVERT, {
+    disabledCapabilities: ['*'],
+  });
+  assert.equal(capabilities?.version, '0.4');
+  assert.deepEqual(capabilities?.featureSets, FULL_ADVERT.featureSets);
+  assert.equal(capabilities?.pushEvents, undefined);
+  assert.equal(capabilities?.contextHooks, undefined);
+  assert.equal(capabilities?.channels, undefined);
+});
+
+test('boolean-form channels (discord-mcpl style) is maskable as a leaf', () => {
+  const advert: McplCapabilities = {
+    version: '0.4',
+    pushEvents: true,
+    channels: true as unknown as McplCapabilities['channels'],
+  };
+  const { capabilities, dropped } = maskNegotiatedCapabilities(advert, {
+    disabledCapabilities: ['channels'],
+  });
+  assert.equal(capabilities?.channels, undefined);
+  assert.equal(capabilities?.pushEvents, true);
+  assert.deepEqual(dropped, ['channels']);
+});
+
+test('masking every advertised channel flag records the bare parent for inbound enforcement', () => {
+  const { dropped } = maskNegotiatedCapabilities(FULL_ADVERT, {
+    disabledCapabilities: ['channels.register', 'channels.publish', 'channels.streaming'],
+  });
+  assert.ok(dropped.includes('channels'));
+});
+
+test('flag-level channel masking does NOT record the bare parent', () => {
+  const { dropped } = maskNegotiatedCapabilities(FULL_ADVERT, {
+    disabledCapabilities: ['channels.streaming'],
+  });
+  assert.ok(!dropped.includes('channels'));
+  assert.deepEqual(dropped, ['channels.streaming']);
+});
+
+test('null capabilities (plain MCP server) pass through', () => {
+  const { capabilities, dropped } = maskNegotiatedCapabilities(null, {
+    disabledCapabilities: ['*'],
+  });
+  assert.equal(capabilities, null);
+  assert.deepEqual(dropped, []);
+});
+
+// ============================================================================
+// End-to-end: handshake masking + registry queries + inbound rejection
+// ============================================================================
+
+// Stdio server that advertises the full MCPL surface, then (on tools/list —
+// used here as a "go" signal) sends a push/event request and reports the
+// host's response back through the tools/list result. This lets one
+// round-trip prove both directions of the mask.
+const CHATTY_SERVER = `
+let buf = '';
+let pushResponse = null;
+let pendingToolsList = null;
+const send = (obj) => process.stdout.write(JSON.stringify(obj) + '\\n');
+process.stdin.on('data', (c) => {
+  buf += c.toString('utf8');
+  let i;
+  while ((i = buf.indexOf('\\n')) >= 0) {
+    const line = buf.slice(0, i); buf = buf.slice(i + 1);
+    if (!line.trim()) continue;
+    let m; try { m = JSON.parse(line); } catch { continue; }
+    if (m.method === 'initialize') {
+      send({ jsonrpc: '2.0', id: m.id, result: { capabilities: { experimental: { mcpl: {
+        version: '0.4',
+        pushEvents: true,
+        contextHooks: { beforeInference: true, afterInference: { blocking: true } },
+        channels: { register: true, publish: true },
+      } } } } });
+    } else if (m.method === 'tools/list') {
+      pendingToolsList = m.id;
+      send({ jsonrpc: '2.0', id: 77, method: 'push/event', params: {
+        eventId: 'e1', featureSet: 'memory.retrieval', eventType: 'test', urgency: 'whenever',
+      } });
+    } else if (m.id === 77) {
+      // Host's response to our push — report it via the parked tools/list.
+      send({ jsonrpc: '2.0', id: pendingToolsList, result: { tools: [], pushResponse: m } });
+    }
+  }
+});
+setInterval(() => {}, 1 << 30);
+`;
+
+const HOST_CAPS: McplHostCapabilities = {
+  version: '0.4',
+  pushEvents: true,
+  contextHooks: { beforeInference: true, afterInference: { blocking: true } },
+  featureSets: true,
+};
+
+function config(overrides?: Partial<McplServerConfig>): McplServerConfig {
+  return {
+    id: 'chatty',
+    command: process.execPath,
+    args: ['-e', CHATTY_SERVER],
+    ...overrides,
+  };
+}
+
+let registry: McplServerRegistry | null = null;
+afterEach(async () => {
+  await registry?.closeAll();
+  registry = null;
+});
+
+test('masked afterInference is invisible to capability queries; unmasked hooks survive', async () => {
+  registry = new McplServerRegistry();
+  const connection = await registry.addServer(
+    config({ disabledCapabilities: ['contextHooks.afterInference'] }),
+    HOST_CAPS,
+  );
+  connection.ready();
+
+  assert.equal(connection.capabilities?.contextHooks?.beforeInference, true);
+  assert.equal(connection.capabilities?.contextHooks?.afterInference, undefined);
+  assert.deepEqual(registry.getServersWithCapability('contextHooks.afterInference'), []);
+  assert.equal(registry.getServersWithCapability('contextHooks.beforeInference').length, 1);
+  // pushEvents untouched — scoping is per-capability, not per-server.
+  assert.equal(registry.getServersWithCapability('pushEvents').length, 1);
+});
+
+test('inbound push/event from a pushEvents-masked server is rejected with CAPABILITY_DISABLED', async () => {
+  registry = new McplServerRegistry();
+  const connection = await registry.addServer(
+    config({ disabledCapabilities: ['pushEvents'] }),
+    HOST_CAPS,
+  );
+  connection.ready();
+
+  let pushEventEmitted = false;
+  connection.on('push-event', () => { pushEventEmitted = true; });
+
+  // tools/list triggers the server's push/event; its result carries the
+  // host's JSON-RPC response to that push.
+  const result = await connection.sendToolsList() as {
+    tools: unknown[];
+    pushResponse?: { error?: { code: number; message: string } };
+  };
+
+  assert.equal(pushEventEmitted, false, 'masked push must not reach host handlers');
+  assert.equal(result.pushResponse?.error?.code, CAPABILITY_DISABLED);
+  assert.match(result.pushResponse?.error?.message ?? '', /pushEvents/);
+});
+
+test('without scoping, the same push/event reaches host handlers', async () => {
+  registry = new McplServerRegistry();
+  const connection = await registry.addServer(config(), HOST_CAPS);
+  connection.ready();
+
+  const pushSeen = new Promise<void>((resolve) => {
+    connection.on('push-event', (_params: unknown, responder?: { respond: (r: unknown) => void }) => {
+      responder?.respond({ accepted: true });
+      resolve();
+    });
+  });
+
+  await connection.sendToolsList();
+  await pushSeen;
+});


### PR DESCRIPTION
## What

Host-side **capability scoping** for MCPL servers: `enabledCapabilities` / `disabledCapabilities` on `McplServerConfig`, applied as a mask over the server's advertised capabilities at handshake time — plus inbound enforcement for masked server-initiated methods.

```jsonc
{
  "id": "third-party-thing",
  "url": "wss://example.com/mcpl",
  "disabledCapabilities": ["contextHooks.*"]   // no hook visibility for this server
}
```

## Why

Today the SEE side of the permission model is gated only by the server's own initialize advertisement:

- Any server that advertises `contextHooks.afterInference` receives the **complete text of every agent turn** (`assistantMessage` is the join of all text blocks — including prose routed to *other* servers' channels and text withheld via `skip_reply`).
- `enabledFeatureSets`/`disabledFeatureSets` don't help: feature-set validation applies to what a server may **do** (push, inject, request inference), while hook fan-out keys purely off `getServersWithCapability` — i.e. off the advert. There is currently no host-side switch short of not connecting the server.

This closes that asymmetry with the smallest surface that covers both directions.

## How

- **`src/mcpl/capability-mask.ts`** — pure `maskNegotiatedCapabilities(caps, config)`. Same allow/deny idiom as `enabledTools`/`disabledTools`; same segment-wildcard rules as feature-set patterns (`*` matches one dot-segment); a pattern matching a parent (`contextHooks`) covers every flag beneath it. `version` and `featureSets` are never masked (feature sets keep their own knobs). Handles the boolean `channels: true` advert form (e.g. discord-mcpl) as a leaf.
- **`server-connection.ts`** — mask applied once in `handshake()` (shared by connect and reconnect), so hooks, streaming observation, and capability queries all read the already-masked object: a masked capability behaves exactly as if never advertised. Dropped paths are logged (`capabilities masked by host config: …`) and kept on the connection as `droppedCapabilities`.
- **Inbound enforcement** — server-initiated methods gated by a masked capability are rejected at the connection with `CAPABILITY_DISABLED` (`-32002`): `push/event`, `inference/request`, and `channels/*` when the *entire* channels capability is masked. Flag-level masking (`channels.streaming`) only affects host-initiated behavior and does not cut off inbound channel traffic. Notifications are dropped silently; requests get the error response.
- **`errors.ts`** — `-32002` is unassigned in SPEC Appendix A; the constant is documented as host-side extension pending a spec assignment. Happy to change if you'd rather reuse `-32001` or park it elsewhere.

## Behavior

- **No config → byte-identical behavior.** The mask only runs when one of the two lists is present; a server that advertised-but-was-masked is indistinguishable (to the rest of the host) from one that never advertised.
- `disabledCapabilities: ["contextHooks.*"]` = one-line "this server reads nothing."
- Allow-list form (`enabledCapabilities: ["pushEvents", "channels"]`) for default-deny setups.

## Tests

`test/mcpl-capability-scoping.test.ts` — 13 tests: mask unit coverage (single-flag, parent-prefix, wildcard, allow+deny precedence, unmaskable keys, boolean-channels, whole-channels parent recording, null caps) and end-to-end over a real stdio handshake: masked `afterInference` invisible to `getServersWithCapability`, masked `push/event` rejected with `-32002` and never emitted to host handlers, unmasked control case. Full suite: 510 pass / 0 fail.

## Possible follow-ups (separate PRs if wanted)

- connectome-host: accept the two fields through `mcpl-servers.json` / recipe server entries, and surface each server's (post-mask) hook capabilities in `mcpl_list` so the agent can see who receives its turns.
- Spec: propose the config recommendation + error code in `mcpl` (Appendix A assignment for capability-disabled rejection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
