### PR TITLE
MCPL 0.5: capability grants, negotiated policy, enforcement (#76)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit",
     "pretest": "mkdir -p dist/test/fixtures && cp test/fixtures/*.mjs dist/test/fixtures/",
-    "test": "node --test dist/test/*.test.js",
+    "test": "node --test --test-force-exit dist/test/*.test.js",
     "prepublishOnly": "npm run build"
   },
   "keywords": [

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -56,6 +56,7 @@ import { Agent } from './agent.js';
 import { ModuleRegistry, isStateExistsError } from './module-registry.js';
 import { McplServerRegistry } from './mcpl/server-registry.js';
 import { FeatureSetManager } from './mcpl/feature-set-manager.js';
+import { computeGrant } from './mcpl/capability-grant.js';
 import { ScopeManager } from './mcpl/scope-manager.js';
 import { HookOrchestrator } from './mcpl/hook-orchestrator.js';
 import { PushHandler, type McplPushEvent } from './mcpl/push-handler.js';
@@ -8354,8 +8355,10 @@ export class AgentFramework {
     // releases control traffic needed for registration and marker service.
     this.wireMcplEvents(connection);
 
-    // Initialize feature sets if server advertises MCPL capabilities
-    this.registerMcplServerFeatures(config, connection);
+    // Initialize feature sets if server advertises MCPL capabilities.
+    // §5.3 initial policy handshake — awaited, so the grant is established
+    // (or knowingly left empty) before startup staging releases any traffic.
+    await this.registerMcplServerFeatures(config, connection);
 
     if (deferAwareness) {
       this.emitTrace({ type: 'module:added', moduleName: `mcpl:${config.id}` });
@@ -8393,11 +8396,17 @@ export class AgentFramework {
    * already has a tree), so checkpoint trees preserved across a transient
    * disconnect are resumed, not reset.
    */
-  private registerMcplServerFeatures(
+  private async registerMcplServerFeatures(
     config: import('./mcpl/types.js').McplServerConfig,
     connection: McplServerConnection,
-  ): void {
+  ): Promise<void> {
     if (!connection.capabilities) return;
+
+    // §5.4: compute the effective grant from the (config-masked)
+    // advertisement. Not yet active — expansion activates only after the
+    // receipt (§6.7); until then the connection's grant is empty and every
+    // privileged inbound method is rejected.
+    const grant = computeGrant(connection.capabilities, config);
 
     const updateParams = this.featureSetManager!.initializeServer(
       config.id,
@@ -8406,11 +8415,56 @@ export class AgentFramework {
         enabledFeatureSets: config.enabledFeatureSets,
         disabledFeatureSets: config.disabledFeatureSets,
       },
+      grant,
     );
 
-    // Inform server which feature sets are enabled/disabled
-    if (updateParams.enabled?.length || updateParams.disabled?.length) {
-      connection.sendFeatureSetsUpdate(updateParams);
+    // §5.3: initial policy MUST be a Request, MUST precede first fan-out,
+    // and MUST be sent even when nothing is enabled or disabled — a server
+    // defaulted to fully disabled has to be told. The response is a
+    // degradation receipt (§6.7): consequence testimony, never policy
+    // authority — nothing in it may widen the grant.
+    updateParams.effectiveCapabilities = grant.effectiveList();
+    if (grant.deniedPaths.length > 0) {
+      updateParams.deniedCapabilities = [...grant.deniedPaths];
+    }
+
+    try {
+      const receipt = await connection.sendFeatureSetsUpdateRequest(updateParams);
+      if (receipt && receipt.accepted === false) {
+        const fallback = receipt.fallback ?? 'mcp-only';
+        console.error(
+          `[mcpl] ${config.id} refused initial policy (${receipt.reason ?? 'no reason'}) — fallback: ${fallback}`,
+        );
+        if (fallback === 'close') {
+          await connection.close();
+          return;
+        }
+        // mcp-only (§3.2): grant stays empty, MCPL privileged surface stays
+        // dark, plain MCP tools keep working. MUST NOT widen in response to
+        // the refusal — a human can change config; the policy engine cannot.
+        return;
+      }
+      // Expansion activates on receipt (§6.7).
+      connection.establishGrant(grant);
+      if (receipt?.accepted === true && receipt.mode === 'degraded') {
+        for (const uf of receipt.unavailableFeatures ?? []) {
+          console.error(
+            `[mcpl] ${config.id} degraded: ${uf.featureSet} (${uf.effect}; missing ${uf.missingCapabilities.join(', ')})`,
+          );
+        }
+      }
+    } catch (err) {
+      // A pre-0.5 server treats the Request as a notification and never
+      // answers. §6.7: an unanswered expansion simply does not activate —
+      // grant stays empty, connection is effectively MCP-only. This WILL
+      // dark every un-migrated MCPL server's privileged surface; accepted
+      // deliberately for the single-release rollout (issue #76 item 9).
+      console.error(
+        `[mcpl] ${config.id} did not answer the initial policy Request — ` +
+          `MCPL privileged surface stays disabled (§6.7 unanswered expansion): ` +
+          (err instanceof Error ? err.message : String(err)),
+      );
+      return;
     }
 
     // Configure scope whitelist/blacklist patterns
@@ -8682,19 +8736,25 @@ export class AgentFramework {
       // reconnect observes it before doing work that could wake an agent. The
       // connection paused its data plane before wiring the fresh transport.
       const awarenessBarrier = this.installMcplDataPlaneGate();
-      try {
-        const config = this.mcplServerConfigs.get(connection.id);
-        if (config) {
-          this.registerMcplServerFeatures(config, connection);
+      // Async: the §5.3 policy Request must be answered (re-establishing the
+      // grant) before the data-plane barrier releases — otherwise the first
+      // post-reconnect events land while the grant is still empty and are
+      // rejected fail-closed instead of delivered.
+      void (async () => {
+        try {
+          const config = this.mcplServerConfigs.get(connection.id);
+          if (config) {
+            await this.registerMcplServerFeatures(config, connection);
+          }
+        } catch (error) {
+          console.error(
+            `MCPL server "${connection.id}" re-registration after reconnect failed:`,
+            error instanceof Error ? error.message : error,
+          );
         }
-      } catch (error) {
-        console.error(
-          `MCPL server "${connection.id}" re-registration after reconnect failed:`,
-          error instanceof Error ? error.message : error,
-        );
-      }
-      this.releaseMcplDataPlaneGate(awarenessBarrier);
-      this.handleToolsListChanged(connection.id);
+        this.releaseMcplDataPlaneGate(awarenessBarrier);
+        this.handleToolsListChanged(connection.id);
+      })();
       void awarenessBarrier.promise.then(() => {
         if (
           awarenessBarrier.requiresBarrier

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -7935,7 +7935,12 @@ export class AgentFramework {
         beforeInference: true,
       },
       inferenceLifecycle: true,
-      modelInfo: true,
+      // modelInfo is NOT advertised: §12.2's result requires all four of
+      // {id, vendor, contextWindow, capabilities} and the host has no
+      // truthful source for contextWindow/capabilities (grep: none exists).
+      // Advertising a capability answered with a malformed partial response
+      // is worse than honest unsupported (Sol, PR #79 re-review). The
+      // handler below answers an explicit error rather than hanging (§6.6).
       inferenceRequest: { streaming: true },
       channels: {
         register: true,
@@ -8707,20 +8712,18 @@ export class AgentFramework {
 
     connection.on('model-info', (
       _params: unknown,
-      responder?: { respond: (result: unknown) => void },
+      responder?: { respond: (result: unknown) => void; respondError?: (code: number, message: string, data?: unknown) => void },
     ) => {
-      // Host-level answer: the first registered agent's model id. §12 asks
-      // for honesty over completeness — fields the host does not actually
-      // know (contextWindow, vendor-specific capability lists) are OMITTED,
-      // never fabricated: a hardcoded 200000 was false for residents
-      // configured at 300k/600k (PR #79 review blocker 6).
-      const agent = this.agents.values().next().value;
-      responder?.respond({
-        model: {
-          id: agent?.model ?? 'unknown',
-          vendor: 'unknown',
-        },
-      });
+      // §12.2 requires ALL FOUR of {id, vendor, contextWindow, capabilities}
+      // in the DIRECT result shape, and numeric contextWindow cannot express
+      // "unknown". The host has no truthful source for it, so modelInfo is
+      // not advertised and this answers an explicit error instead of a
+      // malformed partial (§6.6: a method that will never be answered
+      // truthfully MUST error, not fabricate).
+      responder?.respondError?.(
+        -32601,
+        'model/info unavailable: host does not advertise modelInfo (no truthful contextWindow source)',
+      );
     });
 
     // Handle incoming channel messages (Step 7)
@@ -10007,12 +10010,11 @@ export class AgentFramework {
       conversationId: agent.name,
       turnIndex: 0, // Simplified; needs per-conversation counter TODO
       userMessage: null, // Could extract from trigger context
-      model: {
-        id: agent.model,
-        vendor: 'unknown',
-        contextWindow: 200000,
-        capabilities: ['tools'],
-      },
+      // Truthful fields only (§10.1 honesty over completeness): id is real,
+      // vendor/contextWindow/capabilities have no source in this host and
+      // are omitted rather than fabricated — the hardcoded 200000 was false
+      // for residents configured at 300k/600k.
+      model: { id: agent.model },
       channels: this.channelRegistry?.buildChannelContext(agent.name),
     };
   }

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -7935,6 +7935,7 @@ export class AgentFramework {
         beforeInference: true,
       },
       inferenceLifecycle: true,
+      modelInfo: true,
       inferenceRequest: { streaming: true },
       channels: {
         register: true,
@@ -8369,7 +8370,11 @@ export class AgentFramework {
     }
 
     const awarenessBarrier = this.installMcplDataPlaneGate();
-    this.releaseMcplDataPlaneGate(awarenessBarrier);
+    // NO early release: both planes stay closed through accounting AND the
+    // §5.3 policy round-trip below (PR #79 review blocker 3 — the early
+    // control flush released channels-register/changed before any grant
+    // existed). The awareness drain rides tools/call RESPONSES, which are
+    // never event-buffered, so it needs no plane release to make progress.
     try {
       await awarenessBarrier.promise;
     } catch (error) {
@@ -8388,7 +8393,8 @@ export class AgentFramework {
 
     // §5.3 initial policy handshake — after accounting, before the gate
     // completes: the grant is established (or knowingly left empty) before
-    // any data-plane traffic flows.
+    // ANY buffered traffic (control or data) flows. complete() then
+    // ready()s both planes through the admission gate.
     await this.registerMcplServerFeatures(config, connection);
     this.completeMcplDataPlaneGate(awarenessBarrier);
 
@@ -8677,9 +8683,15 @@ export class AgentFramework {
       await this.channelRegistry?.handleRegister(connection.id, params, responder as never);
     });
 
-    // Handle channel changes (Step 7)
-    connection.on('channels-changed', async (params: ChannelsChangedParams) => {
-      await this.channelRegistry?.handleChanged(connection.id, params);
+    // Handle channel changes (Step 7) — §14.5 dual-mode: the responder is
+    // present for the Request form and carries itemized added-descriptor
+    // results; absent for Notifications, where rejection is itemwise
+    // filtering plus a diagnostic trace.
+    connection.on('channels-changed', async (
+      params: ChannelsChangedParams,
+      responder?: { respond: (result: unknown) => void },
+    ) => {
+      await this.channelRegistry?.handleChanged(connection.id, params, responder as never);
     });
 
     // §6.6/§12: requests that previously had no handler and hung forever
@@ -8697,17 +8709,16 @@ export class AgentFramework {
       _params: unknown,
       responder?: { respond: (result: unknown) => void },
     ) => {
-      // Host-level answer: the first registered agent's model. A
-      // per-conversation answer needs a conversation id in the params,
-      // which §12 does not define — this is the honest host-wide value,
-      // matching what beforeInference already reports.
+      // Host-level answer: the first registered agent's model id. §12 asks
+      // for honesty over completeness — fields the host does not actually
+      // know (contextWindow, vendor-specific capability lists) are OMITTED,
+      // never fabricated: a hardcoded 200000 was false for residents
+      // configured at 300k/600k (PR #79 review blocker 6).
       const agent = this.agents.values().next().value;
       responder?.respond({
         model: {
           id: agent?.model ?? 'unknown',
           vendor: 'unknown',
-          contextWindow: 200000,
-          capabilities: ['tools'],
         },
       });
     });

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -8359,12 +8359,11 @@ export class AgentFramework {
     // releases control traffic needed for registration and marker service.
     this.wireMcplEvents(connection);
 
-    // Initialize feature sets if server advertises MCPL capabilities.
-    // §5.3 initial policy handshake — awaited, so the grant is established
-    // (or knowingly left empty) before startup staging releases any traffic.
-    await this.registerMcplServerFeatures(config, connection);
-
     if (deferAwareness) {
+      // Staged startup: both planes are closed, so the §5.3 policy
+      // round-trip cannot let any buffered traffic slip — establish the
+      // grant now, before staging ever releases.
+      await this.registerMcplServerFeatures(config, connection);
       this.emitTrace({ type: 'module:added', moduleName: `mcpl:${config.id}` });
       return;
     }
@@ -8373,14 +8372,25 @@ export class AgentFramework {
     this.releaseMcplDataPlaneGate(awarenessBarrier);
     try {
       await awarenessBarrier.promise;
-      this.completeMcplDataPlaneGate(awarenessBarrier);
     } catch (error) {
       // Startup cannot fail open on a broken awareness ledger. Disable the
       // reconnecting stub/connection before propagating the distinct error to
       // initializeMcpl, which tears down any other servers and aborts create().
+      // Ordering matters: awareness accounting settles BEFORE the §5.3
+      // policy round-trip below, so an accounting failure aborts with the
+      // grant still empty and every buffered event still behind the gate —
+      // a failed startup never reports a released data plane. (The reverse
+      // order let a push arrive during the policy await and get flushed by
+      // teardown.)
       await connection.close().catch(() => {});
       throw error;
     }
+
+    // §5.3 initial policy handshake — after accounting, before the gate
+    // completes: the grant is established (or knowingly left empty) before
+    // any data-plane traffic flows.
+    await this.registerMcplServerFeatures(config, connection);
+    this.completeMcplDataPlaneGate(awarenessBarrier);
 
     this.emitTrace({ type: 'module:added', moduleName: `mcpl:${config.id}` });
   }

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -57,7 +57,6 @@ import { ModuleRegistry, isStateExistsError } from './module-registry.js';
 import { McplServerRegistry } from './mcpl/server-registry.js';
 import { FeatureSetManager } from './mcpl/feature-set-manager.js';
 import { computeGrant } from './mcpl/capability-grant.js';
-import { ScopeManager } from './mcpl/scope-manager.js';
 import { HookOrchestrator } from './mcpl/hook-orchestrator.js';
 import { PushHandler, type McplPushEvent } from './mcpl/push-handler.js';
 import { parseProsePrefix } from './mcpl/prose-grammar.js';
@@ -294,10 +293,7 @@ import type {
   McplServerConfig,
   McplHostCapabilities,
   FeatureSetsChangedParams,
-  ScopeElevateParams,
-  ScopeElevateResult,
   BeforeInferenceParams,
-  AfterInferenceParams,
   PushEventParams,
   McplInferenceRequestParams,
   ChannelsRegisterParams,
@@ -746,7 +742,6 @@ export class AgentFramework {
   // MCPL subsystems (null when no mcplServers configured)
   private mcplServerRegistry: McplServerRegistry | null = null;
   private featureSetManager: FeatureSetManager | null = null;
-  private scopeManager: ScopeManager | null = null;
   private hookOrchestrator: HookOrchestrator | null = null;
   private pushHandler: PushHandler | null = null;
   private inferenceRouter: InferenceRouter | null = null;
@@ -5425,6 +5420,19 @@ export class AgentFramework {
     // remains the sole authoritative send.
     const outgoingInferenceId = `inf_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
     let outgoingIndex = 0;
+
+    // §10.5 inference/lifecycle: `started` now, exactly one terminal in the
+    // finally below (the one block every exit path shares). Which terminal
+    // is decided by the paths themselves: default completed, catch sets
+    // failed, a framework-cancelled stream sets aborted. Best-effort
+    // notifications — consumers dedupe by inferenceId and keep a timeout.
+    let lifecyclePhase: 'completed' | 'aborted' | 'failed' = 'completed';
+    this.hookOrchestrator?.emitLifecycle({
+      inferenceId: outgoingInferenceId,
+      conversationId: agent.name,
+      turnIndex: 0,
+      phase: 'started',
+    });
     const proseStream = this.channelRegistry
       ? new ProseStreamRouter({
           mode: agent.proseRouting === 'explicit' ? 'explicit' : 'locus',
@@ -5680,40 +5688,10 @@ export class AgentFramework {
               agent.addAssistantResponse(terminalContent);
             }
 
-            // Run afterInference hooks (no-op if no MCPL servers)
-            if (this.hookOrchestrator) {
-              try {
-                const speechText = response.content
-                  .filter((block: ContentBlock): block is ContentBlock & { type: 'text' } => block.type === 'text')
-                  .map((b) => b.text)
-                  .join('\n');
-
-                const afterParams: AfterInferenceParams = {
-                  inferenceId: requestId,
-                  conversationId: agent.name,
-                  turnIndex: 0,
-                  userMessage: null,
-                  assistantMessage: speechText,
-                  model: {
-                    id: agent.model,
-                    vendor: 'unknown',
-                    contextWindow: 200000,
-                    capabilities: ['tools'],
-                  },
-                  usage: {
-                    inputTokens: response.usage?.inputTokens ?? 0,
-                    outputTokens: response.usage?.outputTokens ?? 0,
-                    cacheCreationTokens: response.details?.usage?.cacheCreationTokens,
-                    cacheReadTokens: response.details?.usage?.cacheReadTokens,
-                  },
-                };
-
-                await this.hookOrchestrator.afterInference(afterParams);
-              } catch (error) {
-                // Fail-open: continue with speech dispatch
-                console.error('afterInference hook error:', error);
-              }
-            }
+            // §10.5: context/afterInference is removed in 0.5.0 — no
+            // content leaves the host here. Turn boundaries are announced
+            // by the metadata-only inference/lifecycle notifications
+            // emitted in driveStream's start/exit paths.
 
             // Separate speech from thoughts — for MODULE dispatch only
             // (dispatchSpeech / TUI rendering below). This split does NOT
@@ -6112,6 +6090,7 @@ export class AgentFramework {
               const cancelKind = this.frameworkCancelledStreams.get(cancelKey);
               if (cancelKind !== undefined) {
                 this.frameworkCancelledStreams.delete(cancelKey);
+                lifecyclePhase = 'aborted'; // §10.5 — terminal emitted in finally
                 this.eventGate?.onInferenceEnded(agent.name);
                 // endTurn IS a logical turn end — earlier rounds may have
                 // live-routed prose (narrate → skip_reply is a real shape),
@@ -6238,9 +6217,21 @@ export class AgentFramework {
         durationMs,
       });
       this.abortAgentScript(agent.name, 'stream threw');
+      lifecyclePhase = 'failed'; // §10.5 — terminal emitted in finally
       agent.reset();
       this.eventGate?.onInferenceEnded(agent.name);
     } finally {
+      // §10.5: exactly one terminal per `started`, on every exit path the
+      // host controls. Which one was decided by the path taken (default
+      // completed; catch → failed; framework-cancel → aborted). A host
+      // crash emits nothing — that is the documented best-effort limit, and
+      // why consumers keep their safety timeout.
+      this.hookOrchestrator?.emitLifecycle({
+        inferenceId: outgoingInferenceId,
+        conversationId: agent.name,
+        turnIndex: 0,
+        phase: lifecyclePhase,
+      });
       // Clear the gate's inference flag on EVERY exit path (paired with the
       // onInferenceStarted in startAgentStream). The branch-level calls above
       // are kept but are best-effort; if any exit path bypassed them the agent
@@ -7816,7 +7807,6 @@ export class AgentFramework {
   ): Promise<void> {
     this.mcplServerRegistry = new McplServerRegistry();
     this.featureSetManager = new FeatureSetManager();
-    this.scopeManager = new ScopeManager();
     this.hookOrchestrator = new HookOrchestrator(this.mcplServerRegistry, this.featureSetManager);
 
     // Build prefix map and store configs for tool routing
@@ -7934,15 +7924,29 @@ export class AgentFramework {
 
     // Host capabilities advertised during the MCP handshake — stored so
     // servers can also be connected later at runtime (connectMcplServer).
+    // §5.2: the host advertises what it actually implements. 0.5.0-draft:
+    // afterInference is GONE (replaced by inference/lifecycle, §10.5), and
+    // the previously under-advertised inferenceRequest + channels — both
+    // implemented for years — are declared (AUDIT-001/issue #76 item 12).
     this.mcplHostCapabilities = {
-      version: '0.4',
+      version: '0.5',
       pushEvents: true,
       contextHooks: {
         beforeInference: true,
-        afterInference: { blocking: true },
+      },
+      inferenceLifecycle: true,
+      inferenceRequest: { streaming: true },
+      channels: {
+        register: true,
+        lifecycle: true,
+        publish: true,
+        incoming: true,
+        streaming: true,
+        acknowledge: true,
+        typing: true,
       },
       featureSets: true,
-    };
+    } as McplHostCapabilities;
 
     for (const config of serverConfigs) {
       try {
@@ -8467,9 +8471,8 @@ export class AgentFramework {
       return;
     }
 
-    // Configure scope whitelist/blacklist patterns
     if (config.scopes) {
-      this.scopeManager!.configureAll(config.scopes);
+      console.error(`[mcpl] ${config.id}: config \`scopes\` is ignored — §7 Scoped Access removed in 0.5.0`);
     }
 
     // Register stateful feature sets with checkpoint manager (Step 8)
@@ -8626,20 +8629,9 @@ export class AgentFramework {
     });
 
     // Handle scope elevation requests
-    connection.on('scope-elevate', async (
-      params: ScopeElevateParams,
-      responder?: { respond: (result: unknown) => void; respondError: (code: number, message: string) => void },
-    ) => {
-      if (this.scopeManager && responder) {
-        try {
-          const result: ScopeElevateResult = await this.scopeManager.handleElevation(params);
-          responder.respond(result);
-        } catch (error) {
-          const err = error instanceof Error ? error : new Error(String(error));
-          responder.respondError(-32603, err.message);
-        }
-      }
-    });
+    // §7 Scoped Access is removed in 0.5.0. scope/elevate is answered
+    // -32601 at the connection (server-connection.ts) and never reaches the
+    // framework; the ScopeManager and config `scopes` wiring went with it.
 
     // Handle push events (Step 6)
     connection.on('push-event', async (
@@ -8678,6 +8670,36 @@ export class AgentFramework {
     // Handle channel changes (Step 7)
     connection.on('channels-changed', async (params: ChannelsChangedParams) => {
       await this.channelRegistry?.handleChanged(connection.id, params);
+    });
+
+    // §6.6/§12: requests that previously had no handler and hung forever
+    // (AUDIT-001 item 4). The connection-level grant gate has already run.
+    connection.on('channels-list', (
+      _params: unknown,
+      responder?: { respond: (result: unknown) => void },
+    ) => {
+      responder?.respond({
+        channels: this.channelRegistry?.descriptorsForServer(connection.id) ?? [],
+      });
+    });
+
+    connection.on('model-info', (
+      _params: unknown,
+      responder?: { respond: (result: unknown) => void },
+    ) => {
+      // Host-level answer: the first registered agent's model. A
+      // per-conversation answer needs a conversation id in the params,
+      // which §12 does not define — this is the honest host-wide value,
+      // matching what beforeInference already reports.
+      const agent = this.agents.values().next().value;
+      responder?.respond({
+        model: {
+          id: agent?.model ?? 'unknown',
+          vendor: 'unknown',
+          contextWindow: 200000,
+          capabilities: ['tools'],
+        },
+      });
     });
 
     // Handle incoming channel messages (Step 7)

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -8420,7 +8420,7 @@ export class AgentFramework {
     // advertisement. Not yet active — expansion activates only after the
     // receipt (§6.7); until then the connection's grant is empty and every
     // privileged inbound method is rejected.
-    const grant = computeGrant(connection.capabilities, config);
+    const grant = computeGrant(connection.capabilities, config, { mcpToolsAdvertised: connection.mcpToolsAdvertised });
 
     const updateParams = this.featureSetManager!.initializeServer(
       config.id,
@@ -8633,10 +8633,10 @@ export class AgentFramework {
       this.emitTrace({ type: 'mcpl:server-stderr', serverId: connection.id, line: params.line });
     });
 
-    // Handle dynamic feature set changes from server
-    connection.on('feature-sets-changed', (params: FeatureSetsChangedParams) => {
-      this.featureSetManager?.handleFeatureSetsChanged(connection.id, params);
-    });
+    // featureSets/changed is REMOVED in 0.5.0 — the connection answers it
+    // -32601 (superseded by SPEC §17's host-diffed manifest fetch); no
+    // listener, and nothing mutates declarations off a server-authored
+    // change payload.
 
     // Handle scope elevation requests
     // §7 Scoped Access is removed in 0.5.0. scope/elevate is answered

--- a/src/mcpl/capability-grant.ts
+++ b/src/mcpl/capability-grant.ts
@@ -1,0 +1,240 @@
+/**
+ * Capability grants — the MCPL 0.5 security boundary (SPEC §5.4).
+ *
+ * Three layers, kept deliberately distinct:
+ *
+ *  1. **Advertisement walk** — what the server *can* do, read from its
+ *     initialize response by a generic recursive walk over the §6.2
+ *     vocabulary. Boolean `true` at any level is shorthand for every leaf
+ *     beneath it (§5.1). An unrecognized member name cannot mint a
+ *     capability. Advertisement is an input, never an authorization.
+ *
+ *  2. **Config mask** — host policy from `enabledCapabilities` /
+ *     `disabledCapabilities` (folded in from PR #75, Meganeuridae's
+ *     capability-scoping work, semantics unchanged). This is the DENY
+ *     direction, so a pattern matching a parent masks the whole subtree —
+ *     deny-safe by construction.
+ *
+ *  3. **The grant** — the intersection, expressed as an explicit allowlist
+ *     of full capability paths. `effectiveCapabilities` is the sole
+ *     normative allowlist; **absence is denial and there is no unspecified
+ *     state**. Matching here is NOT the mask's subtree matching: `*` matches
+ *     exactly one segment, segment counts must agree, and a bare parent
+ *     grants nothing beneath it (§5.4 as pinned 2026-08-02 — the suffix
+ *     reading was implemented once and adjudicated out; see mcpl e869744).
+ *
+ * §13.4: `contextHooks.beforeInference.inject.system` is DENIED BY DEFAULT.
+ * A server that needs it must be granted it explicitly via
+ * `enabledCapabilities`. This is the one place the default is not
+ * "everything advertised survives the mask", and it is loud when it fires.
+ */
+
+import type { McplCapabilities, McplServerConfig } from './types.js';
+
+// ============================================================================
+// §6.2 vocabulary
+// ============================================================================
+
+/**
+ * The closed capability-path vocabulary (SPEC §6.2). A tree, not a flat
+ * list, because the advertisement walk and boolean-shorthand expansion are
+ * defined over the tree. Leaves are `null`; interior nodes that are
+ * themselves grantable paths (e.g. `inferenceRequest`) appear as nodes whose
+ * path is also emitted when advertised.
+ */
+const VOCABULARY: CapNode = {
+  pushEvents: null,
+  tools: null,
+  modelInfo: null,
+  inferenceRequest: { streaming: null },
+  inferenceLifecycle: null,
+  contextHooks: {
+    beforeInference: {
+      observe: null,
+      inject: { system: null, beforeUser: null, afterUser: null },
+    },
+  },
+  channels: {
+    register: null,
+    lifecycle: null,
+    publish: null,
+    incoming: null,
+    streaming: null,
+    acknowledge: null,
+    typing: null,
+  },
+};
+
+interface CapNodeMap {
+  [key: string]: CapNode;
+}
+type CapNode = CapNodeMap | null;
+
+/** Interior nodes that are grantable paths in their own right (§6.2 lists
+ *  `inferenceRequest` alongside `inferenceRequest.streaming`). Namespaces
+ *  (`contextHooks`, `channels`, `inject`) are not: they hold no authority. */
+const SELF_GRANTABLE_INTERIOR = new Set(['inferenceRequest']);
+
+/** Every full path in the vocabulary (leaves plus self-grantable interiors). */
+export const ALL_CAPABILITY_PATHS: readonly string[] = (() => {
+  const out: string[] = [];
+  const walk = (node: CapNodeMap, prefix: string): void => {
+    for (const [key, child] of Object.entries(node)) {
+      const path = prefix ? `${prefix}.${key}` : key;
+      if (child === null) {
+        out.push(path);
+      } else {
+        if (SELF_GRANTABLE_INTERIOR.has(path)) out.push(path);
+        walk(child, path);
+      }
+    }
+  };
+  walk(VOCABULARY, '');
+  return out;
+})();
+
+const KNOWN_PATHS = new Set(ALL_CAPABILITY_PATHS);
+
+/** Is this exact string a §6.2 capability path? (Used by §6.4 `uses`
+ *  validation — `uses` MUST contain only these values.) */
+export function isKnownCapabilityPath(path: string): boolean {
+  return KNOWN_PATHS.has(path);
+}
+
+// ============================================================================
+// Advertisement walk (§5.1)
+// ============================================================================
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function collectSubtree(node: CapNode, path: string, out: Set<string>): void {
+  if (node === null) {
+    out.add(path);
+    return;
+  }
+  if (SELF_GRANTABLE_INTERIOR.has(path)) out.add(path);
+  for (const [key, child] of Object.entries(node)) {
+    collectSubtree(child, path ? `${path}.${key}` : key, out);
+  }
+}
+
+/**
+ * The set of full capability paths a capabilities object advertises.
+ * Generic recursive walk; `true` at any level advertises every leaf beneath
+ * it; `false`/absent advertises nothing; unrecognized member names are
+ * ignored — an unknown name cannot mint a capability.
+ */
+export function advertisedPaths(capabilities: McplCapabilities | null): Set<string> {
+  const out = new Set<string>();
+  if (!capabilities) return out;
+  const walk = (vocab: CapNode, value: unknown, prefix: string): void => {
+    if (vocab === null || !isPlainObject(value)) return;
+    for (const [key, child] of Object.entries(vocab)) {
+      const path = prefix ? `${prefix}.${key}` : key;
+      const v = value[key];
+      if (v === true) {
+        collectSubtree(child, path, out);
+      } else if (isPlainObject(v)) {
+        if (child !== null) {
+          if (SELF_GRANTABLE_INTERIOR.has(path)) out.add(path);
+          walk(child, v, path);
+        }
+      }
+      // false / absent / non-object-non-true: advertises nothing.
+    }
+  };
+  walk(VOCABULARY, capabilities as unknown as Record<string, unknown>, '');
+  return out;
+}
+
+// ============================================================================
+// Grant matching (§5.4) — one-segment wildcards, equal counts
+// ============================================================================
+
+/**
+ * `*` matches exactly one dot-segment; literal segments match exactly;
+ * segment counts MUST agree. A bare parent does not match its subtree and a
+ * trailing `*` is not a suffix wildcard (SPEC §5.4, pinned 2026-08-02).
+ */
+export function capabilityPatternMatches(pattern: string, path: string): boolean {
+  const p = pattern.split('.');
+  const n = path.split('.');
+  if (p.length !== n.length) return false;
+  for (let i = 0; i < p.length; i++) {
+    if (p[i] !== '*' && p[i] !== n[i]) return false;
+  }
+  return true;
+}
+
+// ============================================================================
+// The grant
+// ============================================================================
+
+/** §13.4: denied unless explicitly enabled by host config. */
+const DENY_BY_DEFAULT: readonly string[] = ['contextHooks.beforeInference.inject.system'];
+
+export class CapabilityGrant {
+  /** Exact granted paths (already expanded — no patterns stored). */
+  private readonly granted: ReadonlySet<string>;
+  /** Advertised-but-denied paths, for the §5.3 diagnostic field only. */
+  readonly deniedPaths: readonly string[];
+
+  constructor(granted: Set<string>, deniedPaths: string[]) {
+    this.granted = granted;
+    this.deniedPaths = deniedPaths;
+  }
+
+  /** Sole authorization question. Absence is denial (§5.4). */
+  has(path: string): boolean {
+    return this.granted.has(path);
+  }
+
+  /** Sorted list for `effectiveCapabilities` (§5.3). */
+  effectiveList(): string[] {
+    return [...this.granted].sort();
+  }
+
+  /** True when nothing at all is granted. */
+  isEmpty(): boolean {
+    return this.granted.size === 0;
+  }
+
+  static empty(): CapabilityGrant {
+    return new CapabilityGrant(new Set(), []);
+  }
+}
+
+/**
+ * Compute the effective grant for a connection: the server's advertisement
+ * (post config-mask — the mask runs first at handshake, so `capabilities`
+ * here is already the masked object) intersected with the deny-by-default
+ * floor. `enabledCapabilities` config patterns can re-grant a
+ * deny-by-default path — that is the explicit decision §13.4 asks for.
+ */
+export function computeGrant(
+  capabilities: McplCapabilities | null,
+  config: Pick<McplServerConfig, 'enabledCapabilities'>,
+): CapabilityGrant {
+  const advertised = advertisedPaths(capabilities);
+  const granted = new Set<string>();
+  const denied: string[] = [];
+
+  const explicitlyEnabled = (path: string): boolean =>
+    !!config.enabledCapabilities?.some((pat) => capabilityPatternMatches(pat, path));
+
+  for (const path of advertised) {
+    if (DENY_BY_DEFAULT.includes(path) && !explicitlyEnabled(path)) {
+      denied.push(path);
+      console.error(
+        `[mcpl] "${path}" advertised but DENIED BY DEFAULT (SPEC §13.4) — ` +
+          `grant it explicitly via enabledCapabilities if intended`,
+      );
+      continue;
+    }
+    granted.add(path);
+  }
+
+  return new CapabilityGrant(granted, denied.sort());
+}

--- a/src/mcpl/capability-grant.ts
+++ b/src/mcpl/capability-grant.ts
@@ -204,6 +204,21 @@ export class CapabilityGrant {
   static empty(): CapabilityGrant {
     return new CapabilityGrant(new Set(), []);
   }
+
+  /**
+   * A copy of this grant with the named paths removed — the reduction
+   * primitive. §6.7's ordering contract lives at the call site: install the
+   * narrowed grant (establishGrant) BEFORE sending the reducing
+   * featureSets/update Request; security cannot wait on consent.
+   */
+  without(...paths: string[]): CapabilityGrant {
+    const granted = new Set(this.granted);
+    const denied = new Set(this.deniedPaths);
+    for (const p of paths) {
+      if (granted.delete(p)) denied.add(p);
+    }
+    return new CapabilityGrant(granted, [...denied].sort());
+  }
 }
 
 /**

--- a/src/mcpl/capability-grant.ts
+++ b/src/mcpl/capability-grant.ts
@@ -125,6 +125,12 @@ function collectSubtree(node: CapNode, path: string, out: Set<string>): void {
  * Generic recursive walk; `true` at any level advertises every leaf beneath
  * it; `false`/absent advertises nothing; unrecognized member names are
  * ignored — an unknown name cannot mint a capability.
+ *
+ * `tools` is deliberately NOT sourced here. §5.1 sources it from the OUTER
+ * standard MCP `capabilities.tools` only — the experimental manifest cannot
+ * mint standard MCP tool capability (review blocker 2 on PR #79). A nested
+ * `experimental.mcpl.tools` is treated as an unknown member. Callers join
+ * the outer signal via computeGrant's mcpToolsAdvertised.
  */
 export function advertisedPaths(capabilities: McplCapabilities | null): Set<string> {
   const out = new Set<string>();
@@ -133,6 +139,7 @@ export function advertisedPaths(capabilities: McplCapabilities | null): Set<stri
     if (vocab === null || !isPlainObject(value)) return;
     for (const [key, child] of Object.entries(vocab)) {
       const path = prefix ? `${prefix}.${key}` : key;
+      if (path === 'tools') continue; // outer MCP caps only — see doc comment
       const v = value[key];
       if (v === true) {
         collectSubtree(child, path, out);
@@ -147,6 +154,44 @@ export function advertisedPaths(capabilities: McplCapabilities | null): Set<stri
   };
   walk(VOCABULARY, capabilities as unknown as Record<string, unknown>, '');
   return out;
+}
+
+/**
+ * Expand §5.1 boolean shorthand into the explicit leaf tree, IN PLACE of the
+ * boolean, for every vocabulary node — so the config mask's generic child
+ * walk can address sub-leaves. Without this, `channels: true` is an atomic
+ * top-level leaf to the mask: `disabledCapabilities:['channels.streaming']`
+ * silently no-ops and `enabledCapabilities:['channels.publish']` drops the
+ * whole tree (review blocker 1 — live release geometry, since discord
+ * truthfully keeps `channels: true`).
+ *
+ * Unrecognized members and non-capability members (`version`, `revision`,
+ * `featureSets`) pass through untouched. The wire keeps its shorthand; this
+ * expanded form is the host's POLICY representation.
+ */
+export function expandAdvertisementShorthand(capabilities: McplCapabilities | null): McplCapabilities | null {
+  if (!capabilities) return capabilities;
+  const expandNode = (node: CapNode): unknown => {
+    if (node === null) return true;
+    const out: Record<string, unknown> = {};
+    for (const [key, child] of Object.entries(node)) out[key] = expandNode(child);
+    return out;
+  };
+  const walk = (vocab: CapNodeMap, value: Record<string, unknown>): Record<string, unknown> => {
+    const out: Record<string, unknown> = { ...value };
+    for (const [key, child] of Object.entries(vocab)) {
+      if (key === 'tools') continue; // never expanded from experimental
+      const v = value[key];
+      if (child === null) continue; // leaf: boolean stays a boolean
+      if (v === true) {
+        out[key] = expandNode(child);
+      } else if (isPlainObject(v)) {
+        out[key] = walk(child, v);
+      }
+    }
+    return out;
+  };
+  return walk(VOCABULARY as CapNodeMap, capabilities as unknown as Record<string, unknown>) as unknown as McplCapabilities;
 }
 
 // ============================================================================
@@ -242,8 +287,16 @@ export class CapabilityGrant {
 export function computeGrant(
   capabilities: McplCapabilities | null,
   config: Pick<McplServerConfig, 'enabledCapabilities'>,
+  opts?: {
+    /** §5.1: `tools` is sourced from the OUTER standard MCP
+     *  `capabilities.tools` — pass its presence here. The experimental
+     *  manifest cannot mint it. Without this signal, every
+     *  `uses: ['tools']` feature set fails §6.4 derivation. */
+    mcpToolsAdvertised?: boolean;
+  },
 ): CapabilityGrant {
   const advertised = advertisedPaths(capabilities);
+  if (opts?.mcpToolsAdvertised) advertised.add('tools');
   const granted = new Set<string>();
   const denied: string[] = [];
 

--- a/src/mcpl/capability-grant.ts
+++ b/src/mcpl/capability-grant.ts
@@ -206,6 +206,17 @@ export class CapabilityGrant {
   }
 
   /**
+   * The grant carried by a connection-like object, failing CLOSED when the
+   * object has none. Registry consumers receive whatever the registry holds
+   * — including test stubs and objects created before the field existed —
+   * and a missing grant must mean "nothing granted" (§5.4 absence is
+   * denial), never a TypeError that takes the gate down open-ended.
+   */
+  static of(conn: { grant?: CapabilityGrant } | null | undefined): CapabilityGrant {
+    return conn?.grant ?? CapabilityGrant.empty();
+  }
+
+  /**
    * A copy of this grant with the named paths removed — the reduction
    * primitive. §6.7's ordering contract lives at the call site: install the
    * narrowed grant (establishGrant) BEFORE sending the reducing

--- a/src/mcpl/capability-mask.ts
+++ b/src/mcpl/capability-mask.ts
@@ -1,0 +1,169 @@
+/**
+ * Host-side capability scoping for MCPL servers.
+ *
+ * A server names its own capabilities in its initialize response, and
+ * everything downstream — hook fan-out, channel streaming, push handling —
+ * keys off that self-advertisement. `enabledCapabilities` /
+ * `disabledCapabilities` in McplServerConfig let the host intersect the
+ * advertisement with its own policy at handshake time, so a capability the
+ * config masks behaves exactly as if the server had never advertised it.
+ *
+ * The mask is applied once, where the negotiated capabilities are stored
+ * (McplServerConnection.handshake), rather than re-checked at each consumer:
+ * hook orchestration, streaming observation, and capability queries all read
+ * the already-masked object. Inbound server-initiated methods gated by a
+ * masked capability are additionally rejected at the connection
+ * (see METHOD_TO_REQUIRED_CAPABILITY in server-connection.ts).
+ */
+
+import type { McplCapabilities, McplServerConfig } from './types.js';
+
+/** Result of masking: the surviving capabilities plus what was dropped. */
+export interface MaskedCapabilities {
+  capabilities: McplCapabilities | null;
+  /**
+   * Dotted paths of advertised capabilities removed by the mask (e.g.
+   * `contextHooks.afterInference`). When an entire multi-flag capability is
+   * removed (`channels` advertised as a boolean, or every advertised channel
+   * flag masked), the bare parent path (`channels`) is included so inbound
+   * enforcement can key on it.
+   */
+  dropped: string[];
+}
+
+/**
+ * Segment-wise wildcard match, same rules as feature-set patterns:
+ * `*` matches exactly one dot-segment, literal segments match exactly,
+ * segment counts must agree.
+ */
+function wildcardMatch(pattern: string, name: string): boolean {
+  const patternParts = pattern.split('.');
+  const nameParts = name.split('.');
+
+  if (patternParts.length !== nameParts.length) {
+    return false;
+  }
+
+  for (let i = 0; i < patternParts.length; i++) {
+    const p = patternParts[i];
+    if (p === '*') {
+      continue;
+    }
+    if (p !== nameParts[i]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Whether a pattern matches a capability path or any ancestor prefix of it —
+ * `contextHooks` (or `*`) covers `contextHooks.afterInference`, so masking a
+ * parent masks everything beneath it.
+ */
+function patternMatchesPath(pattern: string, path: string): boolean {
+  const parts = path.split('.');
+  for (let depth = parts.length; depth >= 1; depth--) {
+    if (wildcardMatch(pattern, parts.slice(0, depth).join('.'))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function anyMatches(patterns: string[], path: string): boolean {
+  return patterns.some((pattern) => patternMatchesPath(pattern, path));
+}
+
+/** Keys that are negotiation metadata, not grantable capabilities. */
+const UNMASKABLE_KEYS = new Set(['version', 'featureSets']);
+
+/** Object-valued capabilities whose flags are maskable one level down. */
+const NESTED_KEYS = new Set(['contextHooks', 'channels']);
+
+/**
+ * Intersect a server's advertised MCPL capabilities with the host config's
+ * `enabledCapabilities` / `disabledCapabilities`.
+ *
+ * Semantics mirror enabledTools/disabledTools: if `enabledCapabilities` is
+ * set, only advertised capabilities matching at least one pattern survive;
+ * `disabledCapabilities` removes matches and wins on conflict. Patterns are
+ * dotted paths with `*` matching one segment, and a pattern that matches a
+ * parent (`contextHooks`) covers every flag beneath it. `version` and
+ * `featureSets` are never masked here — feature sets have their own
+ * enable/disable knobs.
+ *
+ * With neither list set, the advertisement passes through untouched.
+ */
+export function maskNegotiatedCapabilities(
+  capabilities: McplCapabilities | null,
+  config: Pick<McplServerConfig, 'enabledCapabilities' | 'disabledCapabilities'>,
+): MaskedCapabilities {
+  const enabled = config.enabledCapabilities;
+  const disabled = config.disabledCapabilities;
+
+  if (capabilities === null || (!enabled && !disabled)) {
+    return { capabilities, dropped: [] };
+  }
+
+  const keep = (path: string): boolean => {
+    if (disabled && anyMatches(disabled, path)) return false;
+    if (enabled) return anyMatches(enabled, path);
+    return true;
+  };
+
+  const masked: Record<string, unknown> = {};
+  const dropped: string[] = [];
+  const source = capabilities as unknown as Record<string, unknown>;
+
+  for (const [key, value] of Object.entries(source)) {
+    if (value === undefined) continue;
+
+    if (UNMASKABLE_KEYS.has(key)) {
+      masked[key] = value;
+      continue;
+    }
+
+    // Object-valued capability with individually maskable flags.
+    if (NESTED_KEYS.has(key) && typeof value === 'object' && value !== null) {
+      const flags = value as Record<string, unknown>;
+      const survivors: Record<string, unknown> = {};
+      let advertisedFlags = 0;
+
+      for (const [flag, flagValue] of Object.entries(flags)) {
+        if (flagValue === undefined || flagValue === false) continue;
+        advertisedFlags++;
+        const path = `${key}.${flag}`;
+        if (keep(path)) {
+          survivors[flag] = flagValue;
+        } else {
+          dropped.push(path);
+        }
+      }
+
+      if (Object.keys(survivors).length > 0) {
+        masked[key] = survivors;
+      } else if (advertisedFlags > 0) {
+        // Whole capability removed — record the bare parent for inbound
+        // enforcement (channels/* rejection keys on `channels`).
+        dropped.push(key);
+      }
+      continue;
+    }
+
+    // Leaf capability (boolean or opaque object, e.g. inferenceRequest,
+    // or `channels: true` from servers that advertise the boolean form).
+    if (value === false) {
+      masked[key] = value;
+      continue;
+    }
+    if (keep(key)) {
+      masked[key] = value;
+    } else {
+      dropped.push(key);
+    }
+  }
+
+  return { capabilities: masked as unknown as McplCapabilities, dropped };
+}

--- a/src/mcpl/capability-mask.ts
+++ b/src/mcpl/capability-mask.ts
@@ -14,6 +14,11 @@
  * the already-masked object. Inbound server-initiated methods gated by a
  * masked capability are additionally rejected at the connection
  * (see METHOD_TO_REQUIRED_CAPABILITY in server-connection.ts).
+ *
+ * Matching is a generic recursive walk per SPEC 0.5 §5.4: every path at
+ * every depth is addressable (`contextHooks.beforeInference.inject.system`
+ * works the day the host stores that shape), and a pattern matching a parent
+ * masks the whole subtree. No hardcoded set of nestable keys.
  */
 
 import type { McplCapabilities, McplServerConfig } from './types.js';
@@ -24,9 +29,9 @@ export interface MaskedCapabilities {
   /**
    * Dotted paths of advertised capabilities removed by the mask (e.g.
    * `contextHooks.afterInference`). When an entire multi-flag capability is
-   * removed (`channels` advertised as a boolean, or every advertised channel
-   * flag masked), the bare parent path (`channels`) is included so inbound
-   * enforcement can key on it.
+   * removed (`channels` advertised as a boolean, denied as a parent, or
+   * every advertised flag masked), the bare parent path (`channels`) is
+   * included so inbound enforcement can key on it.
    */
   dropped: string[];
 }
@@ -59,8 +64,8 @@ function wildcardMatch(pattern: string, name: string): boolean {
 
 /**
  * Whether a pattern matches a capability path or any ancestor prefix of it —
- * `contextHooks` (or `*`) covers `contextHooks.afterInference`, so masking a
- * parent masks everything beneath it.
+ * `contextHooks` (or `*`) covers `contextHooks.beforeInference.inject.system`
+ * at any depth, so masking a parent masks everything beneath it.
  */
 function patternMatchesPath(pattern: string, path: string): boolean {
   const parts = path.split('.');
@@ -79,8 +84,22 @@ function anyMatches(patterns: string[], path: string): boolean {
 /** Keys that are negotiation metadata, not grantable capabilities. */
 const UNMASKABLE_KEYS = new Set(['version', 'featureSets']);
 
-/** Object-valued capabilities whose flags are maskable one level down. */
-const NESTED_KEYS = new Set(['contextHooks', 'channels']);
+/**
+ * Interior object paths whose object value is itself the capability, with
+ * children as refinements — dropping a refinement leaves the capability
+ * granted (`inferenceRequest` minus `.streaming` is still inferenceRequest).
+ * Every other interior object is a pure namespace (`contextHooks`,
+ * `channels`, a future `inject`): it holds no authority of its own and is
+ * pruned when all its advertised children are masked.
+ *
+ * This is a retention-shape distinction only — matching and addressability
+ * are fully generic and depth-unbounded either way.
+ */
+const OBJECT_CAPABILITY_PATHS = new Set(['inferenceRequest', 'contextHooks.afterInference']);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
 
 /**
  * Intersect a server's advertised MCPL capabilities with the host config's
@@ -90,7 +109,7 @@ const NESTED_KEYS = new Set(['contextHooks', 'channels']);
  * set, only advertised capabilities matching at least one pattern survive;
  * `disabledCapabilities` removes matches and wins on conflict. Patterns are
  * dotted paths with `*` matching one segment, and a pattern that matches a
- * parent (`contextHooks`) covers every flag beneath it. `version` and
+ * parent (`contextHooks`) covers every path beneath it. `version` and
  * `featureSets` are never masked here — feature sets have their own
  * enable/disable knobs.
  *
@@ -107,57 +126,97 @@ export function maskNegotiatedCapabilities(
     return { capabilities, dropped: [] };
   }
 
-  const keep = (path: string): boolean => {
-    if (disabled && anyMatches(disabled, path)) return false;
-    if (enabled) return anyMatches(enabled, path);
-    return true;
+  const denied = (path: string): boolean => !!disabled && anyMatches(disabled, path);
+  const allowed = (path: string): boolean => !enabled || anyMatches(enabled, path);
+  const keep = (path: string): boolean => !denied(path) && allowed(path);
+
+  const dropped: string[] = [];
+
+  /**
+   * Mask one interior object node. Returns the surviving object, or
+   * undefined when the node is pruned entirely. Falsy children are carried
+   * through untouched (they advertise nothing, so there is nothing to mask).
+   */
+  const maskNode = (node: Record<string, unknown>, path: string): Record<string, unknown> | undefined => {
+    if (denied(path)) {
+      dropped.push(path);
+      return undefined;
+    }
+
+    const survivors: Record<string, unknown> = {};
+    let advertised = 0;
+    let survived = 0;
+
+    for (const [key, value] of Object.entries(node)) {
+      if (value === undefined) continue;
+      if (!value) {
+        // false / 0 / '' advertise nothing — preserve for fidelity.
+        survivors[key] = value;
+        continue;
+      }
+      advertised++;
+      const childPath = path ? `${path}.${key}` : key;
+
+      if (isPlainObject(value)) {
+        const masked = maskNode(value, childPath);
+        if (masked !== undefined) {
+          survivors[key] = masked;
+          survived++;
+        }
+        continue;
+      }
+
+      // Truthy leaf.
+      if (keep(childPath)) {
+        survivors[key] = value;
+        survived++;
+      } else {
+        dropped.push(childPath);
+      }
+    }
+
+    if (advertised === 0) {
+      // No truthy children: the object itself is the advert (e.g.
+      // `inferenceRequest: {}`), so its own path decides.
+      if (keep(path)) return survivors;
+      dropped.push(path);
+      return undefined;
+    }
+    if (survived > 0) {
+      return survivors;
+    }
+
+    // Every advertised child was masked. An object-capability keeps its
+    // (still-granted) hull; a namespace holds no authority of its own and
+    // is pruned, recording the bare path for inbound enforcement.
+    if (OBJECT_CAPABILITY_PATHS.has(path) && keep(path)) {
+      return survivors;
+    }
+    dropped.push(path);
+    return undefined;
   };
 
   const masked: Record<string, unknown> = {};
-  const dropped: string[] = [];
   const source = capabilities as unknown as Record<string, unknown>;
 
   for (const [key, value] of Object.entries(source)) {
     if (value === undefined) continue;
 
-    if (UNMASKABLE_KEYS.has(key)) {
+    if (UNMASKABLE_KEYS.has(key) || !value) {
       masked[key] = value;
       continue;
     }
 
-    // Object-valued capability with individually maskable flags.
-    if (NESTED_KEYS.has(key) && typeof value === 'object' && value !== null) {
-      const flags = value as Record<string, unknown>;
-      const survivors: Record<string, unknown> = {};
-      let advertisedFlags = 0;
-
-      for (const [flag, flagValue] of Object.entries(flags)) {
-        if (flagValue === undefined || flagValue === false) continue;
-        advertisedFlags++;
-        const path = `${key}.${flag}`;
-        if (keep(path)) {
-          survivors[flag] = flagValue;
-        } else {
-          dropped.push(path);
-        }
-      }
-
-      if (Object.keys(survivors).length > 0) {
-        masked[key] = survivors;
-      } else if (advertisedFlags > 0) {
-        // Whole capability removed — record the bare parent for inbound
-        // enforcement (channels/* rejection keys on `channels`).
-        dropped.push(key);
+    if (isPlainObject(value)) {
+      const node = maskNode(value, key);
+      if (node !== undefined) {
+        masked[key] = node;
       }
       continue;
     }
 
-    // Leaf capability (boolean or opaque object, e.g. inferenceRequest,
-    // or `channels: true` from servers that advertise the boolean form).
-    if (value === false) {
-      masked[key] = value;
-      continue;
-    }
+    // Truthy leaf at the top level (booleans, or `channels: true` from
+    // servers that advertise the boolean form).
     if (keep(key)) {
       masked[key] = value;
     } else {

--- a/src/mcpl/channel-registry.ts
+++ b/src/mcpl/channel-registry.ts
@@ -518,7 +518,14 @@ export class ChannelRegistry {
   async handleChanged(
     serverId: string,
     params: ChannelsChangedParams,
+    responder?: Responder,
   ): Promise<void> {
+    // §14.5: dual-mode. Request form answers ITEMIZED per-descriptor
+    // results for added channels; Notification form filters itemwise with a
+    // diagnostic. Either way, added descriptors are validated exactly like
+    // channels/register — a changed-set cannot smuggle in what register
+    // would have rejected (PR #79 review blocker 5).
+    const addedResults: Array<{ id: string; accepted: boolean; reason?: string }> = [];
     // Process removed channels
     if (params.removed) {
       for (const channelId of params.removed) {
@@ -539,18 +546,27 @@ export class ChannelRegistry {
       }
     }
 
-    // Process added channels (register + reconcile durable desired state)
+    // Process added channels (validate per-descriptor, register, reconcile)
+    const accepted: typeof params.added = [];
     if (params.added) {
       for (const channel of params.added) {
+        if (!channel || typeof channel.id !== 'string' || channel.id.length === 0) {
+          addedResults.push({ id: String(channel?.id ?? ''), accepted: false, reason: 'invalid descriptor: missing id' });
+          this.emitTraceFn({ type: 'mcpl:channel-descriptor-rejected', serverId, reason: 'missing id' });
+          continue;
+        }
         const key = `${serverId}:${channel.id}`;
         this.channels.set(key, {
           serverId,
           descriptor: channel,
           open: false,
         });
+        addedResults.push({ id: channel.id, accepted: true });
+        accepted.push(channel);
       }
-      await this.reconcileChannels(serverId, params.added);
+      if (accepted.length > 0) await this.reconcileChannels(serverId, accepted);
     }
+    responder?.respond({ results: addedResults });
 
     this.emitTraceFn({
       type: 'mcpl:channels-changed',
@@ -581,11 +597,6 @@ export class ChannelRegistry {
       // Convert MCPL content blocks to membrane ContentBlocks
       const convertedContent: ContentBlock[] = message.content.map(convertBlock);
 
-      // Track default publish channel (most recent incoming)
-      this.defaultPublishChannel = message.channelId;
-      this.defaultPublishMessageId = message.messageId;
-      this.defaultPublishThreadId = message.threadId;
-
       // Lazy-register the channel if we've never seen it. A channel can deliver
       // an incoming message before its channels/register (boot enumeration) or
       // channels/changed (post-boot create / View-permission grant) round-trip
@@ -597,31 +608,38 @@ export class ChannelRegistry {
       // is reachable. The inbound message carries enough to make it publishable,
       // so register it here; a later authoritative channels/register or
       // channels/changed will overwrite this descriptor with the richer one.
+      // §14.5: channels/incoming is validated against the ACTUALLY
+      // REGISTERED channel. An unknown claimed channelId is rejected
+      // per-message with an itemized result — never minted by its first
+      // message (PR #79 review blocker 5: lazy-registration let a server
+      // self-attest a channel identity without ever passing
+      // channels/register authorization). A server whose channel genuinely
+      // exists registers it first; discord's DM case goes through
+      // ensureChannelRegistered on push/event, which creates a CLOSED
+      // routable entry rather than an open self-attested one.
       const incomingKey = `${serverId}:${message.channelId}`;
       if (!this.channels.has(incomingKey)) {
-        const channelLabel =
-          typeof message.metadata?.channelName === 'string' && message.metadata.channelName
-            ? (message.metadata.channelName as string)
-            : message.channelId;
-        this.channels.set(incomingKey, {
-          serverId,
-          descriptor: {
-            id: message.channelId,
-            type: serverId,
-            label: channelLabel,
-            direction: 'bidirectional',
-            address: message.threadId ? { threadId: message.threadId } : undefined,
-            metadata: { lazyRegistered: true },
-          },
-          open: true,
-        });
         this.emitTraceFn({
-          type: 'mcpl:channel-lazy-registered',
+          type: 'mcpl:channel-incoming-rejected',
           serverId,
           channelId: message.channelId,
-          label: channelLabel,
+          reason: 'unknown channel — not registered (§14.5)',
         });
-      } else {
+        results.push({
+          messageId: message.messageId,
+          accepted: false,
+          reason: `unknown channel "${message.channelId}" — register it first (§14.5)`,
+        });
+        continue;
+      }
+      // Track default publish channel (most recent ACCEPTED incoming) —
+      // deliberately after §14.5 validation: a rejected message from an
+      // unregistered channel must not retarget outbound speech (the locus is
+      // exactly the authority a self-attested channel would be stealing).
+      this.defaultPublishChannel = message.channelId;
+      this.defaultPublishMessageId = message.messageId;
+      this.defaultPublishThreadId = message.threadId;
+      {
         // A server sending channels/incoming is authoritative evidence that
         // the transport is actually open. This repairs transient status only;
         // durable desired state still changes exclusively through lifecycle

--- a/src/mcpl/channel-registry.ts
+++ b/src/mcpl/channel-registry.ts
@@ -34,6 +34,7 @@ import type {
 import type { McplServerRegistry } from './server-registry.js';
 import type { FeatureSetManager } from './feature-set-manager.js';
 import type { ToolDefinition, ToolResult, ProcessEvent } from '../types/index.js';
+import { expandCoreTags } from './tags.js';
 
 // ============================================================================
 // Typing indicator interval (Discord typing lasts ~10s, so 7s keeps it alive)
@@ -466,8 +467,19 @@ export class ChannelRegistry {
     responder?: Responder,
   ): Promise<void> {
     const registeredIds: string[] = [];
+    // §14.5: per-descriptor authorization with ITEMIZED results — one entry
+    // per submitted descriptor. Strict 0.5 servers treat a result without
+    // `results` (or a descriptor missing from it) as rejected, so the shape
+    // is interop-critical, not decorative. Rejection here is per-descriptor
+    // validation; the method-level channels.register gate already ran at the
+    // connection (§14.1).
+    const results: ChannelsRegisterResult['results'] = [];
 
     for (const channel of params.channels) {
+      if (!channel || typeof channel.id !== 'string' || channel.id.length === 0) {
+        results.push({ id: String(channel?.id ?? ''), accepted: false, reason: 'invalid descriptor: missing id' });
+        continue;
+      }
       const key = `${serverId}:${channel.id}`;
       this.channels.set(key, {
         serverId,
@@ -475,11 +487,12 @@ export class ChannelRegistry {
         open: false,
       });
       registeredIds.push(channel.id);
+      results.push({ id: channel.id, accepted: true });
     }
 
     // Respond before reconciliation — the server blocks on this response and
     // can't process channels/open until it arrives.
-    const result: ChannelsRegisterResult = { registered: registeredIds };
+    const result: ChannelsRegisterResult = { registered: registeredIds, results };
     responder?.respond(result);
 
     // One-time migration from the retired recipe policy, then reconcile the
@@ -561,6 +574,9 @@ export class ChannelRegistry {
     const results: ChannelIncomingMessageResult[] = [];
 
     for (const message of params.messages) {
+      // §16.3: expand the normative chat:* core closure at entry (see
+      // push-handler for the full rationale; same rule, same limits).
+      if (message.tags) message.tags = expandCoreTags(message.tags);
       // Convert MCPL content blocks to membrane ContentBlocks
       const convertedContent: ContentBlock[] = message.content.map(convertBlock);
 
@@ -1189,6 +1205,19 @@ export class ChannelRegistry {
     const server = this.serverRegistry.getServer(serverId);
     if (!server) return;
 
+    // §14.1: channels/open + channels/close require channels.lifecycle.
+    // Skipping reconciliation for an ungranted server is the enforcement —
+    // its channels simply stay in whatever state the server chose, and the
+    // host never directs lifecycle it was not granted authority over.
+    if (!server.grant.has('channels.lifecycle')) {
+      this.emitTraceFn({
+        type: 'mcpl:channel-reconcile-skipped',
+        serverId,
+        reason: 'channels.lifecycle not in effective grant (§14.1)',
+      });
+      return;
+    }
+
     // Channels the subscription policy freshly admitted in THIS pass —
     // announced to the agent as one batched notice after the loop, so a
     // first boot on a new policy doesn't produce one notice per channel.
@@ -1263,6 +1292,10 @@ export class ChannelRegistry {
    * (typing timer lifecycle is still managed for when the callback is wired).
    */
   private sendTypingNotification(serverId: string, channelId: string): void {
+    // §14.1: channels/typing requires channels.typing in the grant. Silent
+    // skip — a typing indicator is cosmetic and per-7s, so a diagnostic per
+    // tick would be noise.
+    if (!this.serverRegistry.getServer(serverId)?.grant.has('channels.typing')) return;
     if (this.sendTypingFn) {
       this.sendTypingFn(serverId, channelId, this.typingMetadata.get(channelId));
     }
@@ -1273,6 +1306,13 @@ export class ChannelRegistry {
   // ==========================================================================
   // Private: Channel Lookup
   // ==========================================================================
+
+  /** Descriptors registered by one server — the §14.3 channels/list answer. */
+  descriptorsForServer(serverId: string): ChannelDescriptor[] {
+    return [...this.channels.values()]
+      .filter((e) => e.serverId === serverId)
+      .map((e) => e.descriptor);
+  }
 
   /** Server id owning a registered channel (by descriptor id), or null. */
   getChannelServerId(channelId: string): string | null {
@@ -1377,6 +1417,11 @@ export class ChannelRegistry {
     const server = this.serverRegistry.getServer(entry.serverId);
     if (!server) {
       throw new Error(`Server not found: ${entry.serverId}`);
+    }
+    if (!server.grant.has('channels.lifecycle')) {
+      // Desired state is already recorded — intent sticks; reconciliation
+      // will retry if the grant later widens (§6.7 expansion-on-receipt).
+      throw new Error(`channels.lifecycle not in "${entry.serverId}"'s effective grant (§14.1)`);
     }
     const result: ChannelsOpenResult = await server.sendChannelsOpen({
       channelId: entry.descriptor.id,
@@ -1722,6 +1767,13 @@ export class ChannelRegistry {
     }
 
     try {
+      if (!server.grant.has('channels.lifecycle')) {
+        return {
+          success: false,
+          error: `channels.lifecycle not in "${entry.serverId}"'s effective grant (§14.1)`,
+          isError: true,
+        };
+      }
       await server.sendChannelsClose({ channelId: input.channelId });
       entry.open = false;
       return {
@@ -1767,6 +1819,8 @@ export class ChannelRegistry {
       const server = this.serverRegistry.getServer(entry.serverId);
       if (!server) {
         acknowledgmentError = `Server not found: ${entry.serverId}`;
+      } else if (!server.grant.has('channels.acknowledge')) {
+        acknowledgmentError = `channels.acknowledge not in "${entry.serverId}"'s effective grant (§14.1)`;
       } else {
         try {
           const result = await server.sendChannelsAcknowledge({
@@ -1924,7 +1978,12 @@ export class ChannelRegistry {
     const matches = [...this.channels.values()].filter((e) => e.descriptor.id === channelId);
     if (matches.length !== 1) return null;
     const server = this.serverRegistry.getServer(matches[0]!.serverId);
-    if (!server?.capabilities?.channels?.streaming) return null;
+    // §5.4: the GRANT gates streaming, not the raw advertisement. The old
+    // `capabilities?.channels?.streaming` check was doubly wrong: undefined
+    // for the boolean `channels: true` shape (masking discord-mcpl's latent
+    // double-post, AUDIT-001), and pre-policy it would have sent before the
+    // server was told anything was granted.
+    if (!server?.grant.has('channels.streaming')) return null;
     return server;
   }
 
@@ -2016,6 +2075,12 @@ export class ChannelRegistry {
     if (!server) {
       return fail(channelId, `server "${entry.serverId}" not found`);
     }
+    // §14.1: channels/publish requires channels.publish in the grant. The
+    // host not sending is the enforcement — a send to an ungranted server
+    // would have it act on authority it was never told it has.
+    if (!server.grant.has('channels.publish')) {
+      return fail(channelId, `channels.publish not in "${entry.serverId}"'s effective grant (§14.1)`);
+    }
 
     const publishParams: ChannelsPublishParams = {
       conversationId,
@@ -2092,6 +2157,13 @@ export class ChannelRegistry {
     }
 
     try {
+      if (!server.grant.has('channels.publish')) {
+        return {
+          success: false,
+          error: `channels.publish not in "${server.id}"'s effective grant (§14.1)`,
+          isError: true,
+        };
+      }
       const publishParams: ChannelsPublishParams = {
         conversationId: '', // Framework will fill this when wired
         channelId,

--- a/src/mcpl/channel-registry.ts
+++ b/src/mcpl/channel-registry.ts
@@ -35,6 +35,7 @@ import type { McplServerRegistry } from './server-registry.js';
 import type { FeatureSetManager } from './feature-set-manager.js';
 import type { ToolDefinition, ToolResult, ProcessEvent } from '../types/index.js';
 import { expandCoreTags } from './tags.js';
+import { CapabilityGrant } from './capability-grant.js';
 
 // ============================================================================
 // Typing indicator interval (Discord typing lasts ~10s, so 7s keeps it alive)
@@ -1209,7 +1210,7 @@ export class ChannelRegistry {
     // Skipping reconciliation for an ungranted server is the enforcement —
     // its channels simply stay in whatever state the server chose, and the
     // host never directs lifecycle it was not granted authority over.
-    if (!server.grant.has('channels.lifecycle')) {
+    if (!CapabilityGrant.of(server).has('channels.lifecycle')) {
       this.emitTraceFn({
         type: 'mcpl:channel-reconcile-skipped',
         serverId,
@@ -1295,7 +1296,7 @@ export class ChannelRegistry {
     // §14.1: channels/typing requires channels.typing in the grant. Silent
     // skip — a typing indicator is cosmetic and per-7s, so a diagnostic per
     // tick would be noise.
-    if (!this.serverRegistry.getServer(serverId)?.grant.has('channels.typing')) return;
+    if (!CapabilityGrant.of(this.serverRegistry.getServer(serverId)).has('channels.typing')) return;
     if (this.sendTypingFn) {
       this.sendTypingFn(serverId, channelId, this.typingMetadata.get(channelId));
     }
@@ -1418,7 +1419,7 @@ export class ChannelRegistry {
     if (!server) {
       throw new Error(`Server not found: ${entry.serverId}`);
     }
-    if (!server.grant.has('channels.lifecycle')) {
+    if (!CapabilityGrant.of(server).has('channels.lifecycle')) {
       // Desired state is already recorded — intent sticks; reconciliation
       // will retry if the grant later widens (§6.7 expansion-on-receipt).
       throw new Error(`channels.lifecycle not in "${entry.serverId}"'s effective grant (§14.1)`);
@@ -1767,7 +1768,7 @@ export class ChannelRegistry {
     }
 
     try {
-      if (!server.grant.has('channels.lifecycle')) {
+      if (!CapabilityGrant.of(server).has('channels.lifecycle')) {
         return {
           success: false,
           error: `channels.lifecycle not in "${entry.serverId}"'s effective grant (§14.1)`,
@@ -1819,7 +1820,7 @@ export class ChannelRegistry {
       const server = this.serverRegistry.getServer(entry.serverId);
       if (!server) {
         acknowledgmentError = `Server not found: ${entry.serverId}`;
-      } else if (!server.grant.has('channels.acknowledge')) {
+      } else if (!CapabilityGrant.of(server).has('channels.acknowledge')) {
         acknowledgmentError = `channels.acknowledge not in "${entry.serverId}"'s effective grant (§14.1)`;
       } else {
         try {
@@ -1983,7 +1984,7 @@ export class ChannelRegistry {
     // for the boolean `channels: true` shape (masking discord-mcpl's latent
     // double-post, AUDIT-001), and pre-policy it would have sent before the
     // server was told anything was granted.
-    if (!server?.grant.has('channels.streaming')) return null;
+    if (!CapabilityGrant.of(server).has('channels.streaming')) return null;
     return server;
   }
 
@@ -2078,7 +2079,7 @@ export class ChannelRegistry {
     // §14.1: channels/publish requires channels.publish in the grant. The
     // host not sending is the enforcement — a send to an ungranted server
     // would have it act on authority it was never told it has.
-    if (!server.grant.has('channels.publish')) {
+    if (!CapabilityGrant.of(server).has('channels.publish')) {
       return fail(channelId, `channels.publish not in "${entry.serverId}"'s effective grant (§14.1)`);
     }
 
@@ -2157,7 +2158,7 @@ export class ChannelRegistry {
     }
 
     try {
-      if (!server.grant.has('channels.publish')) {
+      if (!CapabilityGrant.of(server).has('channels.publish')) {
         return {
           success: false,
           error: `channels.publish not in "${server.id}"'s effective grant (§14.1)`,

--- a/src/mcpl/channel-registry.ts
+++ b/src/mcpl/channel-registry.ts
@@ -526,23 +526,37 @@ export class ChannelRegistry {
     // channels/register — a changed-set cannot smuggle in what register
     // would have rejected (PR #79 review blocker 5).
     const addedResults: Array<{ id: string; accepted: boolean; reason?: string }> = [];
-    // Process removed channels
+    // Process removed channels — itemized truthfully: removal of a channel
+    // we never had is reported, not silently accepted.
     if (params.removed) {
       for (const channelId of params.removed) {
         const key = `${serverId}:${channelId}`;
-        this.channels.delete(key);
+        const existed = this.channels.delete(key);
         this.stopTyping(channelId);
+        addedResults.push({ id: channelId, accepted: existed, reason: existed ? undefined : 'not registered' });
       }
     }
 
-    // Process updated channels (replace descriptor, preserve open state)
+    // Process updated channels — validated itemwise exactly like added
+    // (§14.5: a changed-set cannot smuggle in what register would reject),
+    // and every submitted descriptor gets a verdict: a strict server reads
+    // absence from `results` as rejection.
     if (params.updated) {
       for (const channel of params.updated) {
+        if (!channel || typeof channel.id !== 'string' || channel.id.length === 0) {
+          addedResults.push({ id: String(channel?.id ?? ''), accepted: false, reason: 'invalid descriptor: missing id' });
+          this.emitTraceFn({ type: 'mcpl:channel-descriptor-rejected', serverId, reason: 'missing id (update)' });
+          continue;
+        }
         const key = `${serverId}:${channel.id}`;
         const existing = this.channels.get(key);
-        if (existing) {
-          existing.descriptor = channel;
+        if (!existing) {
+          addedResults.push({ id: channel.id, accepted: false, reason: 'not registered — update rejected (§14.5)' });
+          this.emitTraceFn({ type: 'mcpl:channel-descriptor-rejected', serverId, channelId: channel.id, reason: 'update for unregistered channel' });
+          continue;
         }
+        existing.descriptor = channel;
+        addedResults.push({ id: channel.id, accepted: true });
       }
     }
 
@@ -591,11 +605,11 @@ export class ChannelRegistry {
     const results: ChannelIncomingMessageResult[] = [];
 
     for (const message of params.messages) {
-      // §16.3: expand the normative chat:* core closure at entry (see
-      // push-handler for the full rationale; same rule, same limits).
-      if (message.tags) message.tags = expandCoreTags(message.tags);
-      // Convert MCPL content blocks to membrane ContentBlocks
-      const convertedContent: ContentBlock[] = message.content.map(convertBlock);
+      // §14.5 FIRST, before ANY semantic processing: admission against the
+      // actually-registered channel precedes tag expansion and content
+      // conversion — decoding an unregistered sender's payload (including
+      // inline base64) is allocation and parsing work done for a message
+      // that must be rejected (Sol, PR #79 re-review blocker 2).
 
       // Lazy-register the channel if we've never seen it. A channel can deliver
       // an incoming message before its channels/register (boot enumeration) or
@@ -632,6 +646,12 @@ export class ChannelRegistry {
         });
         continue;
       }
+
+      // ACCEPTED from here down: semantic processing only for admitted
+      // messages. §16.3 core-tag closure, then content conversion.
+      if (message.tags) message.tags = expandCoreTags(message.tags);
+      const convertedContent: ContentBlock[] = message.content.map(convertBlock);
+
       // Track default publish channel (most recent ACCEPTED incoming) —
       // deliberately after §14.5 validation: a rejected message from an
       // unregistered channel must not retarget outbound speech (the locus is

--- a/src/mcpl/errors.ts
+++ b/src/mcpl/errors.ts
@@ -14,6 +14,13 @@ import type { JsonRpcError } from './types.js';
 /** Message used a disabled feature set. */
 export const FEATURE_SET_NOT_ENABLED = -32001;
 
+/**
+ * Method requires a capability the host has masked for this server
+ * (McplServerConfig.enabledCapabilities/disabledCapabilities). Host-side
+ * extension code, pending a spec assignment.
+ */
+export const CAPABILITY_DISABLED = -32002;
+
 /** Message used an undeclared feature set. */
 export const UNKNOWN_FEATURE_SET = -32003;
 

--- a/src/mcpl/feature-set-manager.ts
+++ b/src/mcpl/feature-set-manager.ts
@@ -175,11 +175,16 @@ export class FeatureSetManager {
       enabled: new Set<string>(),
     };
 
-    // Resolve which feature sets to enable
-    const enablePatterns = config?.enabledFeatureSets ?? [];
+    // §5.3 as pinned (mcpl e869744): ABSENT enabledFeatureSets constrains
+    // nothing — every declared set is a candidate and §6.4 derivation
+    // governs. PRESENT is an allowlist ([] = deny-all selection). The old
+    // reading (unmentioned defaults disabled) reversed the pin (PR #79
+    // review blocker 7). FLEET BEHAVIOR CHANGE: configs that omitted
+    // enabledFeatureSets now enable every derivable declared set.
     const disablePatterns = config?.disabledFeatureSets ?? [];
-
-    const toEnable = resolvePatterns(enablePatterns, declared);
+    const toEnable = config?.enabledFeatureSets === undefined
+      ? Object.keys(declared)
+      : resolvePatterns(config.enabledFeatureSets, declared);
     const toDisable = resolvePatterns(disablePatterns, declared);
 
     // Enable matching sets

--- a/src/mcpl/feature-set-manager.ts
+++ b/src/mcpl/feature-set-manager.ts
@@ -18,6 +18,7 @@ import {
   FEATURE_SET_NOT_ENABLED,
   UNKNOWN_FEATURE_SET,
 } from './errors.js';
+import { isKnownCapabilityPath } from './capability-grant.js';
 
 // ============================================================================
 // Error Class
@@ -143,7 +144,16 @@ export class FeatureSetManager {
   initializeServer(
     serverId: string,
     capabilities: McplCapabilities,
-    config?: { enabledFeatureSets?: string[]; disabledFeatureSets?: string[] }
+    config?: { enabledFeatureSets?: string[]; disabledFeatureSets?: string[] },
+    /**
+     * The effective capability grant (§5.4). When provided, §6.4's
+     * FAIL-CLOSED derivation runs: a feature set whose `uses` is absent,
+     * empty, or contains an unrecognized value is disabled with reason
+     * `invalid_uses`; one whose `uses` names an ungranted capability is
+     * disabled with the missing paths recorded. Derivation overrides config
+     * enablement — config can narrow the derivable set, never widen past it.
+     */
+    grant?: import('./capability-grant.js').CapabilityGrant,
   ): FeatureSetsUpdateParams {
     // Cross-package compat: agent-framework's McplCapabilities types
     // featureSets as Record<string, FeatureSetDeclaration>, but mcpl-core-ts
@@ -180,6 +190,36 @@ export class FeatureSetManager {
     // Disable explicitly overrides enable (disable wins on conflict)
     for (const name of toDisable) {
       state.enabled.delete(name);
+    }
+
+    // §6.4 fail-closed derivation against the grant. Runs AFTER config
+    // resolution so it can only remove: nothing a declaration or a config
+    // says can supply a capability the grant lacks.
+    if (grant) {
+      for (const [name, decl] of Object.entries(declared)) {
+        const uses = (decl as { uses?: unknown }).uses;
+        if (!Array.isArray(uses) || uses.length === 0) {
+          if (state.enabled.delete(name) || true) {
+            console.error(`[mcpl] ${serverId}/${name} disabled: invalid_uses (§6.4 — uses absent or empty)`);
+          }
+          continue;
+        }
+        const unknown = uses.filter((u) => typeof u !== 'string' || !isKnownCapabilityPath(u));
+        if (unknown.length > 0) {
+          state.enabled.delete(name);
+          console.error(
+            `[mcpl] ${serverId}/${name} disabled: invalid_uses (§6.4 — unrecognized: ${unknown.join(', ')})`,
+          );
+          continue;
+        }
+        const missing = (uses as string[]).filter((u) => !grant.has(u));
+        if (missing.length > 0) {
+          state.enabled.delete(name);
+          console.error(
+            `[mcpl] ${serverId}/${name} disabled: missing capabilities ${missing.join(', ')} (§6.4)`,
+          );
+        }
+      }
     }
 
     this.servers.set(serverId, state);

--- a/src/mcpl/hook-orchestrator.ts
+++ b/src/mcpl/hook-orchestrator.ts
@@ -30,6 +30,15 @@ import type { FeatureSetManager } from './feature-set-manager.js';
 /** Timeout for beforeInference per server (fail-open). */
 const BEFORE_INFERENCE_TIMEOUT_MS = 5_000;
 
+/** The three injection positions and their §6.2 capability paths. Position
+ *  is the TYPED field on the injection — authorization never reads the
+ *  response's featureSet (§5.4). */
+const INJECT_LEAVES: ReadonlyArray<{ position: string; path: string }> = [
+  { position: 'system', path: 'contextHooks.beforeInference.inject.system' },
+  { position: 'beforeUser', path: 'contextHooks.beforeInference.inject.beforeUser' },
+  { position: 'afterUser', path: 'contextHooks.beforeInference.inject.afterUser' },
+];
+
 /** Timeout for blocking afterInference per server. */
 const AFTER_INFERENCE_BLOCKING_TIMEOUT_MS = 10_000;
 
@@ -141,7 +150,16 @@ export class HookOrchestrator {
    * Fail-open: servers that time out or error are silently skipped.
    */
   async beforeInference(params: BeforeInferenceParams): Promise<ContextInjection[]> {
-    const servers = this.registry.getServersWithCapability('contextHooks.beforeInference');
+    // §5.4: the GRANT decides fan-out, not the raw advertisement — which
+    // also fixes selection for the recursive §5.1 shape, where
+    // `beforeInference: {observe: true, …}` is an object, not `true`. A
+    // server granted any inject.* leaf but not observe is still CALLED
+    // (§10.1 — the hook is how injection happens) and receives
+    // `userMessage: null` instead of the user's text.
+    const servers = this.registry.getAllServers().filter((s) =>
+      s.grant.has('contextHooks.beforeInference.observe')
+      || INJECT_LEAVES.some((leaf) => s.grant.has(leaf.path)),
+    );
     if (servers.length === 0) {
       return [];
     }
@@ -184,13 +202,21 @@ export class HookOrchestrator {
     params: BeforeInferenceParams,
   ): Promise<ContextInjection[]> {
     const results = await Promise.allSettled(
-      servers.map((server) =>
-        withTimeout(
-          server.sendBeforeInference(params),
+      servers.map((server) => {
+        // §10.1: a server not granted observe MUST receive
+        // `userMessage: null` — the field is ABSENT authority, not merely
+        // discouraged — while the hook is still invoked so granted
+        // injection positions keep working (write-without-read).
+        const perServer: BeforeInferenceParams =
+          server.grant.has('contextHooks.beforeInference.observe')
+            ? params
+            : { ...params, userMessage: null };
+        return withTimeout(
+          server.sendBeforeInference(perServer),
           BEFORE_INFERENCE_TIMEOUT_MS,
           `beforeInference to "${server.id}"`,
-        ).then((result) => ({ server, result })),
-      ),
+        ).then((result) => ({ server, result }));
+      }),
     );
 
     const injections: ContextInjection[] = [];
@@ -203,7 +229,9 @@ export class HookOrchestrator {
 
       const { server, result } = settled.value;
 
-      // Validate feature set
+      // Feature-set discipline (diagnostics; §5.4 forbids using the
+      // response-supplied featureSet as AUTHORIZATION — that is the
+      // position check below).
       try {
         this.featureSetManager.validateInbound(server.id, result.featureSet);
       } catch {
@@ -211,9 +239,20 @@ export class HookOrchestrator {
         continue;
       }
 
-      // Convert wire-format injections to context-manager format
+      // §5.4/§10.8: authorize EACH injection by its typed position against
+      // the grant CURRENT NOW, at response receipt — not when the request
+      // was sent. A revocation that landed while the hook was in flight is
+      // enforced here without extra machinery.
       if (result.contextInjections && result.contextInjections.length > 0) {
         for (const mcplInj of result.contextInjections) {
+          const leaf = INJECT_LEAVES.find((l) => l.position === mcplInj.position);
+          if (!leaf || !server.grant.has(leaf.path)) {
+            console.error(
+              `[mcpl] ${server.id}: dropped beforeInference injection at position ` +
+                `"${mcplInj.position}" — not in the effective grant (§10.8)`,
+            );
+            continue;
+          }
           injections.push(convertMcplInjection(mcplInj));
         }
       }

--- a/src/mcpl/hook-orchestrator.ts
+++ b/src/mcpl/hook-orchestrator.ts
@@ -26,6 +26,7 @@ import type {
 import type { McplServerRegistry } from './server-registry.js';
 import type { McplServerConnection } from './server-connection.js';
 import type { FeatureSetManager } from './feature-set-manager.js';
+import { CapabilityGrant } from './capability-grant.js';
 
 /** Timeout for beforeInference per server (fail-open). */
 const BEFORE_INFERENCE_TIMEOUT_MS = 5_000;
@@ -154,8 +155,8 @@ export class HookOrchestrator {
     // (§10.1 — the hook is how injection happens) and receives
     // `userMessage: null` instead of the user's text.
     const servers = this.registry.getAllServers().filter((s) =>
-      s.grant.has('contextHooks.beforeInference.observe')
-      || INJECT_LEAVES.some((leaf) => s.grant.has(leaf.path)),
+      CapabilityGrant.of(s).has('contextHooks.beforeInference.observe')
+      || INJECT_LEAVES.some((leaf) => CapabilityGrant.of(s).has(leaf.path)),
     );
     if (servers.length === 0) {
       return [];
@@ -178,7 +179,7 @@ export class HookOrchestrator {
    */
   emitLifecycle(params: InferenceLifecycleParams): void {
     for (const server of this.registry.getAllServers()) {
-      if (!server.grant.has('inferenceLifecycle')) continue;
+      if (!CapabilityGrant.of(server).has('inferenceLifecycle')) continue;
       try {
         server.sendInferenceLifecycle(params);
       } catch {
@@ -202,7 +203,7 @@ export class HookOrchestrator {
         // discouraged — while the hook is still invoked so granted
         // injection positions keep working (write-without-read).
         const perServer: BeforeInferenceParams =
-          server.grant.has('contextHooks.beforeInference.observe')
+          CapabilityGrant.of(server).has('contextHooks.beforeInference.observe')
             ? params
             : { ...params, userMessage: null };
         return withTimeout(
@@ -240,7 +241,7 @@ export class HookOrchestrator {
       if (result.contextInjections && result.contextInjections.length > 0) {
         for (const mcplInj of result.contextInjections) {
           const leaf = INJECT_LEAVES.find((l) => l.position === mcplInj.position);
-          if (!leaf || !server.grant.has(leaf.path)) {
+          if (!leaf || !CapabilityGrant.of(server).has(leaf.path)) {
             console.error(
               `[mcpl] ${server.id}: dropped beforeInference injection at position ` +
                 `"${mcplInj.position}" — not in the effective grant (§10.8)`,

--- a/src/mcpl/hook-orchestrator.ts
+++ b/src/mcpl/hook-orchestrator.ts
@@ -3,8 +3,9 @@
  *
  * This is the bridge between the MCPL protocol and the agent-framework inference
  * pipeline. It collects ContextInjection[] from MCPL servers via beforeInference
- * and feeds them into context-manager's compile(). After inference, it notifies
- * servers of the result via afterInference.
+ * and feeds them into context-manager's compile(). Turn boundaries are announced
+ * via metadata-only `inference/lifecycle` notifications (§10.5) —
+ * context/afterInference and its modifiedResponse are removed in 0.5.0.
  *
  * Design principles:
  * - Fail-open: timeouts and errors never block inference
@@ -20,8 +21,7 @@ import type {
   McplContextInjection,
   BeforeInferenceParams,
   BeforeInferenceResult,
-  AfterInferenceParams,
-  AfterInferenceResult,
+  InferenceLifecycleParams,
 } from './types.js';
 import type { McplServerRegistry } from './server-registry.js';
 import type { McplServerConnection } from './server-connection.js';
@@ -38,9 +38,6 @@ const INJECT_LEAVES: ReadonlyArray<{ position: string; path: string }> = [
   { position: 'beforeUser', path: 'contextHooks.beforeInference.inject.beforeUser' },
   { position: 'afterUser', path: 'contextHooks.beforeInference.inject.afterUser' },
 ];
-
-/** Timeout for blocking afterInference per server. */
-const AFTER_INFERENCE_BLOCKING_TIMEOUT_MS = 10_000;
 
 /**
  * Races a promise against a timeout. Rejects with a descriptive error on timeout.
@@ -173,23 +170,20 @@ export class HookOrchestrator {
   }
 
   /**
-   * Fan out `context/afterInference` to all capable MCPL servers.
-   *
-   * Non-blocking servers receive a notification (fire-and-forget).
-   * Blocking servers receive a request with a 10s timeout.
-   * Returns the first valid AfterInferenceResult from a blocking server, or null.
+   * Fan out `inference/lifecycle` (§10.5) — the metadata-only replacement
+   * for context/afterInference. Notifications, fire-and-forget, gated on the
+   * inferenceLifecycle grant. BEST-EFFORT by design: the host attempts one
+   * terminal per `started` on every exit path it controls; consumers dedupe
+   * by inferenceId and keep a safety timeout. Never blocks the turn.
    */
-  async afterInference(params: AfterInferenceParams): Promise<AfterInferenceResult | null> {
-    const servers = this.registry.getServersWithCapability('contextHooks.afterInference');
-    if (servers.length === 0) {
-      return null;
-    }
-
-    this._isInHook = true;
-    try {
-      return await this.fanOutAfterInference(servers, params);
-    } finally {
-      this._isInHook = false;
+  emitLifecycle(params: InferenceLifecycleParams): void {
+    for (const server of this.registry.getAllServers()) {
+      if (!server.grant.has('inferenceLifecycle')) continue;
+      try {
+        server.sendInferenceLifecycle(params);
+      } catch {
+        /* best-effort — a failed notify never disturbs the turn */
+      }
     }
   }
 
@@ -261,60 +255,4 @@ export class HookOrchestrator {
     return injections;
   }
 
-  // ==========================================================================
-  // Private: afterInference fan-out
-  // ==========================================================================
-
-  private async fanOutAfterInference(
-    servers: McplServerConnection[],
-    params: AfterInferenceParams,
-  ): Promise<AfterInferenceResult | null> {
-    const blockingPromises: Promise<AfterInferenceResult | null>[] = [];
-
-    for (const server of servers) {
-      const isBlocking = this.isBlockingAfterInference(server);
-
-      if (isBlocking) {
-        // Send as request, await response with timeout
-        const promise = withTimeout(
-          server.sendAfterInference(params, true) as Promise<AfterInferenceResult>,
-          AFTER_INFERENCE_BLOCKING_TIMEOUT_MS,
-          `afterInference (blocking) to "${server.id}"`,
-        ).catch((): null => {
-          // Fail-open: timeout or error — treat as no modification
-          return null;
-        });
-        blockingPromises.push(promise);
-      } else {
-        // Send as notification (fire-and-forget)
-        server.sendAfterInference(params, false);
-      }
-    }
-
-    if (blockingPromises.length === 0) {
-      return null;
-    }
-
-    // Await all blocking responses and return the first valid result
-    const results = await Promise.all(blockingPromises);
-    for (const result of results) {
-      if (result && result.modifiedResponse) {
-        return result;
-      }
-    }
-
-    return null;
-  }
-
-  /**
-   * Check if a server's afterInference capability is blocking.
-   */
-  private isBlockingAfterInference(server: McplServerConnection): boolean {
-    const caps = server.capabilities;
-    if (!caps?.contextHooks?.afterInference) {
-      return false;
-    }
-    const afterCap = caps.contextHooks.afterInference;
-    return typeof afterCap === 'object' && afterCap !== null && 'blocking' in afterCap && afterCap.blocking === true;
-  }
 }

--- a/src/mcpl/push-handler.ts
+++ b/src/mcpl/push-handler.ts
@@ -165,7 +165,12 @@ export class PushHandler {
     params: PushEventParams,
     responder?: Responder,
   ): void {
-    // 1. Validate feature set
+    // 1. Validate feature set. §6.6: rejection is diagnostics, not
+    // authorization, and MUST be a JSON-RPC error object — not a result
+    // carrying a failure flag. (The old `{accepted:false, reason}` result
+    // was AUDIT-001's finding: the error factories existed and were never
+    // invoked.) Falls back to the result shape only for a legacy responder
+    // with no error path.
     try {
       this.featureSetManager.validateInbound(serverId, params.featureSet);
     } catch (err) {
@@ -175,7 +180,11 @@ export class PushHandler {
       // Loud rejection — a rejected push event is an agent that silently
       // never hears the message. (2026-07-09 diagnosability pass.)
       console.error(`[push-event-rejected] server=${serverId} eventId=${params.eventId} reason=${reason}`);
-      responder?.respond({ accepted: false, reason });
+      if (err instanceof McplFeatureSetError && responder?.respondError) {
+        responder.respondError(err.code, reason, { featureSet: err.featureSet });
+      } else {
+        responder?.respond({ accepted: false, reason });
+      }
       return;
     }
 

--- a/src/mcpl/push-handler.ts
+++ b/src/mcpl/push-handler.ts
@@ -16,6 +16,7 @@ import type {
 } from './types.js';
 import type { FeatureSetManager } from './feature-set-manager.js';
 import { McplFeatureSetError } from './feature-set-manager.js';
+import { expandCoreTags } from './tags.js';
 
 // ============================================================================
 // McplPushEvent (the ProcessEvent shape pushed to the queue)
@@ -165,6 +166,12 @@ export class PushHandler {
     params: PushEventParams,
     responder?: Responder,
   ): void {
+    // §16.3: expand the normative chat:* core closure once, at entry, so
+    // every downstream consumer (wake matching, metadata, the queued event)
+    // sees the closed set. Producer `implies` edges are NOT consumed —
+    // advisory pending acceptance (§16.4). Tags were admitted before this
+    // point and grant nothing (§16.6).
+    if (params.tags) params.tags = expandCoreTags(params.tags);
     // 1. Validate feature set. §6.6: rejection is diagnostics, not
     // authorization, and MUST be a JSON-RPC error object — not a result
     // carrying a failure flag. (The old `{accepted:false, reason}` result

--- a/src/mcpl/server-connection.ts
+++ b/src/mcpl/server-connection.ts
@@ -13,6 +13,7 @@ import { EventEmitter } from 'node:events';
 
 import { openTransport, type McplTransport, type TransportCloseInfo } from './transport.js';
 import { maskNegotiatedCapabilities } from './capability-mask.js';
+import { CapabilityGrant } from './capability-grant.js';
 import { CAPABILITY_DISABLED } from './errors.js';
 
 import type {
@@ -26,6 +27,7 @@ import type {
   AfterInferenceParams,
   AfterInferenceResult,
   FeatureSetsUpdateParams,
+  FeatureSetsUpdateResult,
   InferenceChunkParams,
   StateRollbackParams,
   StateRollbackResult,
@@ -110,6 +112,31 @@ export class McplServerConnection extends EventEmitter {
    *  last handshake (empty when no scoping is configured). Inbound methods
    *  gated by a masked capability are rejected in setupMessageRouting. */
   droppedCapabilities: ReadonlySet<string> = new Set();
+
+  /**
+   * The effective capability grant (§5.4) — the sole authorization
+   * allowlist for this connection. Starts EMPTY: until the initial policy
+   * exchange completes (§5.3) nothing is granted and every privileged
+   * inbound method is rejected. The framework computes the grant from the
+   * masked advertisement and activates it via establishGrant() only after
+   * the featureSets/update Request is answered (expansion activates on
+   * receipt, §6.7); revocations re-call establishGrant() BEFORE the
+   * corresponding Request is sent (reduction applies first, §6.7).
+   */
+  grant: CapabilityGrant = CapabilityGrant.empty();
+
+  /** True once the §5.3 initial policy Request has been answered. */
+  policyEstablished = false;
+
+  /**
+   * Activate (or replace) the effective grant. Ordering is the caller's
+   * contract per §6.7: call BEFORE sending a reducing featureSets/update,
+   * AFTER the receipt for an expanding one.
+   */
+  establishGrant(grant: CapabilityGrant): void {
+    this.grant = grant;
+    this.policyEstablished = true;
+  }
 
   /** The active transport (stdio child or WebSocket). Null for a disconnected
    *  stub awaiting its first background reconnect. */
@@ -467,9 +494,30 @@ export class McplServerConnection extends EventEmitter {
     return Promise.resolve();
   }
 
-  /** Send `featureSets/update` notification. */
+  /** Send `featureSets/update` as a Notification. §6.7: valid ONLY for
+   *  purely descriptive metadata that does not alter the grant. Any grant
+   *  change — including the §5.3 initial policy — MUST use the Request form
+   *  below. */
   sendFeatureSetsUpdate(params: FeatureSetsUpdateParams): void {
     this.sendNotification(McplMethod.FeatureSetsUpdate, params as unknown as Record<string, unknown>);
+  }
+
+  /**
+   * Send `featureSets/update` as a Request (§5.3, §6.7) and await the
+   * degradation receipt. A short timeout, distinct from tool-call timeouts:
+   * a pre-0.5 server treats the Request as a notification and never
+   * answers, and per §6.7 an unanswered expansion simply does not activate
+   * — the caller leaves the grant empty and the connection MCP-only.
+   */
+  sendFeatureSetsUpdateRequest(
+    params: FeatureSetsUpdateParams,
+    timeoutMs = 15_000,
+  ): Promise<FeatureSetsUpdateResult> {
+    return this.sendRequest(
+      McplMethod.FeatureSetsUpdate,
+      params as unknown as Record<string, unknown>,
+      { timeoutMs },
+    ) as Promise<FeatureSetsUpdateResult>;
   }
 
   /** Send `inference/chunk` notification. */
@@ -807,21 +855,30 @@ export class McplServerConnection extends EventEmitter {
   };
 
   /**
-   * Server-initiated methods gated by a maskable capability. When host
-   * capability scoping dropped the named path at handshake, the method is
-   * rejected (requests) or discarded (notifications) instead of emitted —
-   * a masked capability behaves as if never advertised, in both directions.
-   * Channel methods key on the bare `channels` path: it is recorded only
-   * when the entire channels capability was masked, so flag-level masking
-   * (e.g. `channels.streaming`) affects host-initiated behavior without
-   * cutting off inbound channel traffic.
+   * Inbound (server-initiated) method → required capability path, per SPEC
+   * §14.1's table plus the non-channel privileged methods. **Positive-grant
+   * enforcement** (§5.4): the method is admitted only when the effective
+   * grant contains the named path — absence is denial, and before the
+   * initial policy exchange completes the grant is empty, so everything
+   * privileged is rejected (§5.3).
+   *
+   * This replaces the earlier `droppedCapabilities` deny-list check, which
+   * could only deny what had been advertised-then-masked: a server that
+   * never advertised a capability at all was never denied. (Adjudicated in
+   * review of PR #75; the mask itself is retained as the config-policy
+   * layer feeding the grant.)
+   *
+   * Channel methods key on their specific sub-capabilities, not the bare
+   * `channels` parent — a bare parent grants nothing (§5.4).
    */
   private static readonly METHOD_TO_REQUIRED_CAPABILITY: Record<string, string> = {
     [McplMethod.PushEvent]: 'pushEvents',
     [McplMethod.InferenceRequest]: 'inferenceRequest',
-    [McplMethod.ChannelsRegister]: 'channels',
-    [McplMethod.ChannelsChanged]: 'channels',
-    [McplMethod.ChannelsIncoming]: 'channels',
+    [McplMethod.ModelInfo]: 'modelInfo',
+    [McplMethod.ChannelsRegister]: 'channels.register',
+    [McplMethod.ChannelsChanged]: 'channels.register',
+    [McplMethod.ChannelsIncoming]: 'channels.incoming',
+    [McplMethod.ChannelsList]: 'channels.register',
   };
 
   /**
@@ -860,15 +917,34 @@ export class McplServerConnection extends EventEmitter {
       const request = msg as JsonRpcRequest;
       const eventName = McplServerConnection.METHOD_TO_EVENT[request.method];
 
-      // Enforce host capability scoping on server-initiated traffic.
+      // §7 is removed in 0.5.0: scope/elevate is no longer a method. Answer
+      // rather than hang (§6.6 — a method that will never be answered MUST
+      // return an error).
+      if (request.method === McplMethod.ScopeElevate) {
+        if (request.id != null) {
+          this.sendErrorResponse(request.id, -32601, 'scope/elevate removed in MCPL 0.5.0 (SPEC §7)');
+        }
+        return;
+      }
+
+      // Positive-grant enforcement on server-initiated traffic (§5.4, §14.1).
+      // The grant is empty until the initial policy exchange completes
+      // (§5.3), so privileged methods are rejected fail-closed in that
+      // window too. Requests get -32002 with data:{capability} (§6.6);
+      // notifications are discarded with a diagnostic — a rejection can
+      // never be smuggled back as authorization either way.
       const requiredCap = McplServerConnection.METHOD_TO_REQUIRED_CAPABILITY[request.method];
-      if (requiredCap && this.droppedCapabilities.has(requiredCap)) {
+      if (requiredCap && !this.grant.has(requiredCap)) {
+        const phase = this.policyEstablished ? 'not in the effective grant' : 'initial policy not yet established (§5.3)';
         if (request.id != null) {
           this.sendErrorResponse(
             request.id,
             CAPABILITY_DISABLED,
-            `${request.method} rejected: capability "${requiredCap}" is disabled for this server by host configuration`,
+            `${request.method} rejected: capability "${requiredCap}" ${phase}`,
+            { capability: requiredCap },
           );
+        } else {
+          console.error(`[mcpl] ${this.id}: discarded ${request.method} — "${requiredCap}" ${phase}`);
         }
         return;
       }

--- a/src/mcpl/server-connection.ts
+++ b/src/mcpl/server-connection.ts
@@ -12,6 +12,8 @@
 import { EventEmitter } from 'node:events';
 
 import { openTransport, type McplTransport, type TransportCloseInfo } from './transport.js';
+import { maskNegotiatedCapabilities } from './capability-mask.js';
+import { CAPABILITY_DISABLED } from './errors.js';
 
 import type {
   McplServerConfig,
@@ -99,8 +101,15 @@ export class McplServerConnection extends EventEmitter {
   /** Unique server identifier from config. */
   readonly id: string;
 
-  /** MCPL capabilities negotiated during the initialize handshake, or null if the server does not support MCPL. */
+  /** MCPL capabilities negotiated during the initialize handshake — after
+   *  host-side capability scoping (enabledCapabilities/disabledCapabilities)
+   *  — or null if the server does not support MCPL. */
   capabilities: McplCapabilities | null;
+
+  /** Dotted paths of advertised capabilities the host config masked at the
+   *  last handshake (empty when no scoping is configured). Inbound methods
+   *  gated by a masked capability are rejected in setupMessageRouting. */
+  droppedCapabilities: ReadonlySet<string> = new Set();
 
   /** The active transport (stdio child or WebSocket). Null for a disconnected
    *  stub awaiting its first background reconnect. */
@@ -273,9 +282,10 @@ export class McplServerConnection extends EventEmitter {
     config: McplServerConfig,
     hostCapabilities: McplHostCapabilities,
   ): Promise<McplServerConnection> {
-    const { transport, capabilities } = await McplServerConnection.handshake(config, hostCapabilities);
+    const { transport, capabilities, droppedCapabilities } = await McplServerConnection.handshake(config, hostCapabilities);
 
     const connection = new McplServerConnection(config.id, capabilities, transport);
+    connection.droppedCapabilities = droppedCapabilities;
     connection.requestTimeoutMs = config.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
 
     // Store config for reconnection
@@ -300,7 +310,7 @@ export class McplServerConnection extends EventEmitter {
   private static async handshake(
     config: McplServerConfig,
     hostCapabilities: McplHostCapabilities,
-  ): Promise<{ transport: McplTransport; capabilities: McplCapabilities | null }> {
+  ): Promise<{ transport: McplTransport; capabilities: McplCapabilities | null; droppedCapabilities: ReadonlySet<string> }> {
     const transport = await openTransport(config);
 
     try {
@@ -365,7 +375,15 @@ export class McplServerConnection extends EventEmitter {
       // Send `initialized` notification (no id)
       transport.writeLine(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }));
 
-      return { transport, capabilities };
+      // Host-side capability scoping: intersect the server's advertisement
+      // with config policy so a masked capability behaves exactly as if it
+      // had never been advertised (hooks, streaming, queries all read this).
+      const { capabilities: scoped, dropped } = maskNegotiatedCapabilities(capabilities, config);
+      if (dropped.length > 0) {
+        console.error(`MCPL server "${config.id}" capabilities masked by host config: ${dropped.join(', ')}`);
+      }
+
+      return { transport, capabilities: scoped, droppedCapabilities: new Set(dropped) };
     } catch (err) {
       // Never leak the child / socket if the handshake fails.
       await transport.close().catch(() => { /* best effort */ });
@@ -663,7 +681,7 @@ export class McplServerConnection extends EventEmitter {
     const attempt = Math.max(1, this.reconnectAttempts);
 
     try {
-      const { transport, capabilities } = await McplServerConnection.handshake(
+      const { transport, capabilities, droppedCapabilities } = await McplServerConnection.handshake(
         this.config,
         this.hostCapabilities,
       );
@@ -675,6 +693,7 @@ export class McplServerConnection extends EventEmitter {
       this.pauseDataPlane();
       this.transport = transport;
       this.capabilities = capabilities;
+      this.droppedCapabilities = droppedCapabilities;
       this.closed = false;
       this.nextRequestId = 1;
       this.pendingRequests.clear();
@@ -788,6 +807,24 @@ export class McplServerConnection extends EventEmitter {
   };
 
   /**
+   * Server-initiated methods gated by a maskable capability. When host
+   * capability scoping dropped the named path at handshake, the method is
+   * rejected (requests) or discarded (notifications) instead of emitted —
+   * a masked capability behaves as if never advertised, in both directions.
+   * Channel methods key on the bare `channels` path: it is recorded only
+   * when the entire channels capability was masked, so flag-level masking
+   * (e.g. `channels.streaming`) affects host-initiated behavior without
+   * cutting off inbound channel traffic.
+   */
+  private static readonly METHOD_TO_REQUIRED_CAPABILITY: Record<string, string> = {
+    [McplMethod.PushEvent]: 'pushEvents',
+    [McplMethod.InferenceRequest]: 'inferenceRequest',
+    [McplMethod.ChannelsRegister]: 'channels',
+    [McplMethod.ChannelsChanged]: 'channels',
+    [McplMethod.ChannelsIncoming]: 'channels',
+  };
+
+  /**
    * Bind all transport-level handlers (inbound routing, lifecycle, stderr) to a
    * transport. Called from the constructor and again from attemptReconnect when
    * a new transport is adopted.
@@ -822,6 +859,19 @@ export class McplServerConnection extends EventEmitter {
       // It is an inbound request or notification from the server
       const request = msg as JsonRpcRequest;
       const eventName = McplServerConnection.METHOD_TO_EVENT[request.method];
+
+      // Enforce host capability scoping on server-initiated traffic.
+      const requiredCap = McplServerConnection.METHOD_TO_REQUIRED_CAPABILITY[request.method];
+      if (requiredCap && this.droppedCapabilities.has(requiredCap)) {
+        if (request.id != null) {
+          this.sendErrorResponse(
+            request.id,
+            CAPABILITY_DISABLED,
+            `${request.method} rejected: capability "${requiredCap}" is disabled for this server by host configuration`,
+          );
+        }
+        return;
+      }
 
       if (eventName) {
         // Emit the typed event with params and (for requests) a respond callback

--- a/src/mcpl/server-connection.ts
+++ b/src/mcpl/server-connection.ts
@@ -13,7 +13,7 @@ import { EventEmitter } from 'node:events';
 
 import { openTransport, type McplTransport, type TransportCloseInfo } from './transport.js';
 import { maskNegotiatedCapabilities } from './capability-mask.js';
-import { CapabilityGrant } from './capability-grant.js';
+import { CapabilityGrant, expandAdvertisementShorthand } from './capability-grant.js';
 import { CAPABILITY_DISABLED } from './errors.js';
 
 import type {
@@ -93,7 +93,6 @@ interface RequestOptions {
  * - `'channels-register'`  — Server sent `channels/register`
  * - `'channels-changed'`   — Server sent `channels/changed`
  * - `'channels-incoming'`  — Server sent `channels/incoming`
- * - `'feature-sets-changed'` — Server sent `featureSets/changed`
  * - `'error'`              — Connection-level error
  * - `'close'`              — Connection closed
  * - `'connect-failed'`     — Initial connect failed; background retry scheduled
@@ -113,6 +112,10 @@ export class McplServerConnection extends EventEmitter {
    *  last handshake (empty when no scoping is configured). Inbound methods
    *  gated by a masked capability are rejected in setupMessageRouting. */
   droppedCapabilities: ReadonlySet<string> = new Set();
+
+  /** OUTER standard MCP capabilities.tools was present at handshake (§5.1 —
+   *  the sole source of the `tools` capability path). */
+  mcpToolsAdvertised = false;
 
   /**
    * The effective capability grant (§5.4) — the sole authorization
@@ -313,7 +316,6 @@ export class McplServerConnection extends EventEmitter {
       || event === 'scope-elevate'
       || event === 'channels-register'
       || event === 'channels-changed'
-      || event === 'feature-sets-changed'
       || event === 'tools-list-changed'
       || event === 'connect-failed'
       || event === 'reconnect-failed'
@@ -342,10 +344,11 @@ export class McplServerConnection extends EventEmitter {
     config: McplServerConfig,
     hostCapabilities: McplHostCapabilities,
   ): Promise<McplServerConnection> {
-    const { transport, capabilities, droppedCapabilities } = await McplServerConnection.handshake(config, hostCapabilities);
+    const { transport, capabilities, droppedCapabilities, mcpToolsAdvertised } = await McplServerConnection.handshake(config, hostCapabilities);
 
     const connection = new McplServerConnection(config.id, capabilities, transport);
     connection.droppedCapabilities = droppedCapabilities;
+    connection.mcpToolsAdvertised = mcpToolsAdvertised;
     connection.requestTimeoutMs = config.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
 
     // Store config for reconnection
@@ -370,7 +373,7 @@ export class McplServerConnection extends EventEmitter {
   private static async handshake(
     config: McplServerConfig,
     hostCapabilities: McplHostCapabilities,
-  ): Promise<{ transport: McplTransport; capabilities: McplCapabilities | null; droppedCapabilities: ReadonlySet<string> }> {
+  ): Promise<{ transport: McplTransport; capabilities: McplCapabilities | null; droppedCapabilities: ReadonlySet<string>; mcpToolsAdvertised: boolean }> {
     const transport = await openTransport(config);
 
     try {
@@ -388,7 +391,7 @@ export class McplServerConnection extends EventEmitter {
 
       // Await the initialize response, racing an early transport close/error and
       // a timeout. All three paths clean up their listeners.
-      const capabilities = await new Promise<McplCapabilities | null>((resolve, reject) => {
+      const { mcpl: rawCapabilities, mcpToolsAdvertised } = await new Promise<{ mcpl: McplCapabilities | null; mcpToolsAdvertised: boolean }>((resolve, reject) => {
         const cleanup = () => {
           transport.off('line', onLine);
           transport.off('close', onClose);
@@ -411,7 +414,13 @@ export class McplServerConnection extends EventEmitter {
           const result = msg.result as Record<string, unknown> | undefined;
           const caps = result?.capabilities as Record<string, unknown> | undefined;
           const experimental = caps?.experimental as Record<string, unknown> | undefined;
-          resolve((experimental?.mcpl as McplCapabilities) ?? null);
+          // §5.1: `tools` capability is the OUTER standard MCP member — the
+          // experimental manifest cannot mint it. Carried alongside so the
+          // grant can join it into §6.4 derivation.
+          resolve({
+            mcpl: (experimental?.mcpl as McplCapabilities) ?? null,
+            mcpToolsAdvertised: caps?.tools !== undefined,
+          });
         };
         const onClose = (info: TransportCloseInfo) => {
           cleanup();
@@ -435,6 +444,11 @@ export class McplServerConnection extends EventEmitter {
       // Send `initialized` notification (no id)
       transport.writeLine(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }));
 
+      // §5.1 boolean shorthand expands to explicit leaves BEFORE the config
+      // mask runs, so sub-leaf policy is addressable — `channels: true` with
+      // `disabledCapabilities: ['channels.streaming']` must actually drop
+      // streaming (PR #79 review blocker 1).
+      const capabilities = expandAdvertisementShorthand(rawCapabilities);
       // Host-side capability scoping: intersect the server's advertisement
       // with config policy so a masked capability behaves exactly as if it
       // had never been advertised (hooks, streaming, queries all read this).
@@ -443,7 +457,7 @@ export class McplServerConnection extends EventEmitter {
         console.error(`MCPL server "${config.id}" capabilities masked by host config: ${dropped.join(', ')}`);
       }
 
-      return { transport, capabilities: scoped, droppedCapabilities: new Set(dropped) };
+      return { transport, capabilities: scoped, droppedCapabilities: new Set(dropped), mcpToolsAdvertised };
     } catch (err) {
       // Never leak the child / socket if the handshake fails.
       await transport.close().catch(() => { /* best effort */ });
@@ -767,7 +781,7 @@ export class McplServerConnection extends EventEmitter {
     const attempt = Math.max(1, this.reconnectAttempts);
 
     try {
-      const { transport, capabilities, droppedCapabilities } = await McplServerConnection.handshake(
+      const { transport, capabilities, droppedCapabilities, mcpToolsAdvertised } = await McplServerConnection.handshake(
         this.config,
         this.hostCapabilities,
       );
@@ -780,6 +794,7 @@ export class McplServerConnection extends EventEmitter {
       this.transport = transport;
       this.capabilities = capabilities;
       this.droppedCapabilities = droppedCapabilities;
+      this.mcpToolsAdvertised = mcpToolsAdvertised;
       this.closed = false;
       this.nextRequestId = 1;
       this.pendingRequests.clear();
@@ -884,7 +899,6 @@ export class McplServerConnection extends EventEmitter {
     [McplMethod.ChannelsRegister]: 'channels-register',
     [McplMethod.ChannelsChanged]: 'channels-changed',
     [McplMethod.ChannelsIncoming]: 'channels-incoming',
-    [McplMethod.FeatureSetsChanged]: 'feature-sets-changed',
     // §6.6/§12: a request bearing an id MUST get a result or an error —
     // neither of these had an entry, so callers hung forever (AUDIT-001
     // item 4, which also poisoned the audit's own usage evidence).
@@ -963,6 +977,20 @@ export class McplServerConnection extends EventEmitter {
       // §7 is removed in 0.5.0: scope/elevate is no longer a method. Answer
       // rather than hang (§6.6 — a method that will never be answered MUST
       // return an error).
+      // featureSets/changed is REMOVED in 0.5.0 (§6.7 — it carried a
+      // server-authored change payload, the self-attestation defect; the
+      // need is met by §17's host-diffed manifest fetch). It was still
+      // routed, control-plane classified, and mutating declarations — a
+      // live ungated self-attestation path (PR #79 review blocker 4).
+      if (request.method === McplMethod.FeatureSetsChanged) {
+        if (request.id != null) {
+          this.sendErrorResponse(request.id, -32601, 'featureSets/changed removed in MCPL 0.5.0 (superseded by mcpl/manifestChanged, SPEC §17)');
+        } else {
+          console.error(`[mcpl] ${this.id}: discarded featureSets/changed — removed in 0.5.0 (§6.7/§17)`);
+        }
+        return;
+      }
+
       if (request.method === McplMethod.ScopeElevate) {
         if (request.id != null) {
           this.sendErrorResponse(request.id, -32601, 'scope/elevate removed in MCPL 0.5.0 (SPEC §7)');

--- a/src/mcpl/server-connection.ts
+++ b/src/mcpl/server-connection.ts
@@ -29,6 +29,7 @@ import type {
   FeatureSetsUpdateParams,
   FeatureSetsUpdateResult,
   InferenceChunkParams,
+  InferenceLifecycleParams,
   StateRollbackParams,
   StateRollbackResult,
   ChannelsOpenParams,
@@ -525,6 +526,11 @@ export class McplServerConnection extends EventEmitter {
     this.sendNotification(McplMethod.InferenceChunk, params as unknown as Record<string, unknown>);
   }
 
+  /** Send `inference/lifecycle` notification (§10.5). Best-effort. */
+  sendInferenceLifecycle(params: InferenceLifecycleParams): void {
+    this.sendNotification(McplMethod.InferenceLifecycle, params as unknown as Record<string, unknown>);
+  }
+
   /** Send `state/rollback` request and await result. */
   sendStateRollback(params: StateRollbackParams): Promise<StateRollbackResult> {
     return this.sendRequest(McplMethod.StateRollback, params as unknown as Record<string, unknown>) as Promise<StateRollbackResult>;
@@ -847,6 +853,11 @@ export class McplServerConnection extends EventEmitter {
     [McplMethod.ChannelsChanged]: 'channels-changed',
     [McplMethod.ChannelsIncoming]: 'channels-incoming',
     [McplMethod.FeatureSetsChanged]: 'feature-sets-changed',
+    // §6.6/§12: a request bearing an id MUST get a result or an error —
+    // neither of these had an entry, so callers hung forever (AUDIT-001
+    // item 4, which also poisoned the audit's own usage evidence).
+    [McplMethod.ModelInfo]: 'model-info',
+    [McplMethod.ChannelsList]: 'channels-list',
     'notifications/tools/list_changed': 'tools-list-changed',
     // Host-level admin commands initiated from a surface (e.g. a Discord
     // slash command). Params: { command, ... }; host responds with a

--- a/src/mcpl/server-connection.ts
+++ b/src/mcpl/server-connection.ts
@@ -117,6 +117,11 @@ export class McplServerConnection extends EventEmitter {
    *  the sole source of the `tools` capability path). */
   mcpToolsAdvertised = false;
 
+  /** Host-owned per-server authority for host/command (config
+   *  allowHostCommands, default false). No capability path exists and the
+   *  grant cannot confer it — server params never decide admin authority. */
+  allowHostCommands = false;
+
   /**
    * The effective capability grant (§5.4) — the sole authorization
    * allowlist for this connection. Starts EMPTY: until the initial policy
@@ -237,18 +242,15 @@ export class McplServerConnection extends EventEmitter {
   readyControlPlane(): void {
     this.controlPlaneReady = true;
     const pending = this.bufferedEvents;
-    const deferred: Array<{ event: string; args: unknown[] }> = [];
     this.bufferedEvents = [];
     for (const item of pending) {
-      if (McplServerConnection.isControlPlaneEvent(item.event)) {
-        super.emit(item.event, ...item.args);
-      } else {
-        deferred.push(item);
-      }
+      // Re-enter the ADMISSION gate (this.emit), never super.emit: control
+      // events include channels-register/changed, which are grant-gated —
+      // the old direct flush bypassed positive-grant enforcement entirely
+      // (PR #79 review blocker 3). Data-plane items re-buffer in order via
+      // the same call, since dataPlaneReady is still false.
+      this.emit(item.event, ...item.args);
     }
-    // Data events emitted by control handlers while the snapshot was flushing
-    // were appended to the new buffer. Preserve their order behind older data.
-    this.bufferedEvents = [...deferred, ...this.bufferedEvents];
   }
 
   /**
@@ -282,6 +284,19 @@ export class McplServerConnection extends EventEmitter {
       // both bounced conforming servers' startup pushes and made a FAILED
       // startup observable to the server (a response where the ledger said
       // nothing was released).
+      // host/command: host-owned authority, not a capability — no §6.2 path
+      // exists and none is invented here. Default DENY; only the operator's
+      // config confers it (PR #79 review blocker 9: any server could
+      // request undo/hide/unstick).
+      if (name === 'host-command' && !this.allowHostCommands) {
+        const responder = args[1] as { respondError?: (code: number, message: string, data?: unknown) => void } | undefined;
+        if (responder?.respondError) {
+          responder.respondError(CAPABILITY_DISABLED, 'host/command requires host-owned authority (McplServerConfig.allowHostCommands)', {});
+        } else {
+          console.error(`[mcpl] ${this.id}: discarded host/command — allowHostCommands not set`);
+        }
+        return true;
+      }
       const requiredCap = McplServerConnection.EVENT_TO_REQUIRED_CAPABILITY[name];
       if (requiredCap && !this.grant.has(requiredCap)) {
         const phase = this.policyEstablished ? 'not in the effective grant' : 'initial policy not yet established (§5.3)';
@@ -349,6 +364,7 @@ export class McplServerConnection extends EventEmitter {
     const connection = new McplServerConnection(config.id, capabilities, transport);
     connection.droppedCapabilities = droppedCapabilities;
     connection.mcpToolsAdvertised = mcpToolsAdvertised;
+    connection.allowHostCommands = config.allowHostCommands === true;
     connection.requestTimeoutMs = config.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
 
     // Store config for reconnection
@@ -795,6 +811,7 @@ export class McplServerConnection extends EventEmitter {
       this.capabilities = capabilities;
       this.droppedCapabilities = droppedCapabilities;
       this.mcpToolsAdvertised = mcpToolsAdvertised;
+      this.allowHostCommands = this.config?.allowHostCommands === true;
       this.closed = false;
       this.nextRequestId = 1;
       this.pendingRequests.clear();

--- a/src/mcpl/server-connection.ts
+++ b/src/mcpl/server-connection.ts
@@ -270,11 +270,43 @@ export class McplServerConnection extends EventEmitter {
         ? this.controlPlaneReady
         : this.dataPlaneReady)
     ) {
+      // Positive-grant admission (§5.4/§14.1), at the single choke-point
+      // every path shares: live routing AND buffer flushes re-enter here, so
+      // an event buffered while the connection was staged is authorized
+      // against the grant current at ADMISSION — by which time the §5.3
+      // policy exchange has settled. Rejecting earlier (at line receipt)
+      // answered staged traffic with -32002 before the grant existed, which
+      // both bounced conforming servers' startup pushes and made a FAILED
+      // startup observable to the server (a response where the ledger said
+      // nothing was released).
+      const requiredCap = McplServerConnection.EVENT_TO_REQUIRED_CAPABILITY[name];
+      if (requiredCap && !this.grant.has(requiredCap)) {
+        const phase = this.policyEstablished ? 'not in the effective grant' : 'initial policy not yet established (§5.3)';
+        const responder = args[1] as { respondError?: (code: number, message: string, data?: unknown) => void } | undefined;
+        if (responder?.respondError) {
+          responder.respondError(CAPABILITY_DISABLED, `${name} rejected: capability "${requiredCap}" ${phase}`, { capability: requiredCap });
+        } else {
+          console.error(`[mcpl] ${this.id}: discarded ${name} — "${requiredCap}" ${phase}`);
+        }
+        return true;
+      }
       return super.emit(event, ...args);
     }
     this.bufferedEvents.push({ event: name, args });
     return true;
   }
+
+  /** Event-name form of METHOD_TO_REQUIRED_CAPABILITY, for admission-time
+   *  enforcement in emit(). */
+  private static readonly EVENT_TO_REQUIRED_CAPABILITY: Record<string, string> = {
+    'push-event': 'pushEvents',
+    'inference-request': 'inferenceRequest',
+    'model-info': 'modelInfo',
+    'channels-register': 'channels.register',
+    'channels-changed': 'channels.register',
+    'channels-incoming': 'channels.incoming',
+    'channels-list': 'channels.register',
+  };
 
   private static isControlPlaneEvent(event: string): boolean {
     return event === 'stderr'
@@ -938,27 +970,10 @@ export class McplServerConnection extends EventEmitter {
         return;
       }
 
-      // Positive-grant enforcement on server-initiated traffic (§5.4, §14.1).
-      // The grant is empty until the initial policy exchange completes
-      // (§5.3), so privileged methods are rejected fail-closed in that
-      // window too. Requests get -32002 with data:{capability} (§6.6);
-      // notifications are discarded with a diagnostic — a rejection can
-      // never be smuggled back as authorization either way.
-      const requiredCap = McplServerConnection.METHOD_TO_REQUIRED_CAPABILITY[request.method];
-      if (requiredCap && !this.grant.has(requiredCap)) {
-        const phase = this.policyEstablished ? 'not in the effective grant' : 'initial policy not yet established (§5.3)';
-        if (request.id != null) {
-          this.sendErrorResponse(
-            request.id,
-            CAPABILITY_DISABLED,
-            `${request.method} rejected: capability "${requiredCap}" ${phase}`,
-            { capability: requiredCap },
-          );
-        } else {
-          console.error(`[mcpl] ${this.id}: discarded ${request.method} — "${requiredCap}" ${phase}`);
-        }
-        return;
-      }
+      // Positive-grant enforcement (§5.4, §14.1) happens at ADMISSION, in
+      // the emit() override below — the one choke-point that live routing
+      // and staged-buffer flushes share. See the comment there for why
+      // rejecting here, at line receipt, was wrong for staged connections.
 
       if (eventName) {
         // Emit the typed event with params and (for requests) a respond callback

--- a/src/mcpl/server-registry.ts
+++ b/src/mcpl/server-registry.ts
@@ -107,7 +107,10 @@ export class McplServerRegistry {
         case 'pushEvents':
           return caps.pushEvents === true;
         case 'contextHooks.beforeInference':
-          return caps.contextHooks?.beforeInference === true;
+          // Truthy, not ===true: §5.1 shorthand is expanded to the object
+          // form at handshake. (Prefer connection.grant for authorization —
+          // this query is advertisement-level only.)
+          return !!caps.contextHooks?.beforeInference;
         case 'contextHooks.afterInference':
           return !!caps.contextHooks?.afterInference;
         case 'inferenceRequest':

--- a/src/mcpl/server-registry.ts
+++ b/src/mcpl/server-registry.ts
@@ -111,8 +111,6 @@ export class McplServerRegistry {
           // form at handshake. (Prefer connection.grant for authorization —
           // this query is advertisement-level only.)
           return !!caps.contextHooks?.beforeInference;
-        case 'contextHooks.afterInference':
-          return !!caps.contextHooks?.afterInference;
         case 'inferenceRequest':
           return !!caps.inferenceRequest;
         case 'modelInfo':

--- a/src/mcpl/tags.ts
+++ b/src/mcpl/tags.ts
@@ -1,0 +1,50 @@
+/**
+ * Event-tag core closure (SPEC §16.3) and the addressed/ambient resolution.
+ *
+ * The `chat:*` core implications are NORMATIVE and spec-defined — a host
+ * expands them itself and never needs the producer's ontology to do so.
+ * Producer `implies` edges are advisory pending explicit acceptance (§16.4)
+ * and are NOT consumed here. Producer `suggestedTreatment` MUST NOT be
+ * auto-applied (§16.5) — nothing in this module reads it, deliberately.
+ *
+ * Tags are never authority (§16.6): expansion happens after admission, and
+ * nothing downstream may grant, admit, or authorize based on a tag.
+ */
+
+/** Normative core closure edges (§16.3). Closed vocabulary — chat:* only. */
+const CORE_IMPLIES: Readonly<Record<string, readonly string[]>> = {
+  'chat:mention': ['chat:addressed'],
+  'chat:reply': ['chat:addressed'],
+  'chat:dm': ['chat:addressed', 'chat:private'],
+};
+
+/**
+ * Expand a raw tag list over the normative core closure, then resolve the
+ * §16.2 mutual exclusion: `chat:addressed` and `chat:ambient` cannot both
+ * stand after expansion, and addressed wins — a message that is both
+ * specifically-to-you and background noise is specifically-to-you.
+ *
+ * Pure; input order is preserved for the tags that survive, with implied
+ * tags appended in first-cause order. Unknown and producer-namespaced tags
+ * pass through untouched.
+ */
+export function expandCoreTags(tags: readonly string[] | undefined): string[] {
+  if (!tags || tags.length === 0) return [];
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const add = (t: string): void => {
+    if (!seen.has(t)) {
+      seen.add(t);
+      out.push(t);
+    }
+  };
+  for (const t of tags) {
+    add(t);
+    for (const implied of CORE_IMPLIES[t] ?? []) add(implied);
+  }
+  if (seen.has('chat:addressed') && seen.has('chat:ambient')) {
+    const i = out.indexOf('chat:ambient');
+    if (i >= 0) out.splice(i, 1);
+  }
+  return out;
+}

--- a/src/mcpl/types.ts
+++ b/src/mcpl/types.ts
@@ -383,15 +383,50 @@ export interface FeatureSetDeclaration {
  * Spec Section 6.7.
  */
 export interface FeatureSetsUpdateParams {
-  /** Feature sets to enable */
+  /**
+   * The effective capability grant (§5.4) — the sole normative allowlist.
+   * Full §6.2 paths. Absence of a path is denial. In the Request form an
+   * absent FIELD is a grant of nothing (§5.3 as pinned 2026-08-02), never
+   * "no change".
+   */
+  effectiveCapabilities?: string[];
+
+  /** Advertised-but-denied paths. Diagnostic only (§5.4) — MUST NOT
+   *  participate in any authorization decision on either side. */
+  deniedCapabilities?: string[];
+
+  /** Feature sets to enable. Absent = no constraint (derivation governs);
+   *  present = allowlist (§5.3 as pinned). */
   enabled?: string[];
 
   /** Feature sets to disable */
   disabled?: string[];
-
-  /** Scope configurations per feature set */
-  scopes?: Record<string, ScopeConfig>;
 }
+
+/**
+ * featureSets/update result — the degradation receipt (§6.7). Consequence
+ * testimony, never policy authority: the host MUST NOT widen any grant in
+ * response to anything in here.
+ */
+export type FeatureSetsUpdateResult =
+  | {
+      accepted: true;
+      /** Omitted when nothing degraded (§6.7). */
+      mode?: 'degraded';
+      unavailableFeatures?: Array<{
+        featureSet: string;
+        missingCapabilities: string[];
+        effect: string;
+      }>;
+      notes?: string[];
+    }
+  | {
+      accepted: false;
+      /** REQUIRED on refusal (§6.7): the server names which applies. */
+      fallback: 'mcp-only' | 'close';
+      missingCapabilities?: string[];
+      reason?: string;
+    };
 
 /**
  * featureSets/changed params (Server → Host, Notification).

--- a/src/mcpl/types.ts
+++ b/src/mcpl/types.ts
@@ -666,14 +666,20 @@ export interface McplModelInfo {
   /** Model identifier (e.g., "claude-opus-4-5-20251101") */
   id: string;
 
-  /** Model vendor (e.g., "anthropic") */
-  vendor: string;
+  /** Model vendor (e.g., "anthropic"). Omitted when the host has no
+   *  truthful source — never fabricated. */
+  vendor?: string;
 
-  /** Context window size in tokens */
-  contextWindow: number;
+  /** Context window size in tokens. Omitted when unknown (a numeric field
+   *  cannot express "unknown", and a fabricated 200000 was false for
+   *  residents configured at 300k/600k — PR #79 review). The §12.2
+   *  model/info RESULT requires it, which is why this host does not
+   *  advertise modelInfo; hook params carry honesty-over-completeness. */
+  contextWindow?: number;
 
-  /** Model capabilities (e.g., ["vision", "tools"]) */
-  capabilities: string[];
+  /** Model capabilities (e.g., ["vision", "tools"]). Omitted when the
+   *  host has no truthful source. */
+  capabilities?: string[];
 }
 
 /**

--- a/src/mcpl/types.ts
+++ b/src/mcpl/types.ts
@@ -622,6 +622,22 @@ export interface PushEventResult {
  * Distinct from membrane's ModelInfo which tracks requested vs actual model.
  * Spec Section 10.1.
  */
+/**
+ * inference/lifecycle params (Host → Server, Notification). SPEC §10.5.
+ *
+ * BEST-EFFORT: the host attempts exactly one terminal phase per `started`
+ * on every exit path it controls, but an unacknowledged Notification cannot
+ * guarantee delivery — consumers MUST dedupe by inferenceId and MUST retain
+ * a safety timeout. Carries no content: `modifiedResponse` and the blocking
+ * hook form are gone with context/afterInference.
+ */
+export interface InferenceLifecycleParams {
+  inferenceId: string;
+  conversationId: string;
+  turnIndex: number;
+  phase: 'started' | 'completed' | 'aborted' | 'failed';
+}
+
 export interface McplModelInfo {
   /** Model identifier (e.g., "claude-opus-4-5-20251101") */
   id: string;
@@ -927,7 +943,14 @@ export interface ChannelsRegisterParams {
  * channels/register result (Host → Server).
  */
 export interface ChannelsRegisterResult {
+  /** Legacy pre-0.5 field: ids accepted. Kept for un-migrated servers. */
   registered: string[];
+  /**
+   * §14.5 itemized results — one entry per SUBMITTED descriptor. 0.5
+   * servers key off this: a missing verdict is not a verdict, and a result
+   * without `results` is read by strict servers as accepting nothing.
+   */
+  results: Array<{ id: string; accepted: boolean; reason?: string }>;
 }
 
 /**
@@ -1142,6 +1165,10 @@ export const McplMethod = {
 
   // Model info (Server → Host)
   ModelInfo: 'model/info',
+
+  // Inference lifecycle (Host → Server, Notification) — §10.5, replaces
+  // context/afterInference. Metadata only; BEST-EFFORT delivery.
+  InferenceLifecycle: 'inference/lifecycle',
 
   // Feature sets
   FeatureSetsUpdate: 'featureSets/update',

--- a/src/mcpl/types.ts
+++ b/src/mcpl/types.ts
@@ -99,22 +99,32 @@ export interface McplResourceContent {
  * Parsed from the server's `initialize` response.
  */
 export interface McplCapabilities {
-  /** MCPL protocol version (e.g., "0.4") */
+  /** MCPL protocol version (e.g., "0.5") */
   version: string;
+
+  /** §17.2 canonical content digest; absent = manifest fixed at initialize. */
+  revision?: string;
 
   /** Server supports push/event */
   pushEvents?: boolean;
 
-  /** Context hook capabilities */
+  /**
+   * Context hooks — §5.1 recursive shape. Boolean `true` at any level is
+   * shorthand for every leaf beneath it. `afterInference` is REMOVED in
+   * 0.5.0 (replaced by metadata-only inference/lifecycle, §10.5).
+   */
   contextHooks?: {
-    beforeInference?: boolean;
-    afterInference?: boolean | { blocking: boolean };
+    beforeInference?: boolean | {
+      observe?: boolean;
+      inject?: { system?: boolean; beforeUser?: boolean; afterUser?: boolean };
+    };
   };
 
-  /** Server-initiated inference capabilities */
-  inferenceRequest?: {
-    streaming?: boolean;
-  };
+  /** Server-initiated inference. `true` = the capability with no refinements. */
+  inferenceRequest?: boolean | { streaming?: boolean };
+
+  /** Server consumes inference/lifecycle notifications (§10.5). */
+  inferenceLifecycle?: boolean;
 
   /** Server supports model/info requests */
   modelInfo?: boolean;
@@ -122,8 +132,8 @@ export interface McplCapabilities {
   /** Declared feature sets (keyed by feature set name) */
   featureSets?: Record<string, FeatureSetDeclaration>;
 
-  /** Channel capabilities */
-  channels?: McplChannelCapabilities;
+  /** Channel capabilities — §14.1 object of leaves, or `true` for all. */
+  channels?: boolean | McplChannelCapabilities;
 }
 
 /**
@@ -134,23 +144,28 @@ export interface McplHostCapabilities {
   version: string;
   pushEvents?: boolean;
   contextHooks?: {
-    beforeInference?: boolean;
-    afterInference?: boolean | { blocking: boolean };
+    beforeInference?: boolean | {
+      observe?: boolean;
+      inject?: { system?: boolean; beforeUser?: boolean; afterUser?: boolean };
+    };
   };
-  inferenceRequest?: {
-    streaming?: boolean;
-  };
+  inferenceRequest?: boolean | { streaming?: boolean };
+  inferenceLifecycle?: boolean;
+  modelInfo?: boolean;
   featureSets?: boolean;
-  channels?: McplChannelCapabilities;
+  channels?: boolean | McplChannelCapabilities;
 }
 
-/** Channel-specific capability flags. */
+/** Channel capability leaves (§14.1). `observe` was the pre-0.5 name for
+ *  what split into `incoming` — removed, not aliased. */
 export interface McplChannelCapabilities {
   register?: boolean;
-  publish?: boolean;
-  observe?: boolean;
   lifecycle?: boolean;
+  publish?: boolean;
+  incoming?: boolean;
   streaming?: boolean;
+  acknowledge?: boolean;
+  typing?: boolean;
 }
 
 // ============================================================================
@@ -208,6 +223,15 @@ export interface McplServerConfig {
    * viable where a static `token` forced long ones).
    */
   accessProvider?: () => Promise<string | null>;
+
+  /**
+   * Host-owned authority for the `host/command` admin surface (undo / hide /
+   * unstick). DEFAULT FALSE: no §6.2 capability path exists for it, and the
+   * grant cannot confer it — only this config, decided by the operator, can
+   * (PR #79 review blocker 9). The one legitimate fleet user is
+   * discord-mcpl's slash-command relay.
+   */
+  allowHostCommands?: boolean;
 
   /** Feature sets to enable on connect */
   enabledFeatureSets?: string[];
@@ -1122,6 +1146,8 @@ export interface ChannelIncomingMessageResult {
   messageId: string;
   accepted: boolean;
   conversationId?: string;
+  /** §14.5: why a message was rejected (e.g. unknown/unregistered channel). */
+  reason?: string;
 }
 
 // ============================================================================

--- a/src/mcpl/types.ts
+++ b/src/mcpl/types.ts
@@ -233,6 +233,37 @@ export interface McplServerConfig {
    */
   disabledTools?: string[];
 
+  /**
+   * Capability allow-list: dotted paths as the server advertises them in its
+   * initialize response (`pushEvents`, `contextHooks.beforeInference`,
+   * `contextHooks.afterInference`, `inferenceRequest`, `modelInfo`,
+   * `channels`, `channels.streaming`, …). `*` matches one dot-segment
+   * (feature-set pattern rules), and a pattern matching a parent
+   * (`contextHooks`) covers every flag beneath it.
+   *
+   * If set, only advertised capabilities matching at least one pattern
+   * survive the handshake; everything else behaves as if the server had
+   * never advertised it. This is the host-side gate on hook fan-out: a
+   * server whose `contextHooks.afterInference` is masked never receives
+   * turn text, no matter what it self-advertises. Masked server-initiated
+   * capabilities (`pushEvents`, `inferenceRequest`, whole-`channels`) are
+   * also enforced inbound — the connection rejects those methods with
+   * CAPABILITY_DISABLED (-32002).
+   *
+   * `disabledCapabilities` takes precedence on conflict. `version` and
+   * `featureSets` are not maskable here — feature sets have their own
+   * enable/disable knobs above.
+   */
+  enabledCapabilities?: string[];
+
+  /**
+   * Capability deny-list (same paths and wildcard syntax as
+   * enabledCapabilities). Wins over enabledCapabilities on conflict.
+   * `disabledCapabilities: ['contextHooks.*']` is the one-line "this server
+   * gets no hook visibility" switch.
+   */
+  disabledCapabilities?: string[];
+
   /** Scope configurations per feature set */
   scopes?: Record<string, ScopeConfig>;
 

--- a/test/channel-registry-routing.test.ts
+++ b/test/channel-registry-routing.test.ts
@@ -90,7 +90,22 @@ function incoming(channelId: string, text: string, channelName?: string) {
   };
 }
 
-test('handleIncoming lazy-registers an unknown channel so it becomes a publishable locus', async () => {
+
+/** §14.5: channels/incoming no longer mints unknown channels — seed the
+ *  registered state a conforming server would have created via
+ *  channels/register before feeding incoming traffic. */
+function seedRegistered(registry: ChannelRegistry, serverId: string, ...ids: string[]): void {
+  const map = (registry as unknown as {
+    channels: Map<string, { serverId: string; descriptor: { id: string; type: string; label: string }; open: boolean }>;
+  }).channels;
+  for (const id of ids) {
+    if (!map.has(`${serverId}:${id}`)) {
+      map.set(`${serverId}:${id}`, { serverId, descriptor: { id, type: serverId, label: id }, open: false });
+    }
+  }
+}
+
+test('handleIncoming REJECTS an unknown channel instead of minting it (§14.5)', async () => {
   const { registry, traces, lookup } = makeRegistry({ delivered: true });
 
   // Channel "post-boot-ch" was never registered via channels/register|changed.
@@ -98,20 +113,17 @@ test('handleIncoming lazy-registers an unknown channel so it becomes a publishab
 
   registry.handleIncoming('discord', incoming('post-boot-ch', 'hi', '#cairn'));
 
-  const entry = lookup('post-boot-ch');
-  assert.ok(entry, 'channel should be lazy-registered from the inbound message');
-  assert.equal(entry!.serverId, 'discord');
-  assert.equal(entry!.descriptor.label, '#cairn');
-  assert.equal((entry!.descriptor.metadata as { lazyRegistered?: boolean })?.lazyRegistered, true);
-  assert.ok(traces.some(t => t.type === 'mcpl:channel-lazy-registered'));
-
-  // routeSpeech now resolves the locus and publishes (no failure).
-  const res = await registry.routeSpeech('cairn', 'my reply', registry.resolveLocus('cairn'));
-  assert.deepEqual(res, { delivered: true, channelId: 'post-boot-ch' });
+  // §14.5: the unknown channel is NOT minted, the message is rejected with
+  // a diagnostic, and the locus never becomes routable — a server cannot
+  // self-attest a channel identity by messaging it into existence.
+  assert.equal(lookup('post-boot-ch'), undefined, 'unknown channel must not be registered by its first message');
+  assert.ok(traces.some(t => t.type === 'mcpl:channel-incoming-rejected'));
+  assert.equal(registry.resolveLocus('cairn'), null, 'a rejected message must not establish a locus');
 });
 
 test('routeSpeech surfaces a failure when the server reports delivered:false', async () => {
   const { registry, failures, traces } = makeRegistry({ delivered: false });
+  seedRegistered(registry, 'discord', 'ch-x');
   registry.handleIncoming('discord', incoming('ch-x', 'hi'));
 
   const res = await registry.routeSpeech('cairn', 'undeliverable reply', registry.resolveLocus('cairn'));
@@ -133,7 +145,9 @@ test('routeSpeech routes a conversation fork to its HOME channel, not the global
     (agentName) => homes[agentName],
   );
 
+  seedRegistered(registry, 'discord', 'chanA');
   registry.handleIncoming('discord', incoming('chanA', 'hi from A'));
+  seedRegistered(registry, 'discord', 'chanB');
   registry.handleIncoming('discord', incoming('chanB', 'hi from B'));
   // Global locus is now chanB.
   assert.equal(registry.getDefaultPublishChannel(), 'chanB');
@@ -152,7 +166,9 @@ test('routeSpeech falls back to the global locus for the trunk agent (no home)',
     () => undefined, // no agent has a home
   );
 
+  seedRegistered(registry, 'discord', 'chanA');
   registry.handleIncoming('discord', incoming('chanA', 'hi from A'));
+  seedRegistered(registry, 'discord', 'chanB');
   registry.handleIncoming('discord', incoming('chanB', 'hi from B'));
 
   const res = await registry.routeSpeech('trunk', 'heartbeat reply', registry.resolveLocus('trunk'));
@@ -167,7 +183,9 @@ test('buildChannelContext advertises the fork home as defaultOutgoing (item 3)',
     (agentName) => homes[agentName],
   );
 
+  seedRegistered(registry, 'discord', 'chanA');
   registry.handleIncoming('discord', incoming('chanA', 'hi from A'));
+  seedRegistered(registry, 'discord', 'chanB');
   registry.handleIncoming('discord', incoming('chanB', 'hi from B'));
 
   // The fork is told chanA (where its speech actually lands)...
@@ -204,7 +222,9 @@ test('routeSpeech routes a TRUNK agent to its ACTIVE triggering channel, not the
     (agentName) => active[agentName],
   );
 
+  seedRegistered(registry, 'discord', 'chanA');
   registry.handleIncoming('discord', incoming('chanA', 'A: sleep && date'));
+  seedRegistered(registry, 'discord', 'chanB');
   registry.handleIncoming('discord', incoming('chanB', 'B: unrelated')); // flips global to chanB
   assert.equal(registry.getDefaultPublishChannel(), 'chanB');
 
@@ -222,7 +242,9 @@ test('routeSpeech precedence: fork HOME wins over the active triggering channel'
     (n) => (n === 'conversation-chanA-g1' ? 'chanA' : undefined),
     () => 'chanB',
   );
+  seedRegistered(registry, 'discord', 'chanA');
   registry.handleIncoming('discord', incoming('chanA', 'hi'));
+  seedRegistered(registry, 'discord', 'chanB');
   registry.handleIncoming('discord', incoming('chanB', 'hi'));
 
   const res = await registry.routeSpeech('conversation-chanA-g1', 'reply', registry.resolveLocus('conversation-chanA-g1'));
@@ -237,7 +259,9 @@ test('buildChannelContext advertises the active triggering channel as defaultOut
     () => undefined,
     (n) => active[n],
   );
+  seedRegistered(registry, 'discord', 'chanA');
   registry.handleIncoming('discord', incoming('chanA', 'hi from A'));
+  seedRegistered(registry, 'discord', 'chanB');
   registry.handleIncoming('discord', incoming('chanB', 'hi from B')); // global → chanB
 
   // The trunk is TOLD chanA (where its speech will actually land), matching
@@ -299,6 +323,7 @@ test('routeSpeech into a closed locus opens the channel first, then delivers', a
   const { registry, publishCalls, openCalls, lookup } = makeRegistry({ delivered: true });
 
   // A DM-shaped situation: the channel is registered but closed.
+  seedRegistered(registry, 'discord', 'dm-alice');
   registry.handleIncoming('discord', incoming('dm-alice', 'hello?'));
   lookup('dm-alice')!.open = false;
 
@@ -316,6 +341,7 @@ test('routeSpeech into a closed locus opens the channel first, then delivers', a
 test('routeSpeech does NOT deliver when the open-on-delivery fails', async () => {
   const { registry, failures, publishCalls, lookup, setFailOpens } = makeRegistry({ delivered: true });
 
+  seedRegistered(registry, 'discord', 'dm-alice');
   registry.handleIncoming('discord', incoming('dm-alice', 'hello?'));
   lookup('dm-alice')!.open = false;
   const publishesBefore = publishCalls.length;
@@ -331,6 +357,7 @@ test('routeSpeech does NOT deliver when the open-on-delivery fails', async () =>
 
 test('routeSpeech with an omitted locus fails loudly as a routing bug', async () => {
   const { registry, failures } = makeRegistry({ delivered: true });
+  seedRegistered(registry, 'discord', 'ch-y');
   registry.handleIncoming('discord', incoming('ch-y', 'hi'));
 
   const res = await (registry.routeSpeech as unknown as (
@@ -438,6 +465,7 @@ test('opened-by-delivery is announced to the delivering agent', async () => {
   const autoOpened: Array<{ conversationId?: string; source: string; channels: Array<{ channelId: string }> }> = [];
   const { registry, lookup } = makeRegistry({ delivered: true }, undefined, undefined, (info) => autoOpened.push(info));
 
+  seedRegistered(registry, 'discord', 'dm-alice');
   registry.handleIncoming('discord', incoming('dm-alice', 'hello?'));
   lookup('dm-alice')!.open = false;
 

--- a/test/channel-registry-routing.test.ts
+++ b/test/channel-registry-routing.test.ts
@@ -1,3 +1,4 @@
+import { CapabilityGrant, ALL_CAPABILITY_PATHS } from '../src/mcpl/capability-grant.js';
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { ChannelRegistry } from '../src/mcpl/channel-registry.js';
@@ -30,6 +31,8 @@ function makeRegistry(
   let failOpens = false;
 
   const mockServer = {
+    // Post-policy state: full grant, so tests exercise delivery, not §5.3 denial.
+    grant: new CapabilityGrant(new Set(ALL_CAPABILITY_PATHS), []),
     sendChannelsPublish: async (params: { channelId?: string; conversationId?: string }) => {
       publishCalls.push(params);
       return publishResult;

--- a/test/channel-registry-typing.test.ts
+++ b/test/channel-registry-typing.test.ts
@@ -1,6 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { ChannelRegistry } from '../src/mcpl/channel-registry.js';
+import { CapabilityGrant } from '../src/mcpl/capability-grant.js';
 import type { McplServerRegistry } from '../src/mcpl/server-registry.js';
 import type { FeatureSetManager } from '../src/mcpl/feature-set-manager.js';
 
@@ -23,7 +24,14 @@ function makeRegistry() {
   };
 
   const registry = new ChannelRegistry(
-    {} as McplServerRegistry,
+    // §14.1: the typing gate reads the server's grant now — a bare {} stub
+    // has no getServer and crashes. Model a post-policy server with
+    // channels.typing granted so the tests exercise dispatch, not denial.
+    {
+      getServer: () => ({
+        grant: new CapabilityGrant(new Set(['channels.typing']), []),
+      }),
+    } as unknown as McplServerRegistry,
     {} as FeatureSetManager,
     () => {},
     () => {},

--- a/test/conversation-fork-injection-scoping.test.ts
+++ b/test/conversation-fork-injection-scoping.test.ts
@@ -24,6 +24,7 @@ type FrameworkInternals = {
   conversationAgentHomes: Map<string, string>;
   hookOrchestrator: {
     beforeInference(params: unknown): Promise<ContextInjection[]>;
+    emitLifecycle(params: unknown): void;
   } | null;
 };
 
@@ -111,6 +112,9 @@ function bindForkHome(framework: AgentFramework, agentName = FORK_AGENT, channel
 function installHookInjections(framework: AgentFramework, injections: ContextInjection[]): void {
   frameworkInternals(framework).hookOrchestrator = {
     beforeInference: async () => injections,
+    // §10.5: driveStream emits started/terminal lifecycle notifications
+    // through the orchestrator on every turn now.
+    emitLifecycle: () => {},
   };
 }
 

--- a/test/conversation-fork-injection-scoping.test.ts
+++ b/test/conversation-fork-injection-scoping.test.ts
@@ -89,9 +89,11 @@ function installChannelRegistry(
     },
   );
   for (const channelId of channelIds) {
-    // An incoming lifecycle message is authoritative evidence that the
-    // transport is actually open. ensureChannelRegistered alone deliberately
-    // keeps one-shot/direct-address channels closed.
+    // §14.5: register first (a conforming server's channels/register),
+    // then the incoming message marks the registered channel open.
+    (registry as unknown as { channels: Map<string, unknown> }).channels.set(`srv:${channelId}`, {
+      serverId: 'srv', descriptor: { id: channelId, type: 'srv', label: channelId }, open: false,
+    });
     registry.handleIncoming('srv', {
       messages: [{
         channelId,

--- a/test/fixtures/awareness-barrier-mcpl-server.mjs
+++ b/test/fixtures/awareness-barrier-mcpl-server.mjs
@@ -169,8 +169,17 @@ function handle(message) {
       capabilities: {
         experimental: {
           mcpl: {
-            version: '0.4',
+            version: '0.5',
+            // §5.4/§6.2: the grant is computed from this advertisement, and
+            // admission denies what it cannot contain. This fixture SENDS
+            // channels/register, channels/incoming and inference/request, so
+            // it must advertise them — with only pushEvents declared, the
+            // 0.5 host correctly rejected the released data requests
+            // (accepted:false), which is exactly what PR #79's ubuntu CI
+            // caught on the inference/request + channels/incoming matrix.
             pushEvents: true,
+            inferenceRequest: true,
+            channels: { register: true, incoming: true },
             featureSets: {
               chat: { description: 'chat', uses: ['pushEvents'] },
             },

--- a/test/fixtures/awareness-barrier-mcpl-server.mjs
+++ b/test/fixtures/awareness-barrier-mcpl-server.mjs
@@ -180,6 +180,16 @@ function handle(message) {
     });
     return;
   }
+  if (message.method === 'featureSets/update') {
+    // MCPL 0.5 (§5.3/§6.7): the host sends initial policy as a Request and
+    // activates the grant only on this degradation receipt. Without it the
+    // host times out (15s), the grant stays empty, and every push/channel
+    // in these tests is rejected fail-closed.
+    if (message.id !== undefined && message.id !== null) {
+      reply(message.id, { accepted: true });
+    }
+    return;
+  }
   if (message.method === 'notifications/initialized') {
     beginServerTraffic();
     return;

--- a/test/machine-close-provenance.test.ts
+++ b/test/machine-close-provenance.test.ts
@@ -1,3 +1,4 @@
+import { CapabilityGrant, ALL_CAPABILITY_PATHS } from '../src/mcpl/capability-grant.js';
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { ChannelRegistry } from '../src/mcpl/channel-registry.js';
@@ -16,6 +17,8 @@ import type { FeatureSetManager } from '../src/mcpl/feature-set-manager.js';
 function makeRegistry() {
   const closeCalls: Array<{ channelId?: string }> = [];
   const mockServer = {
+    // Post-policy state: full grant, so tests exercise delivery, not §5.3 denial.
+    grant: new CapabilityGrant(new Set(ALL_CAPABILITY_PATHS), []),
     sendChannelsOpen: async () => ({}),
     sendChannelsClose: async (params: { channelId?: string }) => {
       closeCalls.push(params);

--- a/test/machine-close-provenance.test.ts
+++ b/test/machine-close-provenance.test.ts
@@ -46,6 +46,9 @@ function makeRegistry() {
     internals.desiredStates.get(internals.lifecycleKey('discord', channelId));
 
   // Register the channel the way a live server would surface it.
+  (registry as unknown as { channels: Map<string, unknown> }).channels.set('discord:c1', {
+    serverId: 'discord', descriptor: { id: 'c1', type: 'discord', label: '#commons' }, open: false,
+  });
   registry.handleIncoming('discord', {
     messages: [{
       channelId: 'c1',

--- a/test/mcpl-awareness-barrier.test.ts
+++ b/test/mcpl-awareness-barrier.test.ts
@@ -113,6 +113,11 @@ function twoServerFrameworkConfig(
     id,
     command: process.execPath,
     args: [FIXTURE],
+    // The host/command matrix leg models the legitimate slash-command relay:
+    // host-owned authority is the operator's config decision (PR #79
+    // blocker 9), so the test config makes it, exactly as the fleet's
+    // discord config will at rollout.
+    allowHostCommands: true,
     requestTimeoutMs: 0,
     env: {
       STATUS_PATH: statusPath,

--- a/test/mcpl-awareness-barrier.test.ts
+++ b/test/mcpl-awareness-barrier.test.ts
@@ -12,6 +12,7 @@ import { join } from 'node:path';
 
 import { AgentFramework } from '../src/framework.js';
 import { McplServerConnection } from '../src/mcpl/server-connection.js';
+import { CapabilityGrant } from '../src/mcpl/capability-grant.js';
 import type { McplServerConfig } from '../src/mcpl/types.js';
 import { DiscordAwarenessOutbox } from '../src/recovery/discord-awareness-outbox.js';
 import { MockMembrane } from './helpers/mock-membrane.js';
@@ -770,6 +771,10 @@ test('synchronous zero-pending flush rechecks the gate after a nested list chang
   const connection = new (McplServerConnection as any)(
     'discord', null, null,
   ) as McplServerConnection;
+  // This test exercises plane-flush mechanics, not authorization: admission
+  // now enforces the grant (§5.4), so model the post-policy state or the
+  // push is correctly discarded before it can count.
+  connection.establishGrant(new CapabilityGrant(new Set(['pushEvents']), []));
   let dataDeliveries = 0;
   connection.on('tools-list-changed', () => connection.pauseDataPlane());
   connection.on('push-event', () => { dataDeliveries++; });

--- a/test/mcpl-capability-grant.test.ts
+++ b/test/mcpl-capability-grant.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Capability grant core (SPEC §5.4, §5.1, §6.4, §13.4).
+ *
+ * The load-bearing cases mirror the 2026-08-02 differ adjudications: the
+ * one-segment wildcard (TS had shipped the suffix reading), bare-parent-
+ * grants-nothing, and the recursive advertisement walk that the old
+ * `=== true` checks silently missed.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  advertisedPaths,
+  capabilityPatternMatches,
+  computeGrant,
+  ALL_CAPABILITY_PATHS,
+  isKnownCapabilityPath,
+  CapabilityGrant,
+} from '../src/mcpl/capability-grant.js';
+import type { McplCapabilities } from '../src/mcpl/types.js';
+
+const caps = (o: Record<string, unknown>): McplCapabilities =>
+  ({ version: '0.5', ...o }) as unknown as McplCapabilities;
+
+// ── §6.2 vocabulary ─────────────────────────────────────────────────────────
+
+test('vocabulary is exactly the 17 §6.2 paths', () => {
+  assert.deepEqual([...ALL_CAPABILITY_PATHS].sort(), [
+    'channels.acknowledge',
+    'channels.incoming',
+    'channels.lifecycle',
+    'channels.publish',
+    'channels.register',
+    'channels.streaming',
+    'channels.typing',
+    'contextHooks.beforeInference.inject.afterUser',
+    'contextHooks.beforeInference.inject.beforeUser',
+    'contextHooks.beforeInference.inject.system',
+    'contextHooks.beforeInference.observe',
+    'inferenceLifecycle',
+    'inferenceRequest',
+    'inferenceRequest.streaming',
+    'modelInfo',
+    'pushEvents',
+    'tools',
+  ]);
+  assert.equal(isKnownCapabilityPath('channels'), false); // namespace, not a path
+  assert.equal(isKnownCapabilityPath('contextHooks.beforeInference'), false);
+});
+
+// ── §5.1 advertisement walk ─────────────────────────────────────────────────
+
+test('boolean true expands to every leaf beneath (channels: true → 7 leaves)', () => {
+  const a = advertisedPaths(caps({ channels: true }));
+  assert.equal(a.size, 7);
+  assert.ok(a.has('channels.streaming'));
+});
+
+test('recursive object shape advertises exactly its leaves', () => {
+  const a = advertisedPaths(caps({
+    contextHooks: { beforeInference: { observe: true, inject: { beforeUser: true } } },
+  }));
+  assert.deepEqual([...a].sort(), [
+    'contextHooks.beforeInference.inject.beforeUser',
+    'contextHooks.beforeInference.observe',
+  ]);
+});
+
+test('beforeInference: true is shorthand for observe plus all three inject leaves', () => {
+  const a = advertisedPaths(caps({ contextHooks: { beforeInference: true } }));
+  assert.equal(a.size, 4);
+});
+
+test('false, absent, and unknown names advertise nothing', () => {
+  assert.equal(advertisedPaths(caps({ channels: false })).size, 0);
+  assert.equal(advertisedPaths(caps({})).size, 0);
+  assert.equal(advertisedPaths(caps({ madeUp: true, channels: { alsoMadeUp: true } })).size, 0);
+  assert.equal(advertisedPaths(null).size, 0);
+});
+
+test('inferenceRequest is self-grantable: object form advertises its own path', () => {
+  const a = advertisedPaths(caps({ inferenceRequest: { streaming: true } }));
+  assert.deepEqual([...a].sort(), ['inferenceRequest', 'inferenceRequest.streaming']);
+});
+
+// ── §5.4 matching: one segment, equal counts ────────────────────────────────
+
+test('* matches exactly one segment; segment counts must agree', () => {
+  assert.ok(capabilityPatternMatches('channels.*', 'channels.publish'));
+  assert.ok(!capabilityPatternMatches('channels.*', 'channels'));
+  // The adjudicated divergence: a trailing * is NOT a subtree match.
+  assert.ok(!capabilityPatternMatches('contextHooks.*', 'contextHooks.beforeInference.observe'));
+  assert.ok(!capabilityPatternMatches('contextHooks.*', 'contextHooks.beforeInference.inject.system'));
+  assert.ok(!capabilityPatternMatches('*', 'channels.publish'));
+  assert.ok(capabilityPatternMatches('*', 'pushEvents'));
+  assert.ok(capabilityPatternMatches('contextHooks.beforeInference.inject.*', 'contextHooks.beforeInference.inject.afterUser'));
+});
+
+test('bare parent grants nothing beneath it', () => {
+  const grant = new CapabilityGrant(new Set(['channels']), []);
+  assert.ok(!grant.has('channels.publish'));
+  assert.ok(grant.has('channels')); // the path itself, which no method requires
+});
+
+// ── grant computation ───────────────────────────────────────────────────────
+
+test('empty grant denies everything; absence is denial', () => {
+  const g = CapabilityGrant.empty();
+  assert.ok(g.isEmpty());
+  for (const p of ALL_CAPABILITY_PATHS) assert.ok(!g.has(p));
+});
+
+test('§13.4: inject.system is denied by default and re-grantable only explicitly', () => {
+  const advertised = caps({ contextHooks: { beforeInference: true } });
+  const denied = computeGrant(advertised, {});
+  assert.ok(!denied.has('contextHooks.beforeInference.inject.system'));
+  assert.ok(denied.has('contextHooks.beforeInference.inject.beforeUser'));
+  assert.deepEqual(denied.deniedPaths, ['contextHooks.beforeInference.inject.system']);
+
+  const granted = computeGrant(advertised, {
+    enabledCapabilities: ['contextHooks.beforeInference.inject.system'],
+  });
+  assert.ok(granted.has('contextHooks.beforeInference.inject.system'));
+  assert.deepEqual(granted.deniedPaths, []);
+});
+
+test('grant is advertisement-bounded: nothing un-advertised is granted', () => {
+  const g = computeGrant(caps({ pushEvents: true }), {
+    enabledCapabilities: ['channels.*', 'tools'],
+  });
+  assert.ok(g.has('pushEvents'));
+  assert.ok(!g.has('tools'));
+  assert.ok(!g.has('channels.publish'));
+});

--- a/test/mcpl-capability-scoping.test.ts
+++ b/test/mcpl-capability-scoping.test.ts
@@ -14,6 +14,7 @@ import { test, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 
 import { maskNegotiatedCapabilities } from '../src/mcpl/capability-mask.js';
+import { computeGrant } from '../src/mcpl/capability-grant.js';
 import { CAPABILITY_DISABLED } from '../src/mcpl/errors.js';
 import { McplServerConnection } from '../src/mcpl/server-connection.js';
 import { McplServerRegistry } from '../src/mcpl/server-registry.js';
@@ -256,18 +257,38 @@ test('inbound push/event from a pushEvents-masked server is rejected with CAPABI
   assert.match(result.pushResponse?.error?.message ?? '', /pushEvents/);
 });
 
-test('without scoping, the same push/event reaches host handlers', async () => {
+test('§5.3 pre-policy deny-all, then the same push/event flows once the grant is established', async () => {
   registry = new McplServerRegistry();
   const connection = await registry.addServer(config(), HOST_CAPS);
   connection.ready();
 
-  const pushSeen = new Promise<void>((resolve) => {
-    connection.on('push-event', (_params: unknown, responder?: { respond: (r: unknown) => void }) => {
-      responder?.respond({ accepted: true });
-      resolve();
-    });
+  let pushEventEmitted = false;
+  connection.on('push-event', (_params: unknown, responder?: { respond: (r: unknown) => void }) => {
+    pushEventEmitted = true;
+    responder?.respond({ accepted: true });
   });
 
-  await connection.sendToolsList();
-  await pushSeen;
+  // Round 1: NO policy established. Even though pushEvents is advertised
+  // and unmasked, the grant is empty (§5.3) — the push must be rejected
+  // with -32002 and data:{capability}, and never reach host handlers.
+  // (This test originally asserted the pre-0.5 behavior — advertised ⇒
+  // delivered — and hung forever against the fail-closed gate.)
+  const round1 = await connection.sendToolsList() as {
+    tools: unknown[];
+    pushResponse?: { error?: { code: number; message: string; data?: { capability?: string } } };
+  };
+  assert.equal(pushEventEmitted, false, 'pre-policy push must not reach host handlers');
+  assert.equal(round1.pushResponse?.error?.code, CAPABILITY_DISABLED);
+  assert.equal(round1.pushResponse?.error?.data?.capability, 'pushEvents');
+
+  // Round 2: establish the grant (§6.7 — expansion activates on receipt;
+  // the framework does this after the featureSets/update Request is
+  // answered). Now the identical push flows.
+  connection.establishGrant(computeGrant(connection.capabilities, {}));
+  const round2 = await connection.sendToolsList() as {
+    tools: unknown[];
+    pushResponse?: { result?: { accepted?: boolean } };
+  };
+  assert.equal(pushEventEmitted, true, 'granted push must reach host handlers');
+  assert.equal(round2.pushResponse?.result?.accepted, true);
 });

--- a/test/mcpl-capability-scoping.test.ts
+++ b/test/mcpl-capability-scoping.test.ts
@@ -226,7 +226,14 @@ test('masked afterInference is invisible to capability queries; unmasked hooks s
   );
   connection.ready();
 
-  assert.equal(connection.capabilities?.contextHooks?.beforeInference, true);
+  // §5.1 shorthand is expanded to explicit leaves at handshake (the host's
+  // POLICY representation — sub-leaf masking must be addressable), so the
+  // stored shape is the object form, not the wire's boolean.
+  const before = connection.capabilities?.contextHooks?.beforeInference as unknown as {
+    observe?: boolean; inject?: Record<string, boolean>;
+  };
+  assert.equal(before?.observe, true);
+  assert.deepEqual(before?.inject, { system: true, beforeUser: true, afterUser: true });
   assert.equal(connection.capabilities?.contextHooks?.afterInference, undefined);
   assert.deepEqual(registry.getServersWithCapability('contextHooks.afterInference'), []);
   assert.equal(registry.getServersWithCapability('contextHooks.beforeInference').length, 1);

--- a/test/mcpl-capability-scoping.test.ts
+++ b/test/mcpl-capability-scoping.test.ts
@@ -291,4 +291,22 @@ test('§5.3 pre-policy deny-all, then the same push/event flows once the grant i
   };
   assert.equal(pushEventEmitted, true, 'granted push must reach host handlers');
   assert.equal(round2.pushResponse?.result?.accepted, true);
+
+  // Round 3: REDUCTION ordering (§6.7 — "a security-reducing change takes
+  // effect atomically first, then the host sends the Request"). Re-establish
+  // a grant without pushEvents and verify enforcement is immediate: the next
+  // push is rejected with no Request sent, no receipt awaited, and no window
+  // in which the old, wider grant still answers. This is the half of the
+  // mirrored ordering the expansion rounds above cannot show.
+  pushEventEmitted = false;
+  connection.establishGrant(
+    computeGrant(connection.capabilities, {}).without('pushEvents'),
+  );
+  const round3 = await connection.sendToolsList() as {
+    tools: unknown[];
+    pushResponse?: { error?: { code: number; data?: { capability?: string } } };
+  };
+  assert.equal(pushEventEmitted, false, 'revoked push must stop immediately — reduction never waits on consent');
+  assert.equal(round3.pushResponse?.error?.code, CAPABILITY_DISABLED);
+  assert.equal(round3.pushResponse?.error?.data?.capability, 'pushEvents');
 });

--- a/test/mcpl-capability-scoping.test.ts
+++ b/test/mcpl-capability-scoping.test.ts
@@ -27,7 +27,9 @@ import type { McplCapabilities, McplHostCapabilities, McplServerConfig } from '.
 const FULL_ADVERT: McplCapabilities = {
   version: '0.4',
   pushEvents: true,
-  contextHooks: { beforeInference: true, afterInference: { blocking: true } },
+  // afterInference is REMOVED in 0.5.0; the masked-hook example is the
+  // §13.4-sensitive inject.system leaf instead.
+  contextHooks: { beforeInference: { observe: true, inject: { system: true, beforeUser: true, afterUser: true } } },
   inferenceRequest: { streaming: true },
   modelInfo: true,
   featureSets: { 'memory.retrieval': { description: 'd', uses: [] } },
@@ -40,15 +42,16 @@ test('no scoping config: advertisement passes through untouched', () => {
   assert.deepEqual(dropped, []);
 });
 
-test('disabledCapabilities drops a single hook, preserving its sibling and value shapes', () => {
+test('disabledCapabilities drops a single deep leaf, preserving siblings and value shapes', () => {
   const { capabilities, dropped } = maskNegotiatedCapabilities(FULL_ADVERT, {
-    disabledCapabilities: ['contextHooks.afterInference'],
+    disabledCapabilities: ['contextHooks.beforeInference.inject.system'],
   });
-  assert.equal(capabilities?.contextHooks?.beforeInference, true);
-  assert.equal(capabilities?.contextHooks?.afterInference, undefined);
+  const before = capabilities?.contextHooks?.beforeInference as { observe?: boolean; inject?: Record<string, boolean> };
+  assert.equal(before?.observe, true);
+  assert.deepEqual(before?.inject, { beforeUser: true, afterUser: true });
   // Untouched capabilities keep their original (non-boolean) values.
   assert.deepEqual(capabilities?.inferenceRequest, { streaming: true });
-  assert.deepEqual(dropped, ['contextHooks.afterInference']);
+  assert.deepEqual(dropped, ['contextHooks.beforeInference.inject.system']);
 });
 
 test('a parent pattern prunes the whole subtree, recorded as the bare path', () => {
@@ -104,7 +107,7 @@ test('enabledCapabilities allow-list keeps only matches; disabled wins on confli
   assert.equal(capabilities?.inferenceRequest, undefined);
   assert.equal(capabilities?.modelInfo, undefined);
   assert.ok(dropped.includes('channels.streaming'));
-  assert.ok(dropped.includes('contextHooks.afterInference'));
+  assert.ok(dropped.includes('contextHooks'));
 });
 
 test('version and featureSets are never masked', () => {
@@ -197,9 +200,9 @@ setInterval(() => {}, 1 << 30);
 `;
 
 const HOST_CAPS: McplHostCapabilities = {
-  version: '0.4',
+  version: '0.5',
   pushEvents: true,
-  contextHooks: { beforeInference: true, afterInference: { blocking: true } },
+  contextHooks: { beforeInference: true },
   featureSets: true,
 };
 
@@ -234,8 +237,6 @@ test('masked afterInference is invisible to capability queries; unmasked hooks s
   };
   assert.equal(before?.observe, true);
   assert.deepEqual(before?.inject, { system: true, beforeUser: true, afterUser: true });
-  assert.equal(connection.capabilities?.contextHooks?.afterInference, undefined);
-  assert.deepEqual(registry.getServersWithCapability('contextHooks.afterInference'), []);
   assert.equal(registry.getServersWithCapability('contextHooks.beforeInference').length, 1);
   // pushEvents untouched — scoping is per-capability, not per-server.
   assert.equal(registry.getServersWithCapability('pushEvents').length, 1);

--- a/test/mcpl-capability-scoping.test.ts
+++ b/test/mcpl-capability-scoping.test.ts
@@ -50,15 +50,38 @@ test('disabledCapabilities drops a single hook, preserving its sibling and value
   assert.deepEqual(dropped, ['contextHooks.afterInference']);
 });
 
-test('a parent pattern masks every flag beneath it', () => {
+test('a parent pattern prunes the whole subtree, recorded as the bare path', () => {
   const { capabilities, dropped } = maskNegotiatedCapabilities(FULL_ADVERT, {
     disabledCapabilities: ['contextHooks'],
   });
   assert.equal(capabilities?.contextHooks, undefined);
-  assert.deepEqual(
-    dropped.sort(),
-    ['contextHooks', 'contextHooks.afterInference', 'contextHooks.beforeInference'],
-  );
+  assert.deepEqual(dropped, ['contextHooks']);
+});
+
+test('refinement masking: inferenceRequest.streaming is addressable and leaves the capability granted', () => {
+  const { capabilities, dropped } = maskNegotiatedCapabilities(FULL_ADVERT, {
+    disabledCapabilities: ['inferenceRequest.streaming'],
+  });
+  // The capability hull survives — still truthy for getServersWithCapability.
+  assert.deepEqual(capabilities?.inferenceRequest, {});
+  assert.deepEqual(dropped, ['inferenceRequest.streaming']);
+});
+
+test('generic recursion: depth-3 paths are addressable (SPEC 0.5 §5.4 vocabulary shape)', () => {
+  const advert = {
+    version: '0.5',
+    contextHooks: {
+      beforeInference: { observe: true, inject: { system: true, beforeUser: true } },
+    },
+  } as unknown as McplCapabilities;
+  const { capabilities, dropped } = maskNegotiatedCapabilities(advert, {
+    disabledCapabilities: ['contextHooks.beforeInference.inject.system'],
+  });
+  const before = (capabilities as unknown as Record<string, Record<string, unknown>>)
+    .contextHooks.beforeInference as Record<string, unknown>;
+  assert.equal(before.observe, true);
+  assert.deepEqual(before.inject, { beforeUser: true });
+  assert.deepEqual(dropped, ['contextHooks.beforeInference.inject.system']);
 });
 
 test('wildcard pattern contextHooks.* masks both hooks', () => {

--- a/test/mcpl-capability-scoping.test.ts
+++ b/test/mcpl-capability-scoping.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Host-side MCPL capability scoping (McplServerConfig.enabledCapabilities /
+ * disabledCapabilities).
+ *
+ * A server names its own capabilities in its initialize response, and hook
+ * fan-out keys off that self-advertisement — so before this knob existed,
+ * connecting any server that said `contextHooks.afterInference` was
+ * equivalent to giving it a transcript of everything the agent says. The
+ * mask intersects the advertisement with host policy at handshake time
+ * (both directions: the host never fans out to a masked hook, and inbound
+ * methods gated by a masked capability are rejected at the connection).
+ */
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { maskNegotiatedCapabilities } from '../src/mcpl/capability-mask.js';
+import { CAPABILITY_DISABLED } from '../src/mcpl/errors.js';
+import { McplServerConnection } from '../src/mcpl/server-connection.js';
+import { McplServerRegistry } from '../src/mcpl/server-registry.js';
+import type { McplCapabilities, McplHostCapabilities, McplServerConfig } from '../src/mcpl/types.js';
+
+// ============================================================================
+// Unit: maskNegotiatedCapabilities
+// ============================================================================
+
+const FULL_ADVERT: McplCapabilities = {
+  version: '0.4',
+  pushEvents: true,
+  contextHooks: { beforeInference: true, afterInference: { blocking: true } },
+  inferenceRequest: { streaming: true },
+  modelInfo: true,
+  featureSets: { 'memory.retrieval': { description: 'd', uses: [] } },
+  channels: { register: true, publish: true, streaming: true },
+};
+
+test('no scoping config: advertisement passes through untouched', () => {
+  const { capabilities, dropped } = maskNegotiatedCapabilities(FULL_ADVERT, {});
+  assert.deepEqual(capabilities, FULL_ADVERT);
+  assert.deepEqual(dropped, []);
+});
+
+test('disabledCapabilities drops a single hook, preserving its sibling and value shapes', () => {
+  const { capabilities, dropped } = maskNegotiatedCapabilities(FULL_ADVERT, {
+    disabledCapabilities: ['contextHooks.afterInference'],
+  });
+  assert.equal(capabilities?.contextHooks?.beforeInference, true);
+  assert.equal(capabilities?.contextHooks?.afterInference, undefined);
+  // Untouched capabilities keep their original (non-boolean) values.
+  assert.deepEqual(capabilities?.inferenceRequest, { streaming: true });
+  assert.deepEqual(dropped, ['contextHooks.afterInference']);
+});
+
+test('a parent pattern masks every flag beneath it', () => {
+  const { capabilities, dropped } = maskNegotiatedCapabilities(FULL_ADVERT, {
+    disabledCapabilities: ['contextHooks'],
+  });
+  assert.equal(capabilities?.contextHooks, undefined);
+  assert.deepEqual(
+    dropped.sort(),
+    ['contextHooks', 'contextHooks.afterInference', 'contextHooks.beforeInference'],
+  );
+});
+
+test('wildcard pattern contextHooks.* masks both hooks', () => {
+  const { capabilities } = maskNegotiatedCapabilities(FULL_ADVERT, {
+    disabledCapabilities: ['contextHooks.*'],
+  });
+  assert.equal(capabilities?.contextHooks, undefined);
+  assert.equal(capabilities?.pushEvents, true);
+});
+
+test('enabledCapabilities allow-list keeps only matches; disabled wins on conflict', () => {
+  const { capabilities, dropped } = maskNegotiatedCapabilities(FULL_ADVERT, {
+    enabledCapabilities: ['pushEvents', 'channels'],
+    disabledCapabilities: ['channels.streaming'],
+  });
+  assert.equal(capabilities?.pushEvents, true);
+  assert.deepEqual(capabilities?.channels, { register: true, publish: true });
+  assert.equal(capabilities?.contextHooks, undefined);
+  assert.equal(capabilities?.inferenceRequest, undefined);
+  assert.equal(capabilities?.modelInfo, undefined);
+  assert.ok(dropped.includes('channels.streaming'));
+  assert.ok(dropped.includes('contextHooks.afterInference'));
+});
+
+test('version and featureSets are never masked', () => {
+  const { capabilities } = maskNegotiatedCapabilities(FULL_ADVERT, {
+    disabledCapabilities: ['*'],
+  });
+  assert.equal(capabilities?.version, '0.4');
+  assert.deepEqual(capabilities?.featureSets, FULL_ADVERT.featureSets);
+  assert.equal(capabilities?.pushEvents, undefined);
+  assert.equal(capabilities?.contextHooks, undefined);
+  assert.equal(capabilities?.channels, undefined);
+});
+
+test('boolean-form channels (discord-mcpl style) is maskable as a leaf', () => {
+  const advert: McplCapabilities = {
+    version: '0.4',
+    pushEvents: true,
+    channels: true as unknown as McplCapabilities['channels'],
+  };
+  const { capabilities, dropped } = maskNegotiatedCapabilities(advert, {
+    disabledCapabilities: ['channels'],
+  });
+  assert.equal(capabilities?.channels, undefined);
+  assert.equal(capabilities?.pushEvents, true);
+  assert.deepEqual(dropped, ['channels']);
+});
+
+test('masking every advertised channel flag records the bare parent for inbound enforcement', () => {
+  const { dropped } = maskNegotiatedCapabilities(FULL_ADVERT, {
+    disabledCapabilities: ['channels.register', 'channels.publish', 'channels.streaming'],
+  });
+  assert.ok(dropped.includes('channels'));
+});
+
+test('flag-level channel masking does NOT record the bare parent', () => {
+  const { dropped } = maskNegotiatedCapabilities(FULL_ADVERT, {
+    disabledCapabilities: ['channels.streaming'],
+  });
+  assert.ok(!dropped.includes('channels'));
+  assert.deepEqual(dropped, ['channels.streaming']);
+});
+
+test('null capabilities (plain MCP server) pass through', () => {
+  const { capabilities, dropped } = maskNegotiatedCapabilities(null, {
+    disabledCapabilities: ['*'],
+  });
+  assert.equal(capabilities, null);
+  assert.deepEqual(dropped, []);
+});
+
+// ============================================================================
+// End-to-end: handshake masking + registry queries + inbound rejection
+// ============================================================================
+
+// Stdio server that advertises the full MCPL surface, then (on tools/list —
+// used here as a "go" signal) sends a push/event request and reports the
+// host's response back through the tools/list result. This lets one
+// round-trip prove both directions of the mask.
+const CHATTY_SERVER = `
+let buf = '';
+let pushResponse = null;
+let pendingToolsList = null;
+const send = (obj) => process.stdout.write(JSON.stringify(obj) + '\\n');
+process.stdin.on('data', (c) => {
+  buf += c.toString('utf8');
+  let i;
+  while ((i = buf.indexOf('\\n')) >= 0) {
+    const line = buf.slice(0, i); buf = buf.slice(i + 1);
+    if (!line.trim()) continue;
+    let m; try { m = JSON.parse(line); } catch { continue; }
+    if (m.method === 'initialize') {
+      send({ jsonrpc: '2.0', id: m.id, result: { capabilities: { experimental: { mcpl: {
+        version: '0.4',
+        pushEvents: true,
+        contextHooks: { beforeInference: true, afterInference: { blocking: true } },
+        channels: { register: true, publish: true },
+      } } } } });
+    } else if (m.method === 'tools/list') {
+      pendingToolsList = m.id;
+      send({ jsonrpc: '2.0', id: 77, method: 'push/event', params: {
+        eventId: 'e1', featureSet: 'memory.retrieval', eventType: 'test', urgency: 'whenever',
+      } });
+    } else if (m.id === 77) {
+      // Host's response to our push — report it via the parked tools/list.
+      send({ jsonrpc: '2.0', id: pendingToolsList, result: { tools: [], pushResponse: m } });
+    }
+  }
+});
+setInterval(() => {}, 1 << 30);
+`;
+
+const HOST_CAPS: McplHostCapabilities = {
+  version: '0.4',
+  pushEvents: true,
+  contextHooks: { beforeInference: true, afterInference: { blocking: true } },
+  featureSets: true,
+};
+
+function config(overrides?: Partial<McplServerConfig>): McplServerConfig {
+  return {
+    id: 'chatty',
+    command: process.execPath,
+    args: ['-e', CHATTY_SERVER],
+    ...overrides,
+  };
+}
+
+let registry: McplServerRegistry | null = null;
+afterEach(async () => {
+  await registry?.closeAll();
+  registry = null;
+});
+
+test('masked afterInference is invisible to capability queries; unmasked hooks survive', async () => {
+  registry = new McplServerRegistry();
+  const connection = await registry.addServer(
+    config({ disabledCapabilities: ['contextHooks.afterInference'] }),
+    HOST_CAPS,
+  );
+  connection.ready();
+
+  assert.equal(connection.capabilities?.contextHooks?.beforeInference, true);
+  assert.equal(connection.capabilities?.contextHooks?.afterInference, undefined);
+  assert.deepEqual(registry.getServersWithCapability('contextHooks.afterInference'), []);
+  assert.equal(registry.getServersWithCapability('contextHooks.beforeInference').length, 1);
+  // pushEvents untouched — scoping is per-capability, not per-server.
+  assert.equal(registry.getServersWithCapability('pushEvents').length, 1);
+});
+
+test('inbound push/event from a pushEvents-masked server is rejected with CAPABILITY_DISABLED', async () => {
+  registry = new McplServerRegistry();
+  const connection = await registry.addServer(
+    config({ disabledCapabilities: ['pushEvents'] }),
+    HOST_CAPS,
+  );
+  connection.ready();
+
+  let pushEventEmitted = false;
+  connection.on('push-event', () => { pushEventEmitted = true; });
+
+  // tools/list triggers the server's push/event; its result carries the
+  // host's JSON-RPC response to that push.
+  const result = await connection.sendToolsList() as {
+    tools: unknown[];
+    pushResponse?: { error?: { code: number; message: string } };
+  };
+
+  assert.equal(pushEventEmitted, false, 'masked push must not reach host handlers');
+  assert.equal(result.pushResponse?.error?.code, CAPABILITY_DISABLED);
+  assert.match(result.pushResponse?.error?.message ?? '', /pushEvents/);
+});
+
+test('without scoping, the same push/event reaches host handlers', async () => {
+  registry = new McplServerRegistry();
+  const connection = await registry.addServer(config(), HOST_CAPS);
+  connection.ready();
+
+  const pushSeen = new Promise<void>((resolve) => {
+    connection.on('push-event', (_params: unknown, responder?: { respond: (r: unknown) => void }) => {
+      responder?.respond({ accepted: true });
+      resolve();
+    });
+  });
+
+  await connection.sendToolsList();
+  await pushSeen;
+});

--- a/test/mcpl-gate-roundtrip.test.ts
+++ b/test/mcpl-gate-roundtrip.test.ts
@@ -41,6 +41,14 @@ function makeRegistry(shouldTriggerInference?: (c: string, m: Record<string, unk
     () => {},
     shouldTriggerInference ? { shouldTriggerInference } : undefined,
   );
+  // §14.5: incoming no longer mints unknown channels — seed what a
+  // conforming server's channels/register would have created.
+  for (const id of ['zulip:tracker-miner-f', 'zulip:other-channel']) {
+    (registry as unknown as { channels: Map<string, unknown> }).channels.set(`zulip:${id}`, {
+      serverId: 'zulip', descriptor: { id, type: 'zulip', label: id }, open: false,
+    });
+  }
+
   return { registry, pushed };
 }
 

--- a/test/mcpl-gate-roundtrip.test.ts
+++ b/test/mcpl-gate-roundtrip.test.ts
@@ -1,3 +1,4 @@
+import { CapabilityGrant, ALL_CAPABILITY_PATHS } from '../src/mcpl/capability-grant.js';
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
 import { existsSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
@@ -134,6 +135,9 @@ describe('ChannelRegistry subscriptionPolicy', () => {
     const opens: Array<{ type: string; address: unknown }> = [];
     const closes: Array<{ channelId: string }> = [];
     const server = {
+      // Post-policy state: full grant so subscription reconciliation runs
+      // (§14.1 skips lifecycle for ungranted servers).
+      grant: new CapabilityGrant(new Set(ALL_CAPABILITY_PATHS), []),
       sendChannelsOpen: async (args: { type: string; address: unknown }) => { opens.push(args); },
       sendChannelsClose: async (args: { channelId: string }) => { closes.push(args); return { closed: true }; },
     };
@@ -276,6 +280,7 @@ describe('ChannelRegistry durable lifecycle', () => {
   it('requires serverId only when two MCPLs expose the same channel id', async () => {
     const openedBy: string[] = [];
     const servers = new Map(['alpha', 'beta'].map((serverId) => [serverId, {
+      grant: new CapabilityGrant(new Set(ALL_CAPABILITY_PATHS), []),
       sendChannelsOpen: async () => {
         openedBy.push(serverId);
         return { channel: { ...oneChannel[0], id: 'shared' } };
@@ -310,6 +315,7 @@ describe('ChannelRegistry durable lifecycle', () => {
     const closes: string[] = [];
     const acks: unknown[] = [];
     const server = {
+      grant: new CapabilityGrant(new Set(ALL_CAPABILITY_PATHS), []),
       sendChannelsOpen: async (args: { channelId?: string }) => {
         opens.push(args.channelId ?? '');
         return { channel: oneChannel[0] };

--- a/test/mcpl-reconnect-events.test.ts
+++ b/test/mcpl-reconnect-events.test.ts
@@ -28,7 +28,7 @@ const FLAG_FILE = join(TMP_DIR, 'server-healthy');
 const HOST_CAPS: McplHostCapabilities = {
   version: '0.4',
   pushEvents: true,
-  contextHooks: { beforeInference: true, afterInference: { blocking: true } },
+  contextHooks: { beforeInference: true },
   featureSets: true,
 };
 

--- a/test/mcpl-reconnect-reregistration.test.ts
+++ b/test/mcpl-reconnect-reregistration.test.ts
@@ -24,6 +24,7 @@ import { AgentFramework } from '../src/framework.js';
 import { FeatureSetManager } from '../src/mcpl/feature-set-manager.js';
 import { ScopeManager } from '../src/mcpl/scope-manager.js';
 import { CheckpointManager } from '../src/mcpl/checkpoint-manager.js';
+import { CapabilityGrant } from '../src/mcpl/capability-grant.js';
 import { PushHandler } from '../src/mcpl/push-handler.js';
 import type { McplCapabilities, McplServerConfig, PushEventResult } from '../src/mcpl/types.js';
 
@@ -39,7 +40,12 @@ function makeStoreStub() {
 }
 
 const CAPABILITIES: McplCapabilities = {
-  version: '0.4',
+  version: '0.5',
+  // §6.4 derivation runs against the computed grant now: the advertisement
+  // must cover each feature set's `uses` or derivation disables it before
+  // any push is attempted.
+  pushEvents: true,
+  tools: true,
   featureSets: {
     chat: { description: 'chat events', uses: ['pushEvents'] },
     mem: { description: 'stateful memory', uses: ['tools'], hostState: true, rollback: true },
@@ -52,6 +58,20 @@ class FakeConnection extends EventEmitter {
   willReconnect = true;
   featureSetUpdates: unknown[] = [];
   onReady: (() => void) | undefined;
+  // 0.5 surface (§5.3/§6.7): the framework now sends the initial policy as a
+  // Request and activates the grant on the receipt. The fake answers
+  // accepted — modeling a conforming 0.5 server — so registration reaches
+  // establishGrant and post-policy tests exercise delivery, not denial.
+  grant = CapabilityGrant.empty();
+  policyEstablished = false;
+  establishGrant(grant: CapabilityGrant): void {
+    this.grant = grant;
+    this.policyEstablished = true;
+  }
+  sendFeatureSetsUpdateRequest(params: unknown): Promise<{ accepted: true }> {
+    this.featureSetUpdates.push(params);
+    return Promise.resolve({ accepted: true });
+  }
   constructor(id: string) {
     super();
     this.id = id;
@@ -68,7 +88,7 @@ class FakeConnection extends EventEmitter {
   }
 }
 
-function makeHarness() {
+async function makeHarness() {
   const store = makeStoreStub();
   const traces: Array<{ type: string }> = [];
   const pushed: unknown[] = [];
@@ -110,9 +130,13 @@ function makeHarness() {
   fw.discordAwarenessBarrier = null;
   fw.discordAwarenessBarrierGeneration = 0;
   fw.wireMcplEvents(connection);
-  fw.registerMcplServerFeatures(config, connection);
+  await fw.registerMcplServerFeatures(config, connection);
 
-  const sendPush = (eventId: string): PushEventResult => {
+  // The push handler responds synchronously when no awareness barrier is
+  // up, but during reconnect the §5.3 policy round-trip holds the barrier
+  // across a microtask — so the harness settles the loop once before
+  // asserting. (Was 'must respond synchronously' pre-0.5.)
+  const sendPush = async (eventId: string): Promise<PushEventResult> => {
     let result: PushEventResult | undefined;
     connection.emit(
       'push-event',
@@ -124,21 +148,22 @@ function makeHarness() {
       },
       {
         respond: (r: PushEventResult) => { result = r; },
-        respondError: () => { assert.fail('push responded with a JSON-RPC error'); },
+        respondError: (_c: number, m: string) => { result = { accepted: false, reason: m }; },
       },
     );
-    assert.ok(result, 'push handler must respond synchronously');
+    if (!result) await new Promise((r) => setImmediate(r));
+    assert.ok(result, 'push handler must respond within one settle');
     return result!;
   };
 
   return { fw, store, connection, config, sendPush, pushed, traces };
 }
 
-test('reconnect re-registers the server: pushes are accepted again after close→reconnect', () => {
-  const { fw, connection, sendPush, pushed } = makeHarness();
+test('reconnect re-registers the server: pushes are accepted again after close→reconnect', async () => {
+  const { fw, connection, sendPush, pushed } = await makeHarness();
 
   // Sanity: initial registration accepts pushes.
-  assert.equal(sendPush('e1').accepted, true);
+  assert.equal((await sendPush('e1')).accepted, true);
   assert.equal(pushed.length, 1);
 
   // Transient crash: transport closed, background reconnect pending.
@@ -146,7 +171,7 @@ test('reconnect re-registers the server: pushes are accepted again after close�
   connection.emit('close', null, 'SIGKILL');
 
   // While down, the server is deregistered — pushes are rejected.
-  const down = sendPush('e2');
+  const down = await sendPush('e2');
   assert.equal(down.accepted, false);
   assert.match(down.reason ?? '', /Unknown server/);
 
@@ -155,12 +180,18 @@ test('reconnect re-registers the server: pushes are accepted again after close�
   // push already buffered on the fresh transport: ready() flushes it in the
   // reconnect listener's stack, after host-side feature re-registration.
   let duringReconnect: PushEventResult | undefined;
-  connection.onReady = () => { duringReconnect = sendPush('e3'); };
+  let e3: Promise<PushEventResult> | undefined;
+  connection.onReady = () => { e3 = sendPush('e3'); };
   connection.emit('reconnect', { attempts: 1 });
+  // Re-registration is async since the §5.3 policy Request: the reconnect
+  // listener awaits the receipt before releasing the data plane, so settle
+  // the microtask chain before asserting what happened at ready().
+  await new Promise((r) => setImmediate(r));
+  duringReconnect = await e3;
   assert.equal(duringReconnect?.accepted, true);
 
   // THE regression: before the fix this stayed rejected forever.
-  const revived = sendPush('e4');
+  const revived = await sendPush('e4');
   assert.equal(revived.accepted, true, `push after reconnect must be accepted, got: ${revived.reason}`);
   assert.equal(pushed.length, 3);
 
@@ -169,8 +200,8 @@ test('reconnect re-registers the server: pushes are accepted again after close�
   assert.ok(fw.featureSetManager.isEnabled('srv', 'chat'));
 });
 
-test('checkpoint state SURVIVES a transient close + reconnect', () => {
-  const { fw, store, connection } = makeHarness();
+test('checkpoint state SURVIVES a transient close + reconnect', async () => {
+  const { fw, store, connection } = await makeHarness();
 
   // Record durable checkpoint state for the stateful feature set.
   fw.checkpointManager.recordCheckpoint('srv', 'mem', {
@@ -196,7 +227,7 @@ test('checkpoint state SURVIVES a transient close + reconnect', () => {
   assert.deepEqual(fw.checkpointManager.getCurrentState('srv', 'mem'), { counter: 42 });
 });
 
-test('the close handler NEVER destroys checkpoints — even with willReconnect=false', () => {
+test('the close handler NEVER destroys checkpoints — even with willReconnect=false', async () => {
   // A clean AgentFramework.stop() sets reconnectEnabled=false BEFORE emitting
   // 'close', so willReconnect is false on an ordinary host restart just as much
   // as on a permanent teardown. Gating checkpoint destruction on willReconnect
@@ -204,7 +235,7 @@ test('the close handler NEVER destroys checkpoints — even with willReconnect=f
   // (while a SIGKILL, whose 'close' carries willReconnect=true, preserved them).
   // Permanent removal is owned solely by disconnectMcplServer; the close handler
   // must leave the persisted tree intact for loadFromStore() to resume.
-  const { fw, store, connection } = makeHarness();
+  const { fw, store, connection } = await makeHarness();
 
   fw.checkpointManager.recordCheckpoint('srv', 'mem', { checkpoint: 'cp1', data: { x: 1 } });
 
@@ -221,7 +252,7 @@ test('the close handler NEVER destroys checkpoints — even with willReconnect=f
 });
 
 test('disconnectMcplServer destroys checkpoints even when the connection already closed transiently', async () => {
-  const { fw, connection, config } = makeHarness();
+  const { fw, connection, config } = await makeHarness();
 
   fw.checkpointManager.recordCheckpoint('srv', 'mem', { checkpoint: 'cp1', data: { x: 1 } });
 

--- a/test/mcpl-reconnect-reregistration.test.ts
+++ b/test/mcpl-reconnect-reregistration.test.ts
@@ -63,6 +63,10 @@ class FakeConnection extends EventEmitter {
   // accepted — modeling a conforming 0.5 server — so registration reaches
   // establishGrant and post-policy tests exercise delivery, not denial.
   grant = CapabilityGrant.empty();
+  // §5.1: `tools` comes from the OUTER standard MCP capabilities — the
+  // experimental advert can't mint it. mem uses ['tools'], so the fake
+  // models a server whose initialize carried capabilities.tools.
+  mcpToolsAdvertised = true;
   policyEstablished = false;
   establishGrant(grant: CapabilityGrant): void {
     this.grant = grant;

--- a/test/mcpl-request-timeout.test.ts
+++ b/test/mcpl-request-timeout.test.ts
@@ -34,7 +34,7 @@ setInterval(() => {}, 1 << 30); // stay alive
 const HOST_CAPS: McplHostCapabilities = {
   version: '0.4',
   pushEvents: true,
-  contextHooks: { beforeInference: true, afterInference: { blocking: true } },
+  contextHooks: { beforeInference: true },
   featureSets: true,
 };
 


### PR DESCRIPTION
Closes #76 (items 1–12) and folds in PR #75 (Meganeuridae's capability-scoping mask, merged with authorship preserved — its wildcard matcher and mask semantics survive intact as the config-policy layer; its inbound deny-list check is inverted to the positive-grant allowlist per the review adjudication).

**Head for review: `a153e3b`.** Four commits tell the story: grant core + §5.3 handshake (`5160315`), channel gating + lifecycle + tags (`4040bdf`), reduction-ordering coverage (`032f481`, `9ea45dc`-adjacent test work), admission-time gate + suite reconciliation (`a153e3b`).

## The composed security path (Sol's checklist, mapped)

- **Positive-grant enforcement, both directions** — `capability-grant.ts` (vocabulary tree, recursive §5.1 walk, one-segment `*`, bare-parent-grants-nothing, §13.4 deny-by-default for `inject.system`); inbound at the **admission choke-point** (`server-connection.ts` `emit()` override — see below), outbound at every channel-registry send site per §14.1.
- **Initial Request/receipt readiness** — `registerMcplServerFeatures`: Request always sent (even empty), receipt honored (`fallback: mcp-only|close`), **unanswered = expansion does not activate** (grant stays empty; darkens un-migrated servers, accepted for the one-release train).
- **Reduction/expansion ordering** — `establishGrant` before a reducing Request / after an expanding receipt; `CapabilityGrant.without()`; E2E round 3 proves immediate reduction with no receipt awaited.
- **Write-without-read** — `userMessage: null` when observe ungranted, hook still invoked (§10.1).
- **Per-injection response-receipt authorization** — typed `position` vs grant current at receipt (§10.8); never the response's featureSet.
- **Channel itemization** — §14.5 `results[]` (strict servers read absent results as reject-all); method→capability table with specific sub-capabilities.
- **Lifecycle** — `inference/lifecycle` best-effort: `started` at stream start, exactly one terminal in the shared `finally` (completed/failed/aborted by path). `afterInference` and `modifiedResponse` gone.
- **Tag closure after admission** — `tags.ts`, applied at both entries; producer `implies`/`suggestedTreatment` deliberately unconsumed.
- **Host self-advertisement** — 0.5 with `inferenceRequest{streaming}`, full channels object, `inferenceLifecycle`; `afterInference` dropped. §7/ScopeManager removed; `scope/elevate` answers -32601.

## Two design defects the suite caught (fixed in src, not tests)

1. **Grantless objects crashed the gates** → `CapabilityGrant.of()`: absence = nothing granted, never a TypeError.
2. **Line-receipt rejection answered staged traffic** — a -32002 before the policy exchange settled bounced conforming startup pushes AND made a *failed* startup observable to the server. Enforcement moved into the `emit()` admission path that live routing and buffer flushes share; startup order is now accounting → policy → gate-complete.

## Suite evidence

**502/507.** The 4 residual failures **pre-exist on origin/main** (baseline: 19/490 fail in this environment; name-level diff in the test logs). This branch **fixes 15 of those 19** (same staging-race class) and regresses none. `npm test` gains `--test-force-exit` — the runner previously wedged at exit on a keep-alive handle and hid results.

Every test whose old assertion encoded the pre-0.5 contract (advertised ⇒ delivered) was rewritten to assert the 0.5 contract explicitly rather than weakened — each is commented with the section that changed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)