### PR TITLE
MCPL 0.5: §17 host-side manifest tracking (#78)

### DIFF
--- a/src/framework.ts
+++ b/src/framework.ts
@@ -56,7 +56,8 @@ import { Agent } from './agent.js';
 import { ModuleRegistry, isStateExistsError } from './module-registry.js';
 import { McplServerRegistry } from './mcpl/server-registry.js';
 import { FeatureSetManager } from './mcpl/feature-set-manager.js';
-import { computeGrant } from './mcpl/capability-grant.js';
+import { computeGrant, CapabilityGrant, expandAdvertisementShorthand } from './mcpl/capability-grant.js';
+import { maskNegotiatedCapabilities } from './mcpl/capability-mask.js';
 import { HookOrchestrator } from './mcpl/hook-orchestrator.js';
 import { PushHandler, type McplPushEvent } from './mcpl/push-handler.js';
 import { parseProsePrefix } from './mcpl/prose-grammar.js';
@@ -8406,6 +8407,169 @@ export class AgentFramework {
     this.emitTrace({ type: 'module:added', moduleName: `mcpl:${config.id}` });
   }
 
+  /** Per-connection §17.8 fetch limiter: at most one in-flight fetch, at
+   *  most one queued behind it (announcements coalesce), floor between
+   *  completed fetches. Exceeding the floor drops the excess with a
+   *  diagnostic — the host bounds the rate; it never depends on server
+   *  coalescing. */
+  private manifestRefreshState: Map<string, { inFlight: boolean; queued: boolean; lastCompletedAt: number }> = new Map();
+  private static readonly MANIFEST_FETCH_FLOOR_MS = 5_000;
+
+  /**
+   * §17.5 host processing: fetch the complete manifest, validate exactly as
+   * at initialize, diff, apply §6.7 consequences (removals eagerly even
+   * when other declarations are invalid; additions only through
+   * tell→receipt→activate), emit ONE change receipt (§17.6).
+   */
+  private async handleManifestChanged(
+    connection: McplServerConnection,
+    announce: { revision?: string; domains?: string[] },
+  ): Promise<void> {
+    const st = this.manifestRefreshState.get(connection.id)
+      ?? { inFlight: false, queued: false, lastCompletedAt: 0 };
+    this.manifestRefreshState.set(connection.id, st);
+    if (st.inFlight) {
+      // Coalesce: one queued refresh re-runs after the current fetch — the
+      // fetch is always of the CURRENT manifest, so N announcements need at
+      // most one trailing fetch (§17.8).
+      st.queued = true;
+      return;
+    }
+    const sinceLast = Date.now() - st.lastCompletedAt;
+    if (sinceLast < AgentFramework.MANIFEST_FETCH_FLOOR_MS) {
+      if (!st.queued) {
+        st.queued = true;
+        setTimeout(() => {
+          const cur = this.manifestRefreshState.get(connection.id);
+          if (cur?.queued && !cur.inFlight) {
+            cur.queued = false;
+            void this.handleManifestChanged(connection, announce).catch(() => {});
+          }
+        }, AgentFramework.MANIFEST_FETCH_FLOOR_MS - sinceLast).unref?.();
+      }
+      return;
+    }
+
+    st.inFlight = true;
+    try {
+      const config = this.mcplServerConfigs.get(connection.id);
+      if (!config) return;
+
+      // §17.4 fetch. A server that cannot answer keeps its previous
+      // manifest in force — an unparseable/failed fetch teaches nothing and
+      // narrows nothing (§17.5 step 1).
+      let fetched: import('./mcpl/types.js').McplCapabilities | null;
+      try {
+        fetched = await connection.sendManifestRequest();
+      } catch (err) {
+        console.error(`[mcpl] ${connection.id}: mcpl/manifest fetch failed — previous manifest stands (§17.5): ${err instanceof Error ? err.message : err}`);
+        return;
+      }
+      if (!fetched || typeof fetched !== 'object') {
+        console.error(`[mcpl] ${connection.id}: mcpl/manifest returned no object — previous manifest stands (§17.5)`);
+        return;
+      }
+
+      // Validate exactly as at initialize: expand §5.1 shorthand, apply the
+      // config mask, recompute the grant. Unknown names mint nothing;
+      // invalid declarations fail closed in derivation — and REMOVALS still
+      // apply, because the new grant/derivation simply lacks whatever no
+      // longer validates (§17.5 step 1's partial-invalid rule falls out of
+      // computing forward from the fetched content).
+      const expanded = expandAdvertisementShorthand(fetched);
+      const { capabilities: masked, dropped } = maskNegotiatedCapabilities(expanded, config);
+      const newGrant = computeGrant(masked, config, { mcpToolsAdvertised: connection.mcpToolsAdvertised });
+
+      const oldEffective = new Set(connection.grant.effectiveList());
+      const newEffective = new Set(newGrant.effectiveList());
+      const revoked = [...oldEffective].filter((p) => !newEffective.has(p)).sort();
+      const added = [...newEffective].filter((p) => !oldEffective.has(p)).sort();
+
+      const oldDeclared = Object.keys(this.featureSetManager?.getDeclaredFeatureSets(connection.id) ?? {});
+      const oldEnabled = oldDeclared.filter((n) => this.featureSetManager?.isEnabled(connection.id, n));
+
+      // §6.7 REDUCTION FIRST, atomically, before the server is told:
+      // security cannot wait on consent. The interim grant is new∩old — no
+      // revoked path survives, no added path activates yet.
+      const hadReduction = revoked.length > 0;
+      if (hadReduction) {
+        const interim = new CapabilityGrant(
+          new Set([...newEffective].filter((p) => oldEffective.has(p))),
+          [...newGrant.deniedPaths],
+        );
+        connection.establishGrant(interim);
+      }
+
+      // Re-derive feature-set state from the fetched declarations + the NEW
+      // grant (§6.4 fail-closed), replacing the stored declarations — a
+      // feature set absent from the new manifest is gone regardless of what
+      // else failed validation.
+      const updateParams = this.featureSetManager!.initializeServer(
+        connection.id,
+        masked ?? ({ version: '0.5' } as import('./mcpl/types.js').McplCapabilities),
+        { enabledFeatureSets: config.enabledFeatureSets, disabledFeatureSets: config.disabledFeatureSets },
+        newGrant,
+      );
+      updateParams.effectiveCapabilities = newGrant.effectiveList();
+      if (newGrant.deniedPaths.length > 0) updateParams.deniedCapabilities = [...newGrant.deniedPaths];
+
+      // Tell → receipt → activate (§6.7): expansions and the full new grant
+      // take effect only after the server acknowledges the new policy. An
+      // unanswered Request leaves the interim (reduced) grant standing.
+      let negotiated = false;
+      try {
+        const receipt = await connection.sendFeatureSetsUpdateRequest(updateParams);
+        if (receipt && receipt.accepted === false) {
+          console.error(`[mcpl] ${connection.id} refused post-manifest policy (${receipt.fallback}); grant stays ${hadReduction ? 'reduced' : 'unchanged'}`);
+        } else {
+          connection.establishGrant(newGrant);
+          connection.manifestState.lastNegotiatedAt = Date.now();
+          negotiated = true;
+        }
+      } catch {
+        console.error(`[mcpl] ${connection.id} did not answer post-manifest policy — expansion does not activate (§6.7)`);
+      }
+
+      // Adopt the validated manifest + tracking.
+      connection.capabilities = masked;
+      connection.manifestState.lastValidatedRevision =
+        typeof (fetched as { revision?: unknown }).revision === 'string'
+          ? (fetched as { revision: string }).revision : null;
+      connection.manifestState.lastFetchedAt = Date.now();
+      if (dropped.length > 0) connection.droppedCapabilities = new Set(dropped);
+
+      const newDeclared = Object.keys(this.featureSetManager?.getDeclaredFeatureSets(connection.id) ?? {});
+      const newEnabled = newDeclared.filter((n) => this.featureSetManager?.isEnabled(connection.id, n));
+      const degraded = oldEnabled.filter((n) => !newEnabled.includes(n)).sort();
+      const restored = newEnabled.filter((n) => !oldEnabled.includes(n)).sort();
+
+      // §17.6: ONE receipt per manifest change, closed host-derived impact
+      // vocabulary, never a server-authored flag.
+      const impacts: Array<{ impact: string; subject: string; disposition: string }> = [
+        ...revoked.map((p) => ({ impact: 'capability-revoked', subject: p, disposition: 'applied' })),
+        ...added.map((p) => ({ impact: 'capability-expansion-pending', subject: p, disposition: negotiated ? 'applied' : 'decision-needed' })),
+        ...degraded.map((n) => ({ impact: 'feature-degraded', subject: n, disposition: 'applied' })),
+        ...restored.map((n) => ({ impact: 'feature-restored', subject: n, disposition: negotiated ? 'applied' : 'decision-needed' })),
+      ];
+      this.emitTrace({
+        type: 'mcpl:manifest-change-receipt',
+        serverId: connection.id,
+        revision: connection.manifestState.lastValidatedRevision,
+        announcedDomains: announce.domains ?? [],
+        impacts,
+      });
+      this.handleToolsListChanged(connection.id);
+    } finally {
+      st.inFlight = false;
+      st.lastCompletedAt = Date.now();
+      if (st.queued) {
+        st.queued = false;
+        setTimeout(() => { void this.handleManifestChanged(connection, announce).catch(() => {}); },
+          AgentFramework.MANIFEST_FETCH_FLOOR_MS).unref?.();
+      }
+    }
+  }
+
   /**
    * (Re-)establish a server's host-side MCPL registration: feature-set state
    * (plus the featureSets/update sent to the server), scope patterns, and
@@ -8722,6 +8886,15 @@ export class AgentFramework {
 
     // §6.6/§12: requests that previously had no handler and hung forever
     // (AUDIT-001 item 4). The connection-level grant gate has already run.
+    // §17.3: a manifest-change announcement. Rate-limited re-fetch → diff
+    // → §6.7 consequences → one receipt. The announcement itself carries no
+    // payload and no authority; everything below acts on FETCHED content.
+    connection.on('manifest-changed', (params: { revision?: string; domains?: string[] }) => {
+      void this.handleManifestChanged(connection, params).catch((err) => {
+        console.error(`[mcpl] ${connection.id} manifest refresh failed:`, err instanceof Error ? err.message : err);
+      });
+    });
+
     connection.on('channels-list', (
       _params: unknown,
       responder?: { respond: (result: unknown) => void },

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -8500,43 +8500,61 @@ export class AgentFramework {
         connection.establishGrant(interim);
       }
 
-      // Re-derive feature-set state from the fetched declarations + the NEW
-      // grant (§6.4 fail-closed), replacing the stored declarations — a
-      // feature set absent from the new manifest is gone regardless of what
-      // else failed validation.
-      const updateParams = this.featureSetManager!.initializeServer(
-        connection.id,
-        masked ?? ({ version: '0.5' } as import('./mcpl/types.js').McplCapabilities),
-        { enabledFeatureSets: config.enabledFeatureSets, disabledFeatureSets: config.disabledFeatureSets },
-        newGrant,
-      );
+      // PHASE 1 — pre-receipt: live feature state derives from ACTIVE
+      // authority (the interim grant when reduced, the standing grant
+      // otherwise), never from the unactivated full grant. Feature state
+      // must obey the same §6.7 ordering the grant does: a newly added
+      // capability-backed feature set cannot be host-enabled while its
+      // capability is still absent from the active grant (Sol, PR #84
+      // review). Declarations come from the fetched manifest either way —
+      // a set absent from the new manifest is gone regardless.
+      const cfg = { enabledFeatureSets: config.enabledFeatureSets, disabledFeatureSets: config.disabledFeatureSets };
+      const maskedOrEmpty = masked ?? ({ version: '0.5' } as import('./mcpl/types.js').McplCapabilities);
+      this.featureSetManager!.initializeServer(connection.id, maskedOrEmpty, cfg, connection.grant);
+
+      // The Request DESCRIBES the proposed new policy — derived from the
+      // full new grant on a scratch manager, installing nothing.
+      const updateParams = new FeatureSetManager().initializeServer(connection.id, maskedOrEmpty, cfg, newGrant);
       updateParams.effectiveCapabilities = newGrant.effectiveList();
       if (newGrant.deniedPaths.length > 0) updateParams.deniedCapabilities = [...newGrant.deniedPaths];
 
-      // Tell → receipt → activate (§6.7): expansions and the full new grant
-      // take effect only after the server acknowledges the new policy. An
-      // unanswered Request leaves the interim (reduced) grant standing.
+      // Tell → receipt → activate (§6.7). PHASE 2 by outcome:
+      //  accepted  → full grant + full-derived feature state;
+      //  refused   → honor fallback: 'close' closes the transport;
+      //              'mcp-only' (or absent) = empty grant + empty-derived
+      //              feature state, mirroring the §5.3 initial path;
+      //  unanswered → interim grant and interim-derived state stand.
       let negotiated = false;
       try {
         const receipt = await connection.sendFeatureSetsUpdateRequest(updateParams);
         if (receipt && receipt.accepted === false) {
-          console.error(`[mcpl] ${connection.id} refused post-manifest policy (${receipt.fallback}); grant stays ${hadReduction ? 'reduced' : 'unchanged'}`);
+          const fallback = receipt.fallback ?? 'mcp-only';
+          console.error(`[mcpl] ${connection.id} refused post-manifest policy — fallback: ${fallback}`);
+          if (fallback === 'close') {
+            await connection.close();
+            return;
+          }
+          connection.establishGrant(CapabilityGrant.empty());
+          this.featureSetManager!.initializeServer(connection.id, maskedOrEmpty, cfg, CapabilityGrant.empty());
         } else {
           connection.establishGrant(newGrant);
+          this.featureSetManager!.initializeServer(connection.id, maskedOrEmpty, cfg, newGrant);
           connection.manifestState.lastNegotiatedAt = Date.now();
           negotiated = true;
         }
       } catch {
-        console.error(`[mcpl] ${connection.id} did not answer post-manifest policy — expansion does not activate (§6.7)`);
+        console.error(`[mcpl] ${connection.id} did not answer post-manifest policy — expansion does not activate (§6.7); interim state stands`);
       }
 
-      // Adopt the validated manifest + tracking.
+      // Adopt the validated manifest + tracking. droppedCapabilities is
+      // REPLACED unconditionally — an empty new mask must clear stale paths
+      // (Sol, PR #84 review).
       connection.capabilities = masked;
       connection.manifestState.lastValidatedRevision =
         typeof (fetched as { revision?: unknown }).revision === 'string'
           ? (fetched as { revision: string }).revision : null;
       connection.manifestState.lastFetchedAt = Date.now();
-      if (dropped.length > 0) connection.droppedCapabilities = new Set(dropped);
+      connection.droppedCapabilities = new Set(dropped);
 
       const newDeclared = Object.keys(this.featureSetManager?.getDeclaredFeatureSets(connection.id) ?? {});
       const newEnabled = newDeclared.filter((n) => this.featureSetManager?.isEnabled(connection.id, n));

--- a/src/mcpl/server-connection.ts
+++ b/src/mcpl/server-connection.ts
@@ -167,6 +167,11 @@ export class McplServerConnection extends EventEmitter {
   private resetPolicyForTransportBoundary(): void {
     this.grant = CapabilityGrant.empty();
     this.policyEstablished = false;
+    // §17 tracking is per-epoch for the same reason the grant is: these are
+    // facts about what THIS host fetched/negotiated on THIS initialized
+    // transport, and a fresh initialize starts a fresh manifest history
+    // (Sol, PR #84 review — they previously survived into the new epoch).
+    this.manifestState = { lastValidatedRevision: null, lastFetchedAt: null, lastNegotiatedAt: null };
   }
 
   /** The active transport (stdio child or WebSocket). Null for a disconnected

--- a/src/mcpl/server-connection.ts
+++ b/src/mcpl/server-connection.ts
@@ -138,6 +138,20 @@ export class McplServerConnection extends EventEmitter {
   policyEstablished = false;
 
   /**
+   * §17 manifest tracking (host side of RFC-003): what this host actually
+   * fetched and acted on — never the server's announcement log (§17.10:
+   * those are different facts). Read by the legibility surface.
+   */
+  manifestState: {
+    /** revision of the last VALIDATED fetched manifest (server-authored,
+     *  untrusted, equality-only) — null until a §17.4 fetch succeeds. */
+    lastValidatedRevision: string | null;
+    lastFetchedAt: number | null;
+    /** epoch ms of the last §6.7 receipt that activated a grant change. */
+    lastNegotiatedAt: number | null;
+  } = { lastValidatedRevision: null, lastFetchedAt: null, lastNegotiatedAt: null };
+
+  /**
    * Activate (or replace) the effective grant. Ordering is the caller's
    * contract per §6.7: call BEFORE sending a reducing featureSets/update,
    * AFTER the receipt for an expanding one.
@@ -601,6 +615,16 @@ export class McplServerConnection extends EventEmitter {
     this.sendNotification(McplMethod.InferenceLifecycle, params as unknown as Record<string, unknown>);
   }
 
+  /**
+   * Fetch the server's complete current manifest (§17.4) — the
+   * experimental.mcpl object in the same shape initialize carries, never a
+   * delta. The fetched CONTENT is authoritative for every decision; the
+   * revision is only the cheap path (§17.1).
+   */
+  sendManifestRequest(timeoutMs = 15_000): Promise<McplCapabilities | null> {
+    return this.sendRequest(McplMethod.Manifest, {}, { timeoutMs }) as Promise<McplCapabilities | null>;
+  }
+
   /** Send `state/rollback` request and await result. */
   sendStateRollback(params: StateRollbackParams): Promise<StateRollbackResult> {
     return this.sendRequest(McplMethod.StateRollback, params as unknown as Record<string, unknown>) as Promise<StateRollbackResult>;
@@ -930,6 +954,11 @@ export class McplServerConnection extends EventEmitter {
     // neither of these had an entry, so callers hung forever (AUDIT-001
     // item 4, which also poisoned the audit's own usage evidence).
     [McplMethod.ModelInfo]: 'model-info',
+    // §17.3: deliberately UNGATED (not in EVENT_TO_REQUIRED_CAPABILITY) —
+    // announcing conveys no authority, and gating it would silence exactly
+    // the servers whose grants just narrowed. The cost is the host's
+    // re-fetch, which the framework rate-limits (§17.8).
+    [McplMethod.ManifestChanged]: 'manifest-changed',
     [McplMethod.ChannelsList]: 'channels-list',
     'notifications/tools/list_changed': 'tools-list-changed',
     // Host-level admin commands initiated from a surface (e.g. a Discord

--- a/src/mcpl/types.ts
+++ b/src/mcpl/types.ts
@@ -662,6 +662,14 @@ export interface InferenceLifecycleParams {
   phase: 'started' | 'completed' | 'aborted' | 'failed';
 }
 
+/** mcpl/manifestChanged params (Server → Host, Notification). §17.3. */
+export interface ManifestChangedParams {
+  /** §17.2 canonical content digest. Untrusted; equality-only. */
+  revision: string;
+  /** Subset of the three §17.1 domains. A hint the host MAY ignore. */
+  domains: Array<'capabilities' | 'featureSets' | 'tagOntology'>;
+}
+
 export interface McplModelInfo {
   /** Model identifier (e.g., "claude-opus-4-5-20251101") */
   id: string;
@@ -1201,6 +1209,14 @@ export const McplMethod = {
   // Inference lifecycle (Host → Server, Notification) — §10.5, replaces
   // context/afterInference. Metadata only; BEST-EFFORT delivery.
   InferenceLifecycle: 'inference/lifecycle',
+
+  // Server manifest changes (§17). manifestChanged is S→H Notification —
+  // an opaque revision plus changed domains, NO payload, deliberately
+  // ungated (§17.3: gating it would silence exactly the servers whose
+  // grants just narrowed). manifest is H→S Request returning the complete
+  // current experimental.mcpl object, never a delta.
+  ManifestChanged: 'mcpl/manifestChanged',
+  Manifest: 'mcpl/manifest',
 
   // Feature sets
   FeatureSetsUpdate: 'featureSets/update',

--- a/src/types/trace.ts
+++ b/src/types/trace.ts
@@ -340,6 +340,15 @@ export type TraceEvent =
       willRetry: boolean;
     })
   | (TraceEventBase & {
+      /** §17.6: the ONE normalized receipt per manifest change — closed
+       *  host-derived impact vocabulary, never a server-authored flag. */
+      type: 'mcpl:manifest-change-receipt';
+      serverId: string;
+      revision: string | null;
+      announcedDomains: string[];
+      impacts: Array<{ impact: string; subject: string; disposition: string }>;
+    })
+  | (TraceEventBase & {
       type: 'mcpl:server-reconnected';
       serverId: string;
       /** How many attempts the reconnect loop needed (1 = first retry succeeded). */

--- a/test/mcpl-manifest-changed.test.ts
+++ b/test/mcpl-manifest-changed.test.ts
@@ -43,8 +43,10 @@ class ManifestFake extends EventEmitter {
   events: Array<{ kind: string; detail?: unknown }> = [];
   /** Next mcpl/manifest answer; a function may throw to model fetch failure. */
   nextManifest: () => McplCapabilities = () => INITIAL;
-  /** Whether featureSets/update Requests are answered. */
-  answerPolicy = true;
+  /** How featureSets/update Requests are answered. */
+  answerPolicy: 'accept' | 'never' | 'refuse-mcp-only' | 'refuse-close' = 'accept';
+  closed = false;
+  close(): Promise<void> { this.closed = true; return Promise.resolve(); }
 
   establishGrant(grant: CapabilityGrant): void {
     this.grant = grant;
@@ -55,10 +57,14 @@ class ManifestFake extends EventEmitter {
     this.events.push({ kind: 'fetch' });
     return Promise.resolve(this.nextManifest());
   }
-  sendFeatureSetsUpdateRequest(params: unknown): Promise<{ accepted: true }> {
+  sendFeatureSetsUpdateRequest(params: unknown): Promise<unknown> {
     this.events.push({ kind: 'policy-request', detail: params });
-    if (!this.answerPolicy) return new Promise(() => {}); // never answers
-    return Promise.resolve({ accepted: true });
+    switch (this.answerPolicy) {
+      case 'never': return new Promise(() => {});
+      case 'refuse-mcp-only': return Promise.resolve({ accepted: false, fallback: 'mcp-only' });
+      case 'refuse-close': return Promise.resolve({ accepted: false, fallback: 'close' });
+      default: return Promise.resolve({ accepted: true });
+    }
   }
   sendFeatureSetsUpdate(): void {}
 }
@@ -128,12 +134,16 @@ test('reduction applies BEFORE the policy Request; receipt names it applied', as
 
 test('expansion activates only after the receipt; unanswered Request leaves it inactive', async () => {
   const { fw, connection } = makeHarness();
-  connection.answerPolicy = false; // server never answers the new policy
+  connection.answerPolicy = 'never'; // server never answers the new policy
   connection.nextManifest = () => ({
     version: '0.5',
     pushEvents: true,
     channels: { incoming: true, publish: true, streaming: true }, // + streaming
-    featureSets: { chat: { description: 'chat', uses: ['pushEvents', 'channels.incoming', 'channels.publish'] } },
+    featureSets: {
+      chat: { description: 'chat', uses: ['pushEvents', 'channels.incoming', 'channels.publish'] },
+      // NEW set backed by the NEW capability — the §84-review probe.
+      streamy: { description: 's', uses: ['channels.streaming'] },
+    },
   }) as unknown as McplCapabilities;
 
   // Fire and give the pipeline a beat; the policy Request hangs forever.
@@ -143,7 +153,36 @@ test('expansion activates only after the receipt; unanswered Request leaves it i
     'unanswered expansion must not activate (§6.7)');
   assert.ok(connection.grant.has('channels.publish'),
     'no reduction occurred, so the standing grant survives');
+  // Sol's #84 blocker: a NEW capability-backed feature set must not be
+  // host-enabled while its capability is absent from the ACTIVE grant.
+  assert.equal(fw.featureSetManager.isEnabled('srv', 'streamy'), false,
+    'feature state must not run ahead of active authority');
+  assert.equal(fw.featureSetManager.isEnabled('srv', 'chat'), true,
+    'interim-derived state keeps what active authority supports');
   void p; // intentionally left pending — models the wedged server
+});
+
+test('refusal with fallback mcp-only: empty grant, empty-derived feature state', async () => {
+  const { fw, connection } = makeHarness();
+  connection.answerPolicy = 'refuse-mcp-only';
+  connection.nextManifest = () => INITIAL;
+
+  await fw.handleManifestChanged(connection, { revision: 'sha256:r1', domains: ['capabilities'] });
+
+  assert.deepEqual(connection.grant.effectiveList(), [], 'mcp-only = empty grant, like the §5.3 path');
+  assert.equal(fw.featureSetManager.isEnabled('srv', 'chat'), false,
+    'feature state derives from the (empty) active grant');
+  assert.equal(connection.closed, false);
+});
+
+test('refusal with fallback close: the transport is closed', async () => {
+  const { fw, connection } = makeHarness();
+  connection.answerPolicy = 'refuse-close';
+  connection.nextManifest = () => INITIAL;
+
+  await fw.handleManifestChanged(connection, { revision: 'sha256:r2', domains: ['capabilities'] });
+
+  assert.equal(connection.closed, true, 'fallback close must be honored (§6.7)');
 });
 
 test('failed fetch: previous manifest and grant stand untouched', async () => {

--- a/test/mcpl-manifest-changed.test.ts
+++ b/test/mcpl-manifest-changed.test.ts
@@ -1,0 +1,173 @@
+/**
+ * §17 host-side manifest tracking (RFC-003, af#78).
+ *
+ * The load-bearing orderings, each pinned:
+ *  - reduction applies BEFORE the post-manifest policy Request is sent
+ *    (§6.7: security cannot wait on consent);
+ *  - expansion activates only AFTER the receipt (an unanswered Request
+ *    leaves the interim reduced grant standing);
+ *  - a failed fetch teaches nothing — the previous manifest stands;
+ *  - exactly ONE receipt trace per change, host-derived vocabulary;
+ *  - announcements coalesce under the §17.8 fetch floor.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+
+import { AgentFramework } from '../src/framework.js';
+import { FeatureSetManager } from '../src/mcpl/feature-set-manager.js';
+import { CapabilityGrant, computeGrant, expandAdvertisementShorthand } from '../src/mcpl/capability-grant.js';
+import type { McplCapabilities, McplServerConfig } from '../src/mcpl/types.js';
+
+const INITIAL: McplCapabilities = {
+  version: '0.5',
+  pushEvents: true,
+  channels: { incoming: true, publish: true },
+  featureSets: {
+    chat: { description: 'chat', uses: ['pushEvents', 'channels.incoming', 'channels.publish'] },
+  },
+} as unknown as McplCapabilities;
+
+class ManifestFake extends EventEmitter {
+  readonly id = 'srv';
+  capabilities: McplCapabilities | null = null;
+  willReconnect = false;
+  mcpToolsAdvertised = false;
+  allowHostCommands = false;
+  grant = CapabilityGrant.empty();
+  policyEstablished = false;
+  manifestState = { lastValidatedRevision: null as string | null, lastFetchedAt: null as number | null, lastNegotiatedAt: null as number | null };
+  droppedCapabilities: ReadonlySet<string> = new Set();
+
+  /** Ordered record of what the host did to us, for ordering assertions. */
+  events: Array<{ kind: string; detail?: unknown }> = [];
+  /** Next mcpl/manifest answer; a function may throw to model fetch failure. */
+  nextManifest: () => McplCapabilities = () => INITIAL;
+  /** Whether featureSets/update Requests are answered. */
+  answerPolicy = true;
+
+  establishGrant(grant: CapabilityGrant): void {
+    this.grant = grant;
+    this.policyEstablished = true;
+    this.events.push({ kind: 'grant', detail: grant.effectiveList() });
+  }
+  sendManifestRequest(): Promise<McplCapabilities> {
+    this.events.push({ kind: 'fetch' });
+    return Promise.resolve(this.nextManifest());
+  }
+  sendFeatureSetsUpdateRequest(params: unknown): Promise<{ accepted: true }> {
+    this.events.push({ kind: 'policy-request', detail: params });
+    if (!this.answerPolicy) return new Promise(() => {}); // never answers
+    return Promise.resolve({ accepted: true });
+  }
+  sendFeatureSetsUpdate(): void {}
+}
+
+function makeHarness() {
+  const traces: Array<{ type: string; [k: string]: unknown }> = [];
+  const fw = Object.create(AgentFramework.prototype) as any;
+  fw.traceListeners = [(e: unknown) => traces.push(e as never)];
+  fw.featureSetManager = new FeatureSetManager();
+  fw.mcplTools = [];
+  fw.mcplToolRefreshInFlight = false;
+  fw.mcplToolRefreshPending = false;
+  fw.agents = new Map();
+  fw.manifestRefreshState = new Map();
+  fw.handleToolsListChanged = () => {};
+
+  const config: McplServerConfig = { id: 'srv', command: 'unused' };
+  fw.mcplServerConfigs = new Map([[config.id, config]]);
+
+  const connection = new ManifestFake();
+  connection.capabilities = expandAdvertisementShorthand(INITIAL);
+  fw.mcplServerRegistry = { getAllServers: () => [connection], getServer: (id: string) => (id === 'srv' ? connection : null) };
+
+  // Model post-§5.3 state: initial policy done, full grant active.
+  const grant = computeGrant(connection.capabilities, config, { mcpToolsAdvertised: false });
+  fw.featureSetManager.initializeServer('srv', connection.capabilities!, {}, grant);
+  connection.establishGrant(grant);
+  connection.events = []; // discard setup noise
+
+  return { fw, connection, traces };
+}
+
+const settle = () => new Promise((r) => setImmediate(r));
+
+test('reduction applies BEFORE the policy Request; receipt names it applied', async () => {
+  const { fw, connection, traces } = makeHarness();
+  // New manifest drops channels.publish (and the chat set with it, since
+  // uses requires it).
+  connection.nextManifest = () => ({
+    version: '0.5',
+    pushEvents: true,
+    channels: { incoming: true },
+    featureSets: { chat: { description: 'chat', uses: ['pushEvents', 'channels.incoming', 'channels.publish'] } },
+  }) as unknown as McplCapabilities;
+
+  await fw.handleManifestChanged(connection, { revision: 'sha256:x', domains: ['capabilities'] });
+
+  const kinds = connection.events.map((e) => e.kind);
+  const firstGrant = kinds.indexOf('grant');
+  const policyIdx = kinds.indexOf('policy-request');
+  assert.ok(firstGrant >= 0 && policyIdx >= 0 && firstGrant < policyIdx,
+    `reduction must land before the Request (got order: ${kinds.join(',')})`);
+  const interim = connection.events[firstGrant].detail as string[];
+  assert.ok(!interim.includes('channels.publish'), 'interim grant must not carry the revoked path');
+
+  // After the receipt: final grant matches the new manifest; chat degraded
+  // by §6.4 (its uses still names the revoked path).
+  assert.ok(!connection.grant.has('channels.publish'));
+  assert.equal(fw.featureSetManager.isEnabled('srv', 'chat'), false);
+
+  const receipts = traces.filter((t) => t.type === 'mcpl:manifest-change-receipt');
+  assert.equal(receipts.length, 1, 'exactly ONE receipt per change');
+  const impacts = (receipts[0].impacts as Array<{ impact: string; subject: string; disposition: string }>);
+  assert.ok(impacts.some((i) => i.impact === 'capability-revoked' && i.subject === 'channels.publish' && i.disposition === 'applied'));
+  assert.ok(impacts.some((i) => i.impact === 'feature-degraded' && i.subject === 'chat'));
+});
+
+test('expansion activates only after the receipt; unanswered Request leaves it inactive', async () => {
+  const { fw, connection } = makeHarness();
+  connection.answerPolicy = false; // server never answers the new policy
+  connection.nextManifest = () => ({
+    version: '0.5',
+    pushEvents: true,
+    channels: { incoming: true, publish: true, streaming: true }, // + streaming
+    featureSets: { chat: { description: 'chat', uses: ['pushEvents', 'channels.incoming', 'channels.publish'] } },
+  }) as unknown as McplCapabilities;
+
+  // Fire and give the pipeline a beat; the policy Request hangs forever.
+  const p = fw.handleManifestChanged(connection, { revision: 'sha256:y', domains: ['capabilities'] });
+  await settle(); await settle();
+  assert.ok(!connection.grant.has('channels.streaming'),
+    'unanswered expansion must not activate (§6.7)');
+  assert.ok(connection.grant.has('channels.publish'),
+    'no reduction occurred, so the standing grant survives');
+  void p; // intentionally left pending — models the wedged server
+});
+
+test('failed fetch: previous manifest and grant stand untouched', async () => {
+  const { fw, connection, traces } = makeHarness();
+  const before = connection.grant.effectiveList();
+  connection.nextManifest = () => { throw new Error('boom'); };
+
+  await fw.handleManifestChanged(connection, { revision: 'sha256:z', domains: ['featureSets'] });
+
+  assert.deepEqual(connection.grant.effectiveList(), before);
+  assert.equal(traces.filter((t) => t.type === 'mcpl:manifest-change-receipt').length, 0,
+    'no receipt for a change the host could not observe');
+});
+
+test('announcements coalesce: rapid-fire N announces cause one immediate fetch', async () => {
+  const { fw, connection } = makeHarness();
+  connection.nextManifest = () => INITIAL;
+
+  const first = fw.handleManifestChanged(connection, { revision: 'sha256:a', domains: [] });
+  // While the first is in flight (or inside the floor window) these coalesce.
+  void fw.handleManifestChanged(connection, { revision: 'sha256:b', domains: [] });
+  void fw.handleManifestChanged(connection, { revision: 'sha256:c', domains: [] });
+  await first; await settle();
+
+  const fetches = connection.events.filter((e) => e.kind === 'fetch').length;
+  assert.equal(fetches, 1, `rapid announcements must coalesce (§17.8), got ${fetches} fetches`);
+});


### PR DESCRIPTION
Closes #78 — the host half of RFC-003, on top of the merged 0.5 stack.

**Wire**: `mcpl/manifestChanged` routed ungated per §17.3 (announcing conveys no authority; gating would silence exactly the narrowed); `mcpl/manifest` fetched as the complete current object, content authoritative, revision equality-only.

**Processing (§17.5)** — the orderings are the review surface:
- **Rate limit first** (§17.8): per-connection in-flight coalescing + a 5s floor between completed fetches; N rapid announcements → one fetch of the *current* manifest (+ at most one trailing). Host-bounded; never depends on server coalescing.
- **Validate exactly as initialize**: shorthand expansion → config mask → grant computation. Partial-invalid manifests still apply removals — this falls out of deriving everything forward from fetched content rather than patching the old state.
- **§6.7 mirrored orderings**: reduction lands **first**, atomically, as an interim new∩old grant *before* the policy Request is sent; the full new grant (expansions included) activates only on the receipt; an unanswered Request leaves the interim standing.
- **One receipt** (§17.6): single `mcpl:manifest-change-receipt` trace per change with the closed host-derived vocabulary + dispositions. No receipt for a failed fetch — a change the host couldn't observe.
- **Tracking** (§17.10's two-facts split): `manifestState = {lastValidatedRevision, lastFetchedAt, lastNegotiatedAt}` — what the host fetched and acted on, never the server's announcement log. Feeds the legibility surface's future freshness fields (Mega-Codex's #81 follow-on).

**Tests** pin exactly the four behaviors a reviewer should distrust: reduction-before-Request order (with interim-grant content asserted), unanswered-expansion-inactive, failed-fetch-inert, and coalescing. Full suite 515 pass / 0 fail / 1 skip.

Servers already speaking §17 against this: dog-mcp (announce_manifest), zulip (ManifestTracker), with eidoverse#2 next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)