### PR TITLE
Project continuation rounds against the physical window — restart instead of 400 (#92)

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -86,6 +86,10 @@ export class Agent {
    *  cache read. THE window-shaped number — `lastStreamInputTokens` alone
    *  omits cached tokens, which are most of a warm stream's window. */
   lastStreamRealInputTokens = 0;
+  /** Output tokens of the last usage event — the prior round's generated
+   *  thinking/text/tool_use, which becomes part of the NEXT round's input
+   *  and so belongs in the physical-window projection. */
+  lastStreamOutputTokens = 0;
   maxStreamTokens: number;
   /** Provider hard context cap (see AgentConfig.physicalWindowTokens). */
   readonly physicalWindowTokens?: number;
@@ -687,6 +691,14 @@ export class Agent {
     this._streamId++;
     this._inferenceStartedAt = Date.now();
     this.lastStreamInputTokens = 0;
+    // Reset the cache-inclusive counters too: a new stream must not inherit
+    // the prior stream's window size — on the physical-window restart path
+    // that inherited value IS the oversized number that caused the restart,
+    // and projecting on it before this stream's first usage event would
+    // restart again (loop). The `> 0` guard downstream means "no usage
+    // observed on THIS stream yet" only because of this reset.
+    this.lastStreamRealInputTokens = 0;
+    this.lastStreamOutputTokens = 0;
 
     const request = await this.buildActivationRequest(availableTools, injections, budget);
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -82,7 +82,13 @@ export class Agent {
   private _inferenceStartedAt = 0;
   private _streamId = 0;
   lastStreamInputTokens = 0;
+  /** Real prefix size of the last usage event: fresh + cache creation +
+   *  cache read. THE window-shaped number — `lastStreamInputTokens` alone
+   *  omits cached tokens, which are most of a warm stream's window. */
+  lastStreamRealInputTokens = 0;
   maxStreamTokens: number;
+  /** Provider hard context cap (see AgentConfig.physicalWindowTokens). */
+  readonly physicalWindowTokens?: number;
   /** Per-agent context compile budget (input tokens). When unset, the
    * ContextManager's built-in default applies. reserveForResponse uses
    * this agent's maxTokens. */
@@ -117,6 +123,7 @@ export class Agent {
     this.providerParams = config.providerParams;
     this.sameRoundThinkTextPolicy = config.sameRoundThinkTextPolicy;
     this.maxStreamTokens = config.maxStreamTokens ?? 150_000;
+    this.physicalWindowTokens = config.physicalWindowTokens;
     this.contextBudgetTokens = config.contextBudgetTokens;
     this.configuredContextBudgetTokens = config.contextBudgetTokens;
     this.contextManager = contextManager;

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -3861,10 +3861,15 @@ export class AgentFramework {
           // the physical window, break the stream through the same
           // budget-restart path — a fresh compile folds the history back
           // under budget instead of dispatching a doomed request.
+          // Projection terms: prior round's real input + prior round's
+          // OUTPUT (the just-generated thinking/text/tool_use joins the next
+          // round's input — omitting it is a systematic underestimate) +
+          // blocks about to be appended + reserve for the next response.
           const projectedRealTokens = currentState.stream
             && agent.physicalWindowTokens !== undefined
             && agent.lastStreamRealInputTokens > 0
             ? agent.lastStreamRealInputTokens
+              + agent.lastStreamOutputTokens
               + estimateAppendedRoundTokens(currentState.toolResults, spilled, midTurnInjections)
               + agent.maxTokens
             : 0;
@@ -6361,6 +6366,7 @@ export class AgentFramework {
               (event.usage.inputTokens ?? 0) +
               (event.usage.cacheCreationTokens ?? 0) +
               (event.usage.cacheReadTokens ?? 0);
+            agent.lastStreamOutputTokens = event.usage.outputTokens ?? 0;
 
             // Closed-loop estimator calibration (2026-07-12). Sample the REAL
             // prefix size of THIS API call (fresh + cache write + cache read)

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -142,6 +142,43 @@ const isConversationalInjection = (metadata?: MessageMetadata): boolean => {
 };
 
 /**
+ * Rough token estimate for the blocks a continuation round is about to
+ * append to the live wire (issue #92 physical-window projection): the
+ * spilled tool-result strings at chars/4, a flat per-image cost for native
+ * image blocks the wire path preserves (provider vision tokens are
+ * resolution-dependent; 1600 ≈ a max-size Anthropic tile), mid-turn injected
+ * text at chars/4, and a small per-block envelope allowance. Deliberately a
+ * ceiling-ish heuristic — the cost of overestimating is one early recompile;
+ * the cost of underestimating is the 400 this projection exists to prevent.
+ */
+function estimateAppendedRoundTokens(
+  toolResults: CompletedToolCall[],
+  spilled: Map<string, { text: string; filePath: string | null }>,
+  injections: Array<{ content: ContentBlock[] }>,
+): number {
+  let chars = 0;
+  let images = 0;
+  for (const tc of toolResults) {
+    chars += spilled.get(tc.id)?.text.length ?? 0;
+    if (Array.isArray(tc.result.data)) {
+      for (const raw of tc.result.data) {
+        const b = raw as { type?: unknown };
+        if (b && typeof b === 'object' && b.type === 'image') images += 1;
+      }
+    }
+  }
+  for (const inj of injections) {
+    for (const block of inj.content) {
+      if (block.type === 'text' && typeof (block as { text?: unknown }).text === 'string') {
+        chars += (block as { text: string }).text.length;
+      }
+    }
+  }
+  const blockCount = toolResults.length + injections.length;
+  return Math.ceil(chars / 4) + images * 1600 + blockCount * 20;
+}
+
+/**
  * Explicit delivery tools whose successful use into a closed channel OPENS
  * it (send implies engagement — see openIfClosedForSend). Bare tool names,
  * matched after stripping the MCPL server prefix.
@@ -3814,6 +3851,25 @@ export class AgentFramework {
             && agent.lastStreamInputTokens > 0
             && agent.lastStreamInputTokens > agent.maxStreamTokens;
 
+          // Physical-window projection (issue #92): a turn's continuation
+          // rounds append to the compiled request without recompiling, so a
+          // turn that starts near the compile target can walk past the
+          // provider's HARD cap mid-turn and take a wire 400 — the compile
+          // was legal, the growth wasn't. Project the next round's real size
+          // (cache-inclusive input of the prior round + the blocks about to
+          // be appended + reserve for the response) and, when it would cross
+          // the physical window, break the stream through the same
+          // budget-restart path — a fresh compile folds the history back
+          // under budget instead of dispatching a doomed request.
+          const projectedRealTokens = currentState.stream
+            && agent.physicalWindowTokens !== undefined
+            && agent.lastStreamRealInputTokens > 0
+            ? agent.lastStreamRealInputTokens
+              + estimateAppendedRoundTokens(currentState.toolResults, spilled, midTurnInjections)
+              + agent.maxTokens
+            : 0;
+          const overPhysical = projectedRealTokens > (agent.physicalWindowTokens ?? Infinity);
+
           // Addressed re-pin (2026-07-31 Mythos misroutes, antra-ratified):
           // when someone ADDRESSES the agent mid-turn from another channel
           // (mention / reply / DM — the same chat:addressed signal the
@@ -3911,7 +3967,7 @@ export class AgentFramework {
             this.eventGate?.onInferenceEnded(agent.name);
             this.settleAgent(agent.name, { stopReason: 'turn_ended', speech: '' });
             this.emitTrace({ type: 'inference:turn_ended', agentName: agent.name });
-          } else if (overBudget) {
+          } else if (overBudget || overPhysical) {
             // Context budget exceeded: break the stream, let compile() compress.
             // Mark the cancel as framework-initiated BEFORE cancelling: the
             // membrane delivers `aborted` before the restart bumps streamId,
@@ -3936,9 +3992,12 @@ export class AgentFramework {
             this.emitTrace({
               type: 'inference:stream_restarted',
               agentName: agent.name,
-              reason: 'context_budget',
-              inputTokens: agent.lastStreamInputTokens,
-              budget: agent.maxStreamTokens,
+              // 'physical_window' only when the budget check alone would
+              // have let the doomed request through — overBudget keeps its
+              // established label for existing consumers.
+              reason: overBudget ? 'context_budget' : 'physical_window',
+              inputTokens: overBudget ? agent.lastStreamInputTokens : projectedRealTokens,
+              budget: overBudget ? agent.maxStreamTokens : (agent.physicalWindowTokens ?? 0),
             });
             this.pendingRequests.push({
               agentName: agent.name,
@@ -6298,6 +6357,10 @@ export class AgentFramework {
 
           case 'usage': {
             agent.lastStreamInputTokens = event.usage.inputTokens;
+            agent.lastStreamRealInputTokens =
+              (event.usage.inputTokens ?? 0) +
+              (event.usage.cacheCreationTokens ?? 0) +
+              (event.usage.cacheReadTokens ?? 0);
 
             // Closed-loop estimator calibration (2026-07-12). Sample the REAL
             // prefix size of THIS API call (fresh + cache write + cache read)

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -48,6 +48,17 @@ export interface AgentConfig {
    *  restarts with recompiled (compressed) context. Default: 150000. */
   maxStreamTokens?: number;
 
+  /**
+   * The model's PHYSICAL context window (provider hard cap, e.g. 200000).
+   * When set, the framework projects each continuation round's real size
+   * (cache-inclusive input of the prior round + the blocks about to be
+   * appended + reserve for response) and restarts the stream through a fresh
+   * compile instead of dispatching a request the provider will 400
+   * (issue #92: a legal compile can walk past the physical window mid-turn).
+   * Unset → no projection; only the maxStreamTokens restart applies.
+   */
+  physicalWindowTokens?: number;
+
   /** Per-agent context compile budget (input tokens). When unset, the
    *  ContextManager's built-in default (100k) applies. */
   contextBudgetTokens?: number;

--- a/test/physical-window-restart.test.ts
+++ b/test/physical-window-restart.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Issue #92 — mid-turn physical-window projection.
+ *
+ * A turn's continuation rounds append tool results to the compiled request
+ * without recompiling, so a turn that starts near the compile target can
+ * walk past the provider's HARD context cap mid-turn and take a wire 400.
+ * When AgentConfig.physicalWindowTokens is set, the framework projects each
+ * continuation round's real size (cache-INCLUSIVE prior input + blocks about
+ * to be appended + reserve for response) and breaks the stream through the
+ * budget-restart path — fresh compile — instead of dispatching a doomed
+ * request. Unset → behavior unchanged.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { NormalizedRequest, NormalizedResponse, YieldingStream } from '@animalabs/membrane';
+import type {
+  EventResponse,
+  Module,
+  ProcessEvent,
+  ToolDefinition,
+  ToolResult,
+  TraceEvent,
+} from '../src/index.js';
+import { AgentFramework } from '../src/index.js';
+import { createMockResponse, MockMembrane, MockYieldingStream } from './helpers/mock-membrane.js';
+
+/** Each streamYielding call consumes exactly ONE queued response — the
+ *  restart must open a fresh stream rather than continue the first. */
+class SequentialStreamMembrane extends MockMembrane {
+  private streamIdx = 0;
+  override streamYielding(request: NormalizedRequest, _options?: unknown): YieldingStream {
+    this.calls.push(request);
+    const stream = new MockYieldingStream(this.responses.slice(this.streamIdx, ++this.streamIdx));
+    this.lastStream = stream;
+    return stream;
+  }
+}
+
+class BlobToolModule implements Module {
+  readonly name = 'canned';
+  async start(): Promise<void> {}
+  async stop(): Promise<void> {}
+  getTools(): ToolDefinition[] {
+    return [{ name: 'fetch', description: 'blob', inputSchema: { type: 'object', properties: {} } }];
+  }
+  async handleToolCall(): Promise<ToolResult> {
+    return { success: true, data: { blob: 'x'.repeat(30_000) } };
+  }
+  async onProcess(event: ProcessEvent): Promise<EventResponse> {
+    if (event.type === 'external-message') {
+      return {
+        addMessages: [{ participant: 'User', content: (event as { content: unknown }).content as never }],
+        requestInference: true,
+      };
+    }
+    return {};
+  }
+}
+
+/** Tool round whose usage reports a near-cap REAL prefix: only 5k fresh
+ *  input (far under maxStreamTokens) but 195k cache-read — the projection
+ *  must count cached tokens or it misses the window entirely. */
+function nearCapToolResponse(): NormalizedResponse {
+  const r = createMockResponse([
+    { type: 'text', text: 'Working…' },
+    { type: 'tool_use', id: 'call_1', name: 'canned--fetch', input: {} },
+  ], 'tool_use');
+  (r as { usage: unknown }).usage = {
+    inputTokens: 5_000,
+    outputTokens: 5,
+    cacheReadTokens: 195_000,
+  };
+  return r;
+}
+
+async function pollUntil(cond: () => boolean, timeoutMs = 20_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (cond()) return true;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  return cond();
+}
+
+function storedTexts(framework: AgentFramework): string {
+  const cm = framework.getAgent('prime')?.getContextManager();
+  const msgs = (cm?.queryMessages({}).messages ?? []) as unknown as Array<{
+    content: Array<{ type: string; text?: string }>;
+  }>;
+  return msgs
+    .flatMap((m) => m.content ?? [])
+    .filter((b) => b.type === 'text' && typeof b.text === 'string')
+    .map((b) => b.text)
+    .join('\n');
+}
+
+async function runTurn(
+  physicalWindowTokens: number | undefined,
+  /** Sequential = one response per stream (restart opens stream 2); plain
+   *  MockMembrane feeds the whole queue to stream 1 (no-restart continues). */
+  membrane: MockMembrane,
+): Promise<{
+  framework: AgentFramework;
+  membrane: MockMembrane;
+  traces: TraceEvent[];
+  tempDir: string;
+}> {
+  const tempDir = mkdtempSync(join(tmpdir(), 'phys-window-'));
+  membrane.pushResponse(nearCapToolResponse());
+  membrane.pushResponse(createMockResponse([{ type: 'text', text: 'Recovered final answer' }]));
+
+  const framework = await AgentFramework.create({
+    storePath: join(tempDir, 'store'),
+    membrane: membrane.asMembrane(),
+    agents: [{
+      name: 'prime',
+      model: 'test-model',
+      systemPrompt: 'You are prime.',
+      allowedTools: 'all',
+      maxTokens: 4_000,
+      ...(physicalWindowTokens !== undefined ? { physicalWindowTokens } : {}),
+    }],
+    modules: [new BlobToolModule()],
+    syncIntervalMs: 0,
+  });
+  const traces: TraceEvent[] = [];
+  framework.onTrace((e) => traces.push(e));
+  framework.start();
+  framework.pushEvent({
+    type: 'external-message',
+    source: 'test',
+    content: [{ type: 'text', text: 'fetch it' }],
+    metadata: {},
+    triggerInference: true,
+  } as unknown as ProcessEvent);
+  return { framework, membrane, traces, tempDir };
+}
+
+describe('physical-window mid-turn restart (issue #92)', () => {
+  it('restarts through a fresh compile instead of dispatching past the hard cap', async () => {
+    // Projection: 200k real prefix (5k fresh + 195k cached) + appended tool
+    // result + 4k reserve > 200k window → restart. The fresh-input-only
+    // check (5k vs maxStreamTokens 150k) would have sent the doomed request.
+    const h = await runTurn(200_000, new SequentialStreamMembrane());
+    try {
+      const done = await pollUntil(() => storedTexts(h.framework).includes('Recovered final answer'));
+      assert.ok(done, 'turn should complete with the post-restart answer');
+      assert.strictEqual(h.membrane.calls.length, 2, 'restart should open a second stream');
+      const restarted = h.traces.find((e) => e.type === 'inference:stream_restarted') as
+        { reason?: string; inputTokens?: number; budget?: number } | undefined;
+      assert.ok(restarted, 'a stream_restarted trace should be emitted');
+      assert.strictEqual(restarted.reason, 'physical_window');
+      assert.strictEqual(restarted.budget, 200_000);
+      assert.ok((restarted.inputTokens ?? 0) > 200_000, 'trace should carry the projected size');
+    } finally {
+      await h.framework.stop();
+      rmSync(h.tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('leaves behavior unchanged when physicalWindowTokens is unset', async () => {
+    const h = await runTurn(undefined, new MockMembrane());
+    try {
+      // Same near-cap usage, no declared window: the stream resumes in place
+      // and the SECOND queued response is never consumed by a restart —
+      // MockYieldingStream continues the first stream instead.
+      const done = await pollUntil(() => storedTexts(h.framework).includes('Recovered final answer'));
+      assert.ok(done, 'turn should complete on the original stream');
+      assert.strictEqual(h.membrane.calls.length, 1, 'no second stream without a declared window');
+      assert.ok(
+        !h.traces.some((e) => e.type === 'inference:stream_restarted'),
+        'no restart trace without a declared window',
+      );
+    } finally {
+      await h.framework.stop();
+      rmSync(h.tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/physical-window-restart.test.ts
+++ b/test/physical-window-restart.test.ts
@@ -40,6 +40,19 @@ class SequentialStreamMembrane extends MockMembrane {
   }
 }
 
+/** Explicit response queue per streamYielding call. */
+class QueuedStreamsMembrane extends MockMembrane {
+  constructor(private queues: NormalizedResponse[][]) {
+    super();
+  }
+  override streamYielding(request: NormalizedRequest, _options?: unknown): YieldingStream {
+    this.calls.push(request);
+    const stream = new MockYieldingStream(this.queues.shift() ?? []);
+    this.lastStream = stream;
+    return stream;
+  }
+}
+
 class BlobToolModule implements Module {
   readonly name = 'canned';
   async start(): Promise<void> {}
@@ -159,6 +172,60 @@ describe('physical-window mid-turn restart (issue #92)', () => {
     } finally {
       await h.framework.stop();
       rmSync(h.tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not inherit the pre-restart window size into the new stream', async () => {
+    // Regression pin for the reset (opus-rev review finding #1): after a
+    // physical-window restart, the fresh stream runs a tool round that emits
+    // NO usage event before reaching the tool-result boundary. Without the
+    // stream-start reset, the projection would run on the inherited 200k
+    // figure — the very number that caused the restart — and restart again
+    // into an empty queue (loop; this test would then time out).
+    const tempDir = mkdtempSync(join(tmpdir(), 'phys-window-'));
+    const noUsageToolResponse = createMockResponse([
+      { type: 'text', text: 'Continuing…' },
+      { type: 'tool_use', id: 'call_2', name: 'canned--fetch', input: {} },
+    ], 'tool_use');
+    (noUsageToolResponse as { usage: unknown }).usage = undefined;
+    const membrane = new QueuedStreamsMembrane([
+      [nearCapToolResponse()],
+      [noUsageToolResponse, createMockResponse([{ type: 'text', text: 'Recovered final answer' }])],
+    ]);
+
+    const framework = await AgentFramework.create({
+      storePath: join(tempDir, 'store'),
+      membrane: membrane.asMembrane(),
+      agents: [{
+        name: 'prime',
+        model: 'test-model',
+        systemPrompt: 'You are prime.',
+        allowedTools: 'all',
+        maxTokens: 4_000,
+        physicalWindowTokens: 200_000,
+      }],
+      modules: [new BlobToolModule()],
+      syncIntervalMs: 0,
+    });
+    const traces: TraceEvent[] = [];
+    framework.onTrace((e) => traces.push(e));
+    framework.start();
+    framework.pushEvent({
+      type: 'external-message',
+      source: 'test',
+      content: [{ type: 'text', text: 'fetch it' }],
+      metadata: {},
+      triggerInference: true,
+    } as unknown as ProcessEvent);
+    try {
+      const done = await pollUntil(() => storedTexts(framework).includes('Recovered final answer'));
+      assert.ok(done, 'the post-restart stream must resume, not restart again');
+      assert.strictEqual(membrane.calls.length, 2, 'exactly one restart');
+      const restarts = traces.filter((e) => e.type === 'inference:stream_restarted');
+      assert.strictEqual(restarts.length, 1, 'the inherited value must not trigger a second restart');
+    } finally {
+      await framework.stop();
+      rmSync(tempDir, { recursive: true, force: true });
     }
   });
 


### PR DESCRIPTION
Implements the shape proposed in #92: before resuming a stream with tool results, project the next round's REAL size and break the stream through the existing budget-restart path (fresh compile) rather than dispatching a request the provider will 400.

## Why the existing restart couldn't catch this

The `maxStreamTokens` check compares `usage.inputTokens` — **fresh input only**. On a warm stream the cached prefix (cacheRead + cacheCreation) is most of the window: Rhys's doomed round reported ~5–10k fresh tokens while sitting at 199k real. Two things were missing: the cache-inclusive number, and any accounting of the blocks about to be appended.

## What this adds

- **`AgentConfig.physicalWindowTokens`** — the model's hard cap as explicit config (the issue's requirement; same knob the cm-side clamp needs). **Unset → behavior unchanged**, so nothing moves at deploy until recipes opt in (Rhys/Evander/Princess at 200000 are the intended first users).
- **`Agent.lastStreamRealInputTokens`** — fresh + cacheCreation + cacheRead from each usage event, alongside the existing fresh-only field.
- **Projection at the tool-result boundary**: `realPriorInput + estimate(appended blocks) + maxTokens reserve`. The estimate counts spilled tool-result strings at chars/4, a flat 1600/image for native image blocks (Princess's exhibit was image-bearing), mid-turn injected text, and a small per-block envelope. Deliberately ceiling-ish — overestimate costs one early recompile, underestimate costs the 400.
- Over the window → the **existing** `context_budget_restart` flow (cancel marked as framework-initiated, requeue, fresh compile through the solver — all downstream special-casing of that reason applies unchanged). Trace: `inference:stream_restarted` with `reason: 'physical_window'`, carrying projected size + window; the established `'context_budget'` label is untouched when the old check fires.

Not addressed here, per the issue's own scoping: the cm-side grace clamp (`rejectionBudget` legalizing over-window plans) is the companion cm change; pre-allocation/adapter byte bounds remain af#89 item 5.

## Tests

New `test/physical-window-restart.test.ts` (2): the restart case is built so the fresh-only check would pass it (5k fresh, 195k cached) — proving the cache-inclusive projection is what fires — asserting the second stream, the post-restart completion, and the `physical_window` trace with projected size; plus unset-window → resume-in-place, one stream, no restart trace. Full suite twice: 527/0 and 554/0 (collection counts vary per af#96).

Priority note from the issue: not urgent, prioritize if it recurs on Rhys — this PR is the standing fix so that recurrence is a recipe edit away instead of an incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)