### PR TITLE
chore(mcpl): drop the dead context/afterInference send surface (issue #39)

### DIFF
--- a/src/mcpl/index.ts
+++ b/src/mcpl/index.ts
@@ -47,8 +47,6 @@ export type {
   BeforeInferenceParams,
   McplContextInjection,
   BeforeInferenceResult,
-  AfterInferenceParams,
-  AfterInferenceResult,
 
   // Server-initiated inference
   McplMessage,

--- a/src/mcpl/server-connection.ts
+++ b/src/mcpl/server-connection.ts
@@ -24,8 +24,6 @@ import type {
   JsonRpcResponse,
   BeforeInferenceParams,
   BeforeInferenceResult,
-  AfterInferenceParams,
-  AfterInferenceResult,
   FeatureSetsUpdateParams,
   FeatureSetsUpdateResult,
   InferenceChunkParams,
@@ -552,18 +550,6 @@ export class McplServerConnection extends EventEmitter {
     return this.sendRequest(McplMethod.BeforeInference, params as unknown as Record<string, unknown>) as Promise<BeforeInferenceResult>;
   }
 
-  /**
-   * Send `context/afterInference`.
-   * When `blocking` is true, sends as a request and awaits the result.
-   * When `blocking` is false (or omitted), sends as a notification.
-   */
-  sendAfterInference(params: AfterInferenceParams, blocking?: boolean): Promise<AfterInferenceResult | void> {
-    if (blocking) {
-      return this.sendRequest(McplMethod.AfterInference, params as unknown as Record<string, unknown>) as Promise<AfterInferenceResult>;
-    }
-    this.sendNotification(McplMethod.AfterInference, params as unknown as Record<string, unknown>);
-    return Promise.resolve();
-  }
 
   /** Send `featureSets/update` as a Notification. §6.7: valid ONLY for
    *  purely descriptive metadata that does not alter the grant. Any grant

--- a/src/mcpl/types.ts
+++ b/src/mcpl/types.ts
@@ -741,53 +741,6 @@ export interface BeforeInferenceResult {
   contextInjections: McplContextInjection[];
 }
 
-/**
- * context/afterInference params (Host → Server, Request or Notification).
- * Spec Section 10.5.
- */
-export interface AfterInferenceParams {
-  /** Inference identifier (matches beforeInference) */
-  inferenceId: string;
-
-  /** Persistent across turns */
-  conversationId: string;
-
-  /** 0-indexed turn number */
-  turnIndex: number;
-
-  /** Original user input */
-  userMessage: string | null;
-
-  /** Generated assistant response */
-  assistantMessage: string;
-
-  /** Model metadata */
-  model: McplModelInfo;
-
-  /** Token usage */
-  usage: {
-    inputTokens: number;
-    outputTokens: number;
-    cacheCreationTokens?: number;
-    cacheReadTokens?: number;
-  };
-}
-
-/**
- * context/afterInference result (Server → Host, only for blocking hooks).
- * Spec Section 10.5.
- */
-export interface AfterInferenceResult {
-  /** Feature set that provided this response */
-  featureSet: string;
-
-  /** Modified response text (replaces assistantMessage if present) */
-  modifiedResponse?: string;
-
-  /** Arbitrary metadata */
-  metadata?: Record<string, unknown>;
-}
-
 // ============================================================================
 // Section 11 — Server-Initiated Inference
 // ============================================================================
@@ -1187,9 +1140,13 @@ export const McplMethod = {
   // Push events (Server → Host)
   PushEvent: 'push/event',
 
-  // Context hooks (Host → Server)
+  // Context hooks (Host → Server). context/afterInference is gone with the
+  // rest of its surface: removed from the spec in 0.5.0 (§10.5, replaced by
+  // inference/lifecycle), never sent by the runtime, and not part of the
+  // package's public API. Pre-0.5 SERVERS' wire handlers for it are their
+  // own compatibility surface, retired on the fleet-on-0.5 evidence
+  // schedule, not here.
   BeforeInference: 'context/beforeInference',
-  AfterInference: 'context/afterInference',
 
   // Server-initiated inference (Server → Host / Host → Server)
   InferenceRequest: 'inference/request',


### PR DESCRIPTION
The one cleanup Sol's issue-#39 ruling permits now, cut exactly along her stated boundary.

**The helper body** — `sendAfterInference` (server-connection.ts) — is proven dead: whole-ecosystem grep across **14 trees** (agent-framework, connectome-host, discord-mcpl, heartbeat-mcpl, membrane locally, plus fresh clones of dog-mcp, zulip_mcp, portal, xgate, eidoverse-worlds, mcpl-editor, slack-mcpl, mcpl-harness, and the mcpl spec repo) finds exactly one definition and zero callers. The runtime stopped sending `context/afterInference` at the 0.5.0 spec removal (§10.5, replaced by `inference/lifecycle`); only the helper survived.

**The method-table entry and types** — `McplMethod.AfterInference`, `AfterInferenceParams`, `AfterInferenceResult` — leave with it because exact export tracing proves they are private/internal, per the ruling's condition: `package.json` `exports` maps only `"."` (subpath imports sealed), and the root `src/index.ts` re-exports a curated subset of `./mcpl/index.js` that never included any of them. They are not package-visible compatibility surface.

**Deliberately untouched:** pre-0.5 servers' wire *handlers* (e.g. discord-mcpl server.ts:937) — that's their own compatibility surface, retired on fleet-on-0.5 evidence in the named compatibility-retirement release (tracked with the `DISCORD_SUPPRESS_REACTION_EMOJIS` alias retirement from discord-mcpl #13). A comment at the `McplMethod` table says exactly this so the boundary survives the file.

**Verification:** `bunx tsc --noEmit` clean; zero residual `AfterInference` references (BeforeInference untouched); module-adjacent MCPL suites (`mcpl-request-timeout`, `mcpl-ws-transport`, `mcpl-reconnect-events`, `mcpl-capability-scoping`, `mcpl-awareness-barrier`) **57/57 in isolation**. Honest caveat: the full `bun test` run shows a `connectMcplServer`/WebSocket failure cluster with 5s timeouts on this machine — it reproduces identically on clean `main` (and run-to-run collection counts are nondeterministic, 522 vs 825), so it's a pre-existing parallel port/timeout environment flake, not from this change. Flagging rather than hiding it; an independent suite run on a quieter machine is the right check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>