### PR TITLE
feat(mcpl): expose live policy status in server listing

### DIFF
--- a/src/framework.ts
+++ b/src/framework.ts
@@ -8609,23 +8609,44 @@ export class AgentFramework {
   listMcplServers(): Array<{
     id: string;
     connected: boolean;
+    retrying: boolean;
     toolPrefix: string;
     toolCount: number;
+    /** True only after the §5.3 policy receipt activated the grant. */
+    policyEstablished: boolean;
+    /** Sole normative authorization allowlist for the connection (§5.4). */
+    effectiveGrant: string[];
+    /** Advertised paths removed by host enabled/disabled capability config. */
+    maskedCapabilities: string[];
+    /** Advertised paths removed by a host deny-by-default rule (§13.4). */
+    deniedCapabilities: string[];
+    /** Host-owned authority; deliberately separate from the portable grant. */
+    allowHostCommands: boolean;
     command?: string;
     url?: string;
   }> {
     const result: Array<{
-      id: string; connected: boolean; toolPrefix: string; toolCount: number;
+      id: string; connected: boolean; retrying: boolean;
+      toolPrefix: string; toolCount: number; policyEstablished: boolean;
+      effectiveGrant: string[]; maskedCapabilities: string[];
+      deniedCapabilities: string[]; allowHostCommands: boolean;
       command?: string; url?: string;
     }> = [];
     for (const [id, config] of this.mcplServerConfigs) {
       const prefix = config.toolPrefix ?? `mcpl--${id}`;
       const connection = this.mcplServerRegistry?.getServer(id) ?? null;
+      const connected = connection?.isConnected ?? false;
       result.push({
         id,
-        connected: connection?.isConnected ?? false,
+        connected,
+        retrying: !connected && (connection?.willReconnect ?? false),
         toolPrefix: prefix,
         toolCount: this.mcplTools.filter(t => t.name.startsWith(`${prefix}--`)).length,
+        policyEstablished: connection?.policyEstablished ?? false,
+        effectiveGrant: connection?.grant.effectiveList() ?? [],
+        maskedCapabilities: [...(connection?.droppedCapabilities ?? [])].sort(),
+        deniedCapabilities: [...(connection?.grant.deniedPaths ?? [])].sort(),
+        allowHostCommands: config.allowHostCommands === true,
         command: config.command,
         url: config.url,
       });

--- a/test/mcpl-list-status.test.ts
+++ b/test/mcpl-list-status.test.ts
@@ -1,0 +1,63 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { AgentFramework } from '../src/framework.js';
+import { CapabilityGrant } from '../src/mcpl/capability-grant.js';
+
+function frameworkWithConnection(connection: Record<string, unknown>) {
+  const framework = Object.create(AgentFramework.prototype) as any;
+  framework.mcplServerConfigs = new Map([[
+    'discord',
+    { id: 'discord', command: 'node', allowHostCommands: true },
+  ]]);
+  framework.mcplServerRegistry = {
+    getServer: (id: string) => id === 'discord' ? connection : null,
+  };
+  framework.mcplTools = [{ name: 'mcpl--discord--send_message' }];
+  return framework as AgentFramework;
+}
+
+test('listMcplServers exposes the live grant layers and host-owned authority', () => {
+  const grant = new CapabilityGrant(
+    new Set(['channels.incoming', 'channels.publish']),
+    ['contextHooks.beforeInference.inject.system'],
+  );
+  const framework = frameworkWithConnection({
+    isConnected: true,
+    willReconnect: true,
+    policyEstablished: true,
+    grant,
+    droppedCapabilities: new Set(['channels.streaming']),
+  });
+
+  assert.deepEqual(framework.listMcplServers(), [{
+    id: 'discord',
+    connected: true,
+    retrying: false,
+    toolPrefix: 'mcpl--discord',
+    toolCount: 1,
+    policyEstablished: true,
+    effectiveGrant: ['channels.incoming', 'channels.publish'],
+    maskedCapabilities: ['channels.streaming'],
+    deniedCapabilities: ['contextHooks.beforeInference.inject.system'],
+    allowHostCommands: true,
+    command: 'node',
+    url: undefined,
+  }]);
+});
+
+test('listMcplServers distinguishes a disconnected retrying stub from connected', () => {
+  const framework = frameworkWithConnection({
+    isConnected: false,
+    willReconnect: true,
+    policyEstablished: false,
+    grant: CapabilityGrant.empty(),
+    droppedCapabilities: new Set<string>(),
+  });
+
+  const [status] = framework.listMcplServers();
+  assert.equal(status.connected, false);
+  assert.equal(status.retrying, true);
+  assert.equal(status.policyEstablished, false);
+  assert.deepEqual(status.effectiveGrant, []);
+});


### PR DESCRIPTION
Stacked on #79.

Keeps the legibility change deliberately narrow and copies state already owned by McplServerConnection into listMcplServers():

- connected vs retrying
- policyEstablished
- effective grant
- config-masked paths
- deny-by-default paths
- host-owned allowHostCommands

No manifest, ontology, URI, freshness, timestamp, or provenance placeholders are introduced.

Verification:
- npm run build
- focused mcpl-list-status tests
- full npm test: 525 passed, 0 failed, 1 skipped