### PR TITLE
fix(mcpl): revoke stale grants across reconnects

### DIFF
--- a/src/mcpl/server-connection.ts
+++ b/src/mcpl/server-connection.ts
@@ -147,6 +147,14 @@ export class McplServerConnection extends EventEmitter {
     this.policyEstablished = true;
   }
 
+  /** A §5.3 grant belongs to one initialized transport epoch. Reconnecting
+   * performs a fresh initialize handshake, so authority from the dead epoch
+   * must be revoked before the replacement transport is exposed. */
+  private resetPolicyForTransportBoundary(): void {
+    this.grant = CapabilityGrant.empty();
+    this.policyEstablished = false;
+  }
+
   /** The active transport (stdio child or WebSocket). Null for a disconnected
    *  stub awaiting its first background reconnect. */
   private transport: McplTransport | null;
@@ -719,6 +727,7 @@ export class McplServerConnection extends EventEmitter {
       return;
     }
     this.closed = true;
+    this.resetPolicyForTransportBoundary();
 
     // Reject all pending requests
     for (const [id, pending] of this.pendingRequests) {
@@ -807,6 +816,7 @@ export class McplServerConnection extends EventEmitter {
       // awareness barrier synchronously, then releases control traffic needed
       // to establish the server while data remains held.
       this.pauseDataPlane();
+      this.resetPolicyForTransportBoundary();
       this.transport = transport;
       this.capabilities = capabilities;
       this.droppedCapabilities = droppedCapabilities;
@@ -1125,6 +1135,7 @@ export class McplServerConnection extends EventEmitter {
     transport.on('close', (info: TransportCloseInfo) => {
       if (!this.closed) {
         this.closed = true;
+        this.resetPolicyForTransportBoundary();
 
         // Reject all pending requests
         for (const [id, pending] of this.pendingRequests) {

--- a/test/fixtures/flaky-mcpl-server.mjs
+++ b/test/fixtures/flaky-mcpl-server.mjs
@@ -28,7 +28,9 @@ rl.on('line', (line) => {
         id: msg.id,
         result: {
           protocolVersion: '2024-11-05',
-          capabilities: {},
+          capabilities: {
+            experimental: { mcpl: { version: '0.5', pushEvents: true } },
+          },
           serverInfo: { name: 'flaky-mcpl-server', version: '0.0.0' },
         },
       }) + '\n',

--- a/test/mcpl-reconnect-events.test.ts
+++ b/test/mcpl-reconnect-events.test.ts
@@ -14,6 +14,7 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { McplServerConnection } from '../src/mcpl/server-connection.js';
+import { CapabilityGrant } from '../src/mcpl/capability-grant.js';
 import type { McplHostCapabilities, McplServerConfig } from '../src/mcpl/types.js';
 
 // The .mjs fixture is not compiled/copied by tsc, so when this test runs from
@@ -26,7 +27,7 @@ const TMP_DIR = join(import.meta.dirname, '../.test-tmp-reconnect');
 const FLAG_FILE = join(TMP_DIR, 'server-healthy');
 
 const HOST_CAPS: McplHostCapabilities = {
-  version: '0.4',
+  version: '0.5',
   pushEvents: true,
   contextHooks: { beforeInference: true },
   featureSets: true,
@@ -140,5 +141,33 @@ describe('McplServerConnection — reconnect lifecycle events', () => {
     await new Promise((r) => setTimeout(r, 200));
     assert.strictEqual(reconnected.length, 0);
     connection = null;
+  });
+
+  it('clears the previous transport grant before publishing a reconnected handshake', async () => {
+    writeFileSync(FLAG_FILE, '');
+    connection = await McplServerConnection.connect(makeConfig(), HOST_CAPS);
+    connection.establishGrant(new CapabilityGrant(new Set(['pushEvents']), []));
+    assert.strictEqual(connection.policyEstablished, true);
+    assert.deepStrictEqual(connection.grant.effectiveList(), ['pushEvents']);
+
+    let stateAtReconnect: { policyEstablished: boolean; grant: string[] } | null = null;
+    connection.on('reconnect', () => {
+      stateAtReconnect = {
+        policyEstablished: connection!.policyEstablished,
+        grant: connection!.grant.effectiveList(),
+      };
+    });
+    connection.ready();
+
+    // Crash the old transport. The replacement handshake is a fresh policy
+    // epoch: no authority from the prior process may survive until the host's
+    // new §5.3 Request receives its degradation receipt.
+    connection.sendToolsList().catch(() => {});
+    await waitFor(() => stateAtReconnect !== null, 5000, 'reconnect after granted transport');
+
+    assert.deepStrictEqual(stateAtReconnect, {
+      policyEstablished: false,
+      grant: [],
+    });
   });
 });


### PR DESCRIPTION
Stacked on #79. This is separate from the mcpl_list legibility PR.

A successful reconnect performs a new initialize handshake but the connection currently keeps the prior transport epoch policyEstablished=true and its old grant until re-registration finishes. Because the control plane remains available during reconnect establishment, prior authority can survive into the fresh epoch.

The added regression test is red on #79 head 6565b787:

- expected policyEstablished=false and grant=[] at the reconnect event
- actual policyEstablished=true and grant=[pushEvents]

The fix revokes the grant and clears policyEstablished at transport close and again before adopting a replacement transport. Expansion still happens only after the fresh §5.3 receipt.

Verification:
- npm run build
- reconnect regression test: 4/4 pass
- related awareness/reconnect/scoping tests: 48 pass, 0 fail