### PR TITLE
docs: contribution policy — CONTRIBUTING, PR template, changelog CI guards

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+## Problem
+
+<!-- What is wrong / missing, and for whom. Link the issue if one exists. -->
+
+## Changes
+
+<!-- What this PR does. For cross-repo or stacked work, list companion PRs
+     and merge-order guidance ("safe in either order because…"). -->
+
+## Tests
+
+<!-- Evidence, not assertion: paste the numbers.
+     e.g. `npm test`: 318 pass / 2 fail — failure count identical to main baseline.
+     Tests run from dist/, so `npm run build` first. -->
+
+## Not verified
+
+<!-- Anything you did not exercise (live providers, Discord, platforms,
+     migration paths). "Nothing — verified end-to-end" is a fine answer;
+     silence is not. -->
+
+---
+
+- [ ] `CHANGELOG.md` updated under `## Unreleased` — or this change is
+      internal-only / test-only / docs-only (apply the `no-changelog` label).
+
+<!-- AI-assisted contributions are welcome and normal here — see
+     CONTRIBUTING.md for the attribution convention (footer + Co-Authored-By). -->

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,32 @@
+name: Changelog
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  changelog-entry:
+    name: Changelog entry present
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.pull_request.labels.*.name, 'no-changelog')"
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Require CHANGELOG.md update when src/ changes
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          changed=$(git diff --name-only "$base...$head")
+          echo "Changed files:"
+          echo "$changed"
+          if echo "$changed" | grep -q '^src/' && ! echo "$changed" | grep -qx 'CHANGELOG.md'; then
+            echo "::error::This PR touches src/ but not CHANGELOG.md. Add an entry under 'Unreleased' (see CONTRIBUTING.md), or apply the 'no-changelog' label if the change is internal-only."
+            exit 1
+          fi
+          echo "OK"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -14,7 +14,7 @@ jobs:
     if: "!contains(github.event.pull_request.labels.*.name, 'no-changelog')"
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,12 @@ jobs:
         os: [ubuntu-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 20
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,10 +15,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 20
 
@@ -49,7 +51,9 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Require changelog section for this release
         run: |
@@ -61,7 +65,7 @@ jobs:
           fi
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           # node 24 ships npm >= 11.5.1, required for OIDC publishing.
           node-version: 24
@@ -89,7 +93,9 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Mirror changelog section into release notes
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,6 +51,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Require changelog section for this release
+        run: |
+          ver="${GITHUB_REF_NAME#v}"
+          esc=$(printf '%s' "$ver" | sed 's/[.]/\\./g')
+          if ! grep -Eq "^## ${esc}([^0-9]|$)" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no '## ${ver}' section for tag ${GITHUB_REF_NAME}. Retitle the Unreleased section before tagging (see CONTRIBUTING.md)."
+            exit 1
+          fi
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -66,3 +75,40 @@ jobs:
 
       - name: Publish
         run: npm publish --access public --provenance
+
+  github-release:
+    name: GitHub release notes
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    # Deliberately independent of the npm publish job: some consumers run
+    # github-clone checkouts, and release notes must exist even when npm
+    # publish fails — the two jobs succeed or fail on their own.
+    if: startsWith(github.ref, 'refs/tags/v')
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Mirror changelog section into release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ver="${GITHUB_REF_NAME#v}"
+          # Section header is '## X.Y.Z — YYYY-MM-DD'; match the version
+          # field exactly (string compare, no regex escaping needed).
+          awk -v ver="$ver" '
+            /^## / { if (in_section) exit; if ($2 == ver) { in_section = 1; next } }
+            in_section { print }
+          ' CHANGELOG.md | sed '/./,$!d' > notes.md
+          if ! [ -s notes.md ]; then
+            echo "::error::No CHANGELOG.md section found for ${ver}."
+            exit 1
+          fi
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            gh release edit "$GITHUB_REF_NAME" --notes-file notes.md
+          else
+            gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" \
+              --notes-file notes.md --verify-tag
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,296 @@ Releases up to and including 0.7.3 predate this file; for their contents see
 [releases page](https://github.com/anima-research/agent-framework/releases).
 
 ## Unreleased
+
+## 0.9.0 — 2026-08-06
+
+Minor rather than patch because 0.x puts breaking changes in the minor, and
+this release both removes a public method from an exported class and changes
+fleet default behavior.
+
+### Breaking (consumers)
+
+- **`McplServerConnection.sendAfterInference` is removed** (#86). The method
+  was dropped from the spec in MCPL 0.5.0 (§10.5, replaced by
+  `inference/lifecycle`) and the runtime stopped sending it then; only the
+  helper survived.
+  - **Who needs to act:** nobody we can find. `package.json` `exports` maps
+    only `.`, and the root index re-exports a curated subset that never
+    included `McplMethod`, `AfterInferenceParams` or `AfterInferenceResult`,
+    so the surface is provably private. A grep across 14 trees found one
+    definition and zero callers.
+  - **Migration:** consume `inference/lifecycle` — `started` at stream start,
+    exactly one terminal event on every exit path.
+- **Tool results now spill to a file above 5,000 characters by default**
+  (#91). Previously the cap was `strategy.maxMessageTokens * 4` — often tens
+  of thousands of characters, and *no cap at all* when the strategy declares
+  no `maxMessageTokens`.
+  - **Who needs to act:** any deployment relying on large tool results
+    landing inline. Raise `FrameworkConfig.toolResultInlineMaxChars`
+    (minimum 1000), or per-agent via `tool_result_inline_max_chars`.
+  - **Unchanged:** nothing is lost — the full result is written to a spill
+    file and the notice names its path.
+
+### Breaking (MCPL servers)
+
+- **MCPL 0.5 enforces deny-by-default before the policy handshake completes**
+  (§5.3). A connection carries an empty grant until `establishGrant()`, and
+  privileged inbound traffic is rejected until the initial exchange settles.
+  A server that does not answer the `featureSets/update` Request keeps an
+  empty grant — **un-migrated servers will go dark**, accepted deliberately
+  for a single-release rollout.
+- **§7 `scope`/`elevate` is removed** — both now answer `-32601`, config
+  `scopes` is ignored with a warning, and `ScopeManager` is gone from wiring.
+- Requests denied against the grant answer `-32002` with
+  `data: { capability }`; notifications are discarded with diagnostics.
+  `-32001`/`-32003` are JSON-RPC errors with `data: { featureSet }` (§6.6),
+  with result-shape fallback only for legacy responders.
+
+### Breaking (dependency floors)
+
+Raised to fix a build that only worked against local symlinks:
+
+- **chronicle `^0.3.0`** — context-manager 0.6.3 requires `^0.3.0`, so the old
+  `^0.2.2` installed *two* chronicles and the framework handed a 0.2.x
+  `JsStore` to APIs expecting the 0.3.x one. Single copy now.
+- **membrane `^0.5.78`** — the framework consumes the `retrying`
+  yielding-stream event, which existed only in unpublished membrane commits
+  until 0.5.78.
+
+**Deploy note:** chronicle 0.3.0 open-writes a store format 0.2.x cannot
+reopen. Take cold backups before upgrading any residence.
+
+### Added
+
+- **MCPL 0.5 capability grants** (#76, #78, #79) — the §6.2 vocabulary tree, a
+  generic recursive advertisement walk (§5.1 boolean shorthand; unknown names
+  mint nothing), grant matching with one-segment wildcards and
+  bare-parent-grants-nothing (§5.4), and §13.4 deny-by-default for
+  `inject.system`, re-grantable only via explicit config. Enforcement sits at
+  the admission choke-point that live routing and every buffer flush share, so
+  buffered events are authorized against the grant current at admission rather
+  than at emit. Hook fan-out selects by grant, `userMessage` is `null` when
+  `observe` is not granted, and injection positions are authorized against the
+  grant current at response receipt (§10.8).
+- **§17 host-side manifest tracking** (#78) — `mcpl/manifestChanged` routed
+  ungated (§17.3: gating would silence exactly the servers whose grants just
+  narrowed), fetched via `mcpl/manifest`, validated exactly as `initialize`,
+  and applied reduction-first through an interim `new ∩ old` grant before the
+  server is told (§6.7). Rate-limited per connection with in-flight coalescing
+  and a 5s floor, host-bounded rather than trusting server coalescing.
+- **Host-side capability scoping** — `enabledCapabilities` /
+  `disabledCapabilities` per server, same allow/deny and wildcard idiom as
+  `enabledTools`. A server names its own capabilities in its `initialize`
+  response and hook fan-out keyed off that self-advertisement, so connecting
+  any server claiming `contextHooks.afterInference` received the complete text
+  of every agent turn, and disabling its feature sets did not stop that:
+  feature sets gate what a server may *do*, while what it may *see* was gated
+  only by its own advert.
+- Live policy status in the MCPL server listing, and manifest freshness in
+  server status (#87).
+- **`refusalHandling.retries`** (default 0) — plain same-model retries when a
+  turn ends in `stop_reason: refusal`, before rewind or reaction. Near the
+  classifier threshold the verdict is probabilistic rather than a function of
+  the payload; identical bytes were observed passing and refusing minutes
+  apart. Retries are spent at the membrane seam, which replays the same
+  request immediately and cache-warm — a framework requeue recompiled, making
+  attempts correlated rather than fresh draws. `driveStream` handles
+  membrane's `retrying` event by re-minting the outgoing inference id and
+  resetting the prose router, so the surface orphans the partial preview
+  instead of splicing two half-answers together. Escalation order is now
+  retries → rewind → reaction, which restores the reaction's meaning as "the
+  border is close" rather than firing on every near-threshold flip.
+  Operator-forced `/unstick` skips retries and keeps its semantics.
+- **`REFUSAL_REACTIONS`, the fallback marker, and `REFUSAL_REACTION_BASELINE`**
+  are exported from the root index (#88) — the deduplicated set of every
+  marker `reactToRefusal` can emit, so a host can suppress exactly the
+  annotations the framework stamps instead of keeping a list in sync by hand.
+- **`nudgeAgent()`** — queue a normal inference request with zero context
+  mutation, so the turn compiles exactly what the agent already sees. Not
+  idle-gated; queued requests bypass gate sleep as an admin override. Also
+  wired as host/command `nudge`.
+- **`skip_reply` `wake_in_seconds`** — end the turn but come back on your own
+  after N seconds, so "not replying now" can mean "back in a moment" instead
+  of "idle until something external arrives". Deliberately not sleep: no
+  suppression window, external wakes flow normally, and any turn start cancels
+  the pending self-wake. A compact one-line in-window notice rides the wake
+  turn so the agent can tell its own timer from a heartbeat.
+- **`AgentConfig.physicalWindowTokens`** (#92) — continuation rounds append
+  tool results to the compiled request without recompiling, so a compile that
+  was legal could walk past the provider's hard cap mid-turn and take a wire
+  `context_length_exceeded` 400 (observed at 185k → 199.6k → 209k against a
+  200k cap). Grace cannot help, because the provider cap is physical. Unset
+  leaves behavior unchanged.
+- **`tool_result_inline_max_chars` as a durable resident setting** (#91, #94) —
+  persisted to `framework/state` alongside the other durable settings and
+  restored on create, with load-time validation that drops invalid entries
+  loudly. `reset` clears it and returns the agent to the residence default,
+  and the reset itself survives restarts. The *effective* cap is
+  `min(desired, strategy bound)` for every source: a durable preference must
+  not become a durable path for one tool result to exceed the strategy's
+  per-message safety limit. `agent_settings get` reports the full quartet —
+  desired, effective, source, and `clamped_by`.
+- **Routing self-observability** — `[delivered]` prose receipts collected
+  across the logical turn (budget restarts accumulate into one receipt),
+  `channel_open` moves the pin and announces it in its own tool result, and
+  suppressed prose is visible in the receipt. The 2026-07-31 misroute series
+  showed the agent provably knew its prose lane one round before misrouting;
+  the failure was attention, and it could never see afterwards where its words
+  had actually landed.
+- **Engaged-channel re-pin** — a human follow-up in a channel the agent itself
+  sent into this turn moves the locus, even without a mention. Tagged
+  `chat:ambient`, such a message correctly declined the addressed re-pin, but
+  conversationally it is a reply in flow, and trailing prose followed the stale
+  pin into an unrelated DM.
+
+### Fixed
+
+- **A failing MCPL server can no longer crash the agent process.** A websocket
+  dial failing at the HTTP layer (nginx 502 with the backend down) emits
+  `error` on the raw socket more than once; `open()`'s settle paths called
+  `removeAllListeners()` before `terminate()`, so the late error had no
+  listener and became a top-level unhandled `ErrorEvent` — the whole agent died
+  at boot, into a systemd crashloop (623 cycles observed live). Every settle
+  path now leaves a swallow listener; the reconnect loop above owns recovery.
+- Stale MCPL grants are revoked across reconnects.
+- **Cache-inclusive stream counters are reset at stream start.**
+  `lastStreamRealInputTokens` was never reset, so a new stream inherited the
+  previous stream's window size until its own first usage event — and on the
+  restart path introduced by #92 the inherited value is precisely the oversized
+  number that caused the restart, so a round reaching the tool-result boundary
+  before emitting usage would restart again, forever. Prior output is also now
+  counted in the projection.
+- A spill *write* failure now produces a distinct notice and trace, instead of
+  being indistinguishable from a successful spill.
+- The closed-channel invitation states the real delivery model and carries a
+  missed tally.
+- Tool-call state is attributed correctly across multiple feature sets.
+
+## 0.8.0 — 2026-07-31
+
+### Breaking
+
+- **`McplServerConfig.tokenProvider` is renamed `accessProvider`.** Identifiers
+  surface — in stack traces, in agent-readable source, in every model-driven
+  loop over this code — and the name now matches the access-grant framing.
+  Mechanical rename; update the field name at call sites.
+
+### Added
+
+- **Background scripts** — `code_execution` gains `background: true`. The
+  script detaches into a dedicated interpreter, the tool returns immediately
+  with a `script_id`, and the turn is free to end. In-script,
+  `await wake_agent(payload)` delivers a provenance envelope — script id, the
+  line number in the agent's own script, elapsed time, wake count, journal path
+  — plus the payload, and requests inference, entering tagged `script:wake`.
+  The authority is the agent's own: it armed the wake itself. A script that
+  ends without waking wakes nobody, and one that crashes wakes the agent with
+  the error tail.
+- **Oversized tool-result spill** — the agent's context is for signal, not
+  bulk. (Completed with a safe default in 0.9.0; see #91.)
+- **`utils` meta-tool** — `Module.getUtilities?()` takes the same
+  `ToolDefinition` shape and the same `handleToolCall` dispatch as
+  `getTools()`, so a tool migrates surfaces by moving between the two lists.
+  The framework advertises a single `utils` tool (list / describe / run) only
+  when at least one utility is registered, and `run` bounces schema misses with
+  the schema attached. Rationale: every first-class tool schema taxes every
+  inference, and a capability used twice a month shouldn't.
+- **Per-dial MCPL credential provider** — resolved at every dial, connect and
+  each background reconnect, overriding the static token. Host-attached and
+  never serialized: agents name an access grant, credentials are fetched fresh
+  outside model context, which also makes short-lived audience tokens viable
+  where a static `?token=` forced long-lived ones. Dial-failure messages now
+  carry a token-stripped URL, since error strings travel into traces and tool
+  results.
+- **Machine-close provenance and explicit-open protection** — `channel_close`
+  accepts `source` and `overrideExplicitOpen` (module callers only, undeclared
+  in the agent-facing schema). Housekeeping closes previously recorded
+  `source: 'agent-tool'`, so the durable record could not distinguish an
+  agent's decision from a janitor's, and downstream respect for agent decisions
+  became respect for the janitor. A machine-sourced close of a channel an agent
+  or operator explicitly opened is now refused structurally
+  (`data.refusal = 'explicit-open'`) unless the caller certifies otherwise.
+  Adds `ModuleContext.notifyOps`.
+- **Addressed re-pin** — a turn's locus freezes at turn start (deliberate,
+  as ambient-hijack protection), but when someone *addresses* the agent from
+  another channel mid-turn the model conversationally follows the new speaker
+  while its trailing prose lands on the stale pin. In all six recorded
+  incidents the prose answered the injected speaker. Mid-turn addressed
+  injections now move the locus.
+
+### Fixed
+
+- **Phantom skips and falsified history.** A DM's wake fired a turn whose
+  compile ran before the deferred DM flushed: the model saw only the routing
+  notice and reasonably skipped, and the DM then landed in the window
+  mid-compile, positioned *before* the skip — so the window testified that the
+  agent saw and ignored a message it was never shown, and the agent
+  confabulated an apology for a choice it never made, with KV divergence at the
+  inserted message on every later compile. `activeTurnTokens` now marks a turn
+  alive from dequeue through settled teardown (strictly longer than
+  `activeStreams` membership, which begins only after hooks and compile), and
+  `addMessage` defers on turn-alive: the compile window is closed to cross-turn
+  writers.
+- **Lazy workspace sync corrupted binaries.** `ensureSynced` round-tripped
+  every file through UTF-8 before storing the blob, so non-UTF-8 bytes became
+  U+FFFD and any binary entering the tree via lazy sync was permanently
+  corrupted. The bulk path already skipped binaries; lazy sync now mirrors it
+  and serves them from disk. Separately, bare `read_image` was unconditionally
+  intercepted by a tree-only handler with no fallback, and now falls back to
+  disk.
+- **`WorkspaceModule` restart restoration is second-callback-safe** (#72).
+  Hosts call `module.start(ctx)` before `initStore(store)`, but restoration
+  looped over `this.mounts` inside `start()` — empty at that moment — so every
+  restart silently reset materialization state: misleading `pendingChanges`,
+  null `lastMaterializedBranch`, `canMaterialize` true across a branch
+  mismatch, and a disabled branch guard until the next materialization.
+  `start()` now only decodes the persisted payload, and a shared
+  `applySavedState()` applies it once mounts exist, called from both callbacks.
+
+## 0.7.4 — 2026-07-27
+
+### Added
+
+- **Immediate context-budget decrease** — `patch.immediate` (a mode flag, never
+  persisted) takes a `contextBudgetTokens` decrease down the same path as an
+  increase: budget set directly, any in-flight paced descent cancelled, and the
+  next compile plans straight at the new value. Previously a decrease could
+  only converge gradually, which is the wrong tool during a refusal streak or
+  an over-wall wedge — the operator needs the window smaller now, and the whole
+  fold-down and its KV invalidation land on one turn by explicit choice. Also
+  exposed on `agent_settings`.
+
+### Fixed
+
+- **Thinking-only assistant messages are never persisted.** They are refusals:
+  the provider returns signed thinking and no content, so the turn produced no
+  speech and no tool call, and storing one records an action that never
+  happened. Two landing adjacently are toxic — formatters merge consecutive
+  same-role messages, producing a single assistant message carrying signed
+  thinking from two *different* responses, which the provider cannot verify:
+  a 400 that no retry can clear. One such pair took an agent hard down for
+  roughly four hours. Refused at `addAssistantResponse`, the single chokepoint
+  for every assistant persist, and refused loudly.
+- **Unverifiable signed thinking is dropped from the last assistant message.**
+  The provider verifies thinking blocks in the latest assistant message against
+  their signature, and a block whose text was summarized or redacted away
+  (signature present, thinking empty) fails that check and 400s the entire
+  request, unrecoverably — one agent was down ~2.5h across 13 consecutive
+  failures. Such blocks are normal in these stores and harmless everywhere
+  except that one position, where the provider replays their encrypted chain of
+  thought, so the strip is scoped to the last assistant message: a blanket
+  strip would silently discard the agent's interiority.
+- **The typing indicator starts at turn start**, not after module
+  `gatherContext`, MCPL `beforeInference` RPCs, the full context compile and
+  stream initiation. Every millisecond of that leg read as dead air to whoever
+  had just messaged the agent — 30+ seconds during one compile regression, and
+  still seconds afterwards. Typing now means attending, not replying. The
+  failure paths that never reach `driveStream` stop the indicator, so a compile
+  refusal cannot leave it stuck.
+- **Channel invitations reach the `channels/incoming` path.** The
+  addressed-while-closed invitation block existed only on the push-event path,
+  so an agent woken by a mention delivered via `channels.publish` got no
+  guidance and no route — one observed reply of 2,320 characters bounced with
+  "no destination set yet this turn". The invitation's first option was also
+  reworded: "simply write your reply as normal text" is a false promise for
+  explicit prose-routing agents.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+Notable changes to `@animalabs/agent-framework`, loosely following
+[Keep a Changelog](https://keepachangelog.com/). Entries land with the change
+that causes them — see [CONTRIBUTING.md](CONTRIBUTING.md#changelog).
+
+Releases up to and including 0.7.3 predate this file; for their contents see
+`git log` and the
+[releases page](https://github.com/anima-research/agent-framework/releases).
+
+## Unreleased

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,140 @@
+# Contributing to agent-framework
+
+agent-framework is part of the Connectome ecosystem
+([membrane](https://github.com/antra-tess/membrane),
+[context-manager](https://github.com/anima-research/context-manager),
+[chronicle](https://github.com/anima-research/chronicle),
+[connectome-host](https://github.com/anima-research/connectome-host)). These
+conventions describe how work actually lands here — they codify existing
+practice rather than aspiration. When in doubt, recent merged PRs are the best
+reference.
+
+Everything below applies to every change however it lands — external PR or
+maintainer direct push — and to human and AI authors identically. There is
+no separate rulebook for either.
+
+## How changes land
+
+- External contributions come as PRs against `main`, from a fork or a repo
+  branch. Maintainers also land small changes directly on `main`; don't be
+  surprised by history that never saw a PR.
+- Branch names: `feat/<kebab-case>`, `fix/<kebab-case>`, `docs/`, `chore/`.
+  Including the issue number is welcome (`fix/43-scope-module-injections`).
+- PRs are merged as **true merge commits** — no squash, no rebase-merge.
+  Because nothing is squashed, keep individual commits coherent.
+- To update a stale branch, rebase onto `main` or merge `main` in; both are
+  accepted.
+- Stacked PRs and cross-repo companion PRs are fine, but **declare them** in
+  the body with merge-order guidance ("stacked on #7 — review that first";
+  "safe to merge in either order because …"). This repo sits directly on
+  membrane, context-manager and chronicle and is consumed by
+  connectome-host, so companion PRs are common; say which side is safe to
+  land first and what happens if only one does.
+
+## What a PR should contain
+
+Body shape (the PR template mirrors this): **Problem / Changes / Tests**,
+plus, when applicable, **Not verified**, **Out of scope**, and
+**Companion PRs**. The conventions that matter:
+
+- **Evidence over assertion.** State the test baseline numerically:
+  "`npm test`: N pass / M fail, failure count identical to `main` baseline."
+  A claim like "all tests pass" without the count will be re-verified anyway,
+  so save the reviewer the trip.
+- **Say what you did NOT verify.** An honest "not exercised end-to-end
+  against a live provider" is respected; a silent gap that review uncovers
+  is not.
+- **Tests accompany behavior changes.** Review scrutinizes test substance,
+  not mere presence — a test that can't fail on the unfixed code will be
+  called out.
+- **Changelog entry** under `## Unreleased` for anything behavior-affecting
+  (see below).
+
+Conventional-commit-style titles (`feat(modules): …`, `fix(streaming): …`) are
+the house default; plain descriptive titles are accepted.
+
+## Review process — what to expect
+
+- Review arrives as **ordinary PR comments**, not GitHub review approvals —
+  the comment thread is the gate. Reviews are frequently AI-generated and
+  explicitly labeled as such, with a severity verdict and itemized findings.
+- The reviewer will typically **run your branch** (typecheck, test suite,
+  sometimes exercising a module against a real store) and paste transcripts.
+  Claims are checked, not trusted.
+- Respond by pushing fix commits and replying per finding — "Addressed in
+  `<sha>`" — rather than force-pushing a rewritten branch. A re-review then
+  flips the verdict.
+- Maintainers may push small review fixes **directly to your branch** to keep
+  things moving. Say so in the PR body if you'd rather they didn't.
+- PRs are never closed silently: a closed PR gets a one-line disposition
+  comment (usually supersession by another PR).
+
+## AI-assisted contributions
+
+AI-written code is the norm in this ecosystem, welcome from everyone, and
+held to exactly the same evidence standards as anything else. Declare it the
+way we do:
+
+- the `🤖 Generated with [Claude Code](https://claude.com/claude-code)`
+  footer (or equivalent for your tooling) in the PR body, and
+- a `Co-Authored-By:` trailer naming the model in commits.
+
+What earns an automated contribution a changes-requested review is not being
+AI-generated — it's arriving without the suite having been run, with tests
+that don't fail on unfixed code, or with claims the branch itself disproves.
+
+## Changelog
+
+`CHANGELOG.md` keeps a standing `## Unreleased` section with
+`### Breaking` / `### Added` / `### Changed` / `### Fixed` subsections
+(loosely [Keep a Changelog](https://keepachangelog.com/)).
+
+- **The entry lands with the change** — same commit, or at least the same
+  PR. This binds direct pushes to `main` just as much as PRs. On PRs, CI
+  enforces it softly: touching `src/` without touching `CHANGELOG.md` fails
+  the `changelog` check unless the `no-changelog` label is applied.
+- **What needs an entry:** anything a module developer, host, or downstream
+  consumer would notice — behavior, event/trace surfaces, tool namespacing,
+  config schema, agent state machine, public exports, defaults. Internal
+  refactors, test-only, and docs-only changes don't.
+- **Breaking entries are audience-scoped.** Name the audience in the heading
+  (`### Breaking (module authors only)`) and cover: **who needs to act**,
+  **migration**, and **unchanged** (what readers might fear broke but
+  didn't). Because connectome-host and other hosts pin this package by
+  range, a breaking change here surfaces in their next install — spell out
+  the minimum sibling versions it requires.
+- **Keep one `## Unreleased` heading.** Add entries under the existing one;
+  don't open a second. Only the first is cut at release time, so entries
+  filed under a later heading are silently never released — the release
+  script refuses to run if it finds more than one.
+- **Releases** (maintainers): `npm version <patch|minor|major>` does the
+  whole cut — the `version` hook retitles `Unreleased` to
+  `## X.Y.Z — YYYY-MM-DD` (keeping a fresh `Unreleased` above it, and
+  refusing to release when there are no entries), then npm commits and tags.
+  `git push --follow-tags` triggers CI, which refuses a tag with no matching
+  changelog section, publishes `@animalabs/agent-framework` to npm, and
+  creates the GitHub release with that section as its notes. The two release
+  jobs are independent: some consumers run github-clone checkouts, so
+  release notes must exist even when npm publish fails. Version bumps are a
+  maintainer release-time action, not part of feature PRs.
+
+## Building and testing
+
+```bash
+npm install
+npm run build         # tsc; tests run from dist/, so build first
+npm test              # node --test dist/test/*.test.js
+npx tsc --noEmit      # typecheck
+```
+
+`npm test` runs the compiled output, so a stale `dist/` will happily test
+code you no longer have — always build before testing, and after switching
+branches. The `pretest` hook copies `test/fixtures/*.mjs` into `dist/`.
+
+Push-time CI (`ci.yml`) builds, typechecks and tests every push and PR on
+ubuntu and macos. Lockfiles are deliberately gitignored in this repo, so CI
+installs with plain `npm install` and there is no lock to keep in sync.
+
+When working against local sibling checkouts rather than published versions,
+see the ecosystem workspace setup — `bun install` at the `rust-connectome`
+root links the four packages together.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "typecheck": "tsc --noEmit",
     "pretest": "mkdir -p dist/test/fixtures && cp test/fixtures/*.mjs dist/test/fixtures/",
     "test": "node --test --test-force-exit dist/test/*.test.js",
+    "version": "node scripts/release-changelog.mjs && git add CHANGELOG.md",
     "prepublishOnly": "npm run build"
   },
   "keywords": [

--- a/scripts/release-changelog.mjs
+++ b/scripts/release-changelog.mjs
@@ -1,0 +1,58 @@
+// Runs as npm's `version` lifecycle hook (see package.json): at that point
+// package.json already carries the new version, and files staged here are
+// included in the release commit that `npm version` then creates and tags.
+//
+// Cuts the standing `## Unreleased` section into `## X.Y.Z — YYYY-MM-DD` and
+// leaves a fresh empty `## Unreleased` above it. Refuses to release when
+// there is nothing to release, or when the file's shape is ambiguous.
+import { readFileSync, writeFileSync } from "node:fs";
+
+const path = "CHANGELOG.md";
+const { version } = JSON.parse(readFileSync("package.json", "utf8"));
+const text = readFileSync(path, "utf8");
+
+const fail = (msg) => {
+  console.error(`CHANGELOG.md: ${msg}`);
+  process.exit(1);
+};
+
+// Exactly one Unreleased heading. A second one silently strands entries:
+// only the first is ever cut, so anything filed under a later heading is
+// never released and never reaches the GitHub release notes.
+const headings = [...text.matchAll(/^## Unreleased[ \t]*$/gm)];
+if (headings.length === 0) {
+  fail("no '## Unreleased' section — add one before releasing.");
+}
+if (headings.length > 1) {
+  const lines = headings.map((m) => text.slice(0, m.index).split("\n").length);
+  fail(
+    `${headings.length} '## Unreleased' headings (lines ${lines.join(", ")}). ` +
+      "Only the first is released; fold them into one before releasing.",
+  );
+}
+const [header] = headings;
+
+const escaped = version.replace(/[.]/g, "\\.");
+if (new RegExp(`^## ${escaped}([^0-9]|$)`, "m").test(text)) {
+  fail(`a '## ${version}' section already exists.`);
+}
+
+const afterHeader = text.slice(header.index + header[0].length);
+const nextSection = afterHeader.search(/^## /m);
+const body = nextSection === -1 ? afterHeader : afterHeader.slice(0, nextSection);
+if (!/^[ \t]*[-*] /m.test(body)) {
+  fail(`'## Unreleased' has no entries — nothing to release as ${version}.`);
+}
+
+// Spliced by index rather than string-replaced: `text.replace("## Unreleased", …)`
+// would hit the first *substring* occurrence, which is not necessarily the
+// heading the regex matched (an inline mention of `## Unreleased` in prose
+// comes first) and would inject the version heading into the wrong place.
+const date = new Date().toISOString().slice(0, 10);
+writeFileSync(
+  path,
+  text.slice(0, header.index) +
+    `## Unreleased\n\n## ${version} — ${date}` +
+    text.slice(header.index + header[0].length),
+);
+console.log(`CHANGELOG.md: cut Unreleased into '## ${version} — ${date}'.`);


### PR DESCRIPTION
## Problem

agent-framework has no `CONTRIBUTING.md`, no PR template, and no changelog —
and no mechanism that would notice one was missing. `@animalabs/agent-framework`
is at 0.9.0 on npm, and the newest GitHub release in this repo is **v0.3.0 from
April**. Everything since is discoverable only by reading `git log`.

Three releases have shipped in the last two weeks, two of them minors carrying
real breaking changes, and none of them announced anywhere a consumer would
look:

- **0.8.0** renamed `McplServerConfig.tokenProvider` → `accessProvider`.
- **0.9.0** removed a public method from an exported class, changed a fleet
  default (tool results now spill at 5,000 chars), enforced MCPL 0.5
  deny-by-default before the policy handshake — which **darkens un-migrated
  MCPL servers** — and raised the chronicle floor to `^0.3.0`, whose store
  format 0.2.x cannot reopen. That last one wants cold backups before
  upgrading a residence, and the only place it was ever written down is a
  release commit body.

A PR-side check alone can't carry the rule: across the ecosystem 52–85% of
commits on `main` land by direct push, and version bumps are release-time
maintainer actions by construction. The load-bearing layer is the tag-time
guard. This is the third rollout of the same policy, after connectome-host #49
and context-manager #51.

## Changes

Ported from those two, adapted to this repo (build-before-test caveat,
stale-`dist/` warning in the template):

- **`CONTRIBUTING.md`** — codifies existing practice rather than aspiration:
  merge commits only, comment-based review with run-the-branch transcripts,
  evidence-over-assertion test reporting, and AI attribution as the norm.
  Explicitly binds direct pushes and PRs, human and AI authors, identically.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — Problem / Changes / Tests / Not
  verified, plus a changelog checkbox.
- **`.github/workflows/changelog.yml`** — soft PR check: touching `src/`
  without `CHANGELOG.md` fails, with a `no-changelog` label opt-out (label
  created).
- **`publish.yml`** — the publish job is now gated on the ref rather than the
  event, so a manual dispatch against a *branch* can no longer publish
  whatever version `package.json` happens to carry; a tag with no matching
  `## X.Y.Z` section fails the release; and a new `github-release` job mirrors
  the tag's section into GitHub release notes, independent of npm publish so
  notes exist even when publish fails.
- **`scripts/release-changelog.mjs`** + a `version` hook in `package.json` —
  `npm version <level>` cuts `Unreleased` into `## X.Y.Z — YYYY-MM-DD`
  pre-tag, so the tag and tarball carry it. Refuses an empty Unreleased, a
  duplicate section, and more than one `Unreleased` heading (a second one
  silently strands entries).
- **`CHANGELOG.md`**, watermarked at 0.7.3, **with 0.7.4, 0.8.0 and 0.9.0
  written up in full.**

That last point is deliberate. The earliest policy PRs held that the
enforcement PR should itself conform; this branch was cut 2026-07-27 and three
releases have shipped since. Landing an empty changelog would mean adding a
file already three releases behind `main` — the exact failure this PR exists
to prevent, committed by the PR that prevents it.

Entries are reconstructed from `v0.7.3..v0.9.0` and grouped by the release
that carried them. Notes on the judgment calls:

- **Breaking entries are audience-scoped**, as the policy asks: *consumers*
  (the `sendAfterInference` removal, the spill default), *MCPL servers* (0.5
  deny-by-default, §7 removal), and *dependency floors* separately — the three
  audiences act on different things, and only the third needs the backup
  warning.
- 0.9.0's release commit already itemized its breaking surface and floors;
  that is carried over rather than re-derived.
- **Review-response commits are folded into the entry for the feature they
  correct**, not listed separately — the changelog describes released
  behavior, not the path to it.
- Test-only and refactor commits are omitted, per the policy's own rule about
  what needs an entry.

The `package.json` conflict from the rebase was resolved in favour of `main`'s
`--test-force-exit` test script, with only the `version` hook added.

## Tests

`npm test`: **560 tests, 560 pass, 0 fail, 0 skipped** (70 suites). `npm run
build` clean; `tsc --noEmit`: **0 errors**. Green on this branch, ahead of the
539/538/1-skipped baseline the 0.9.0 release commit reported.

No `src/` changes — this is docs, CI config, and one npm lifecycle hook — so
the suite is a regression check, not a demonstration. What was exercised
directly is the tooling this branch adds, against the real `CHANGELOG.md`:

- **Tag guard** simulated for all three sections: `0.7.4`, `0.8.0`, `0.9.0` —
  all match.
- **Release-notes extraction**, same awk as the workflow: 45 / 79 / 162 lines
  respectively, each starting at its first `###` heading and stopping at the
  next `##` — no bleed across section boundaries.
- **`scripts/release-changelog.mjs`** against a copy, `package.json` at 0.9.1:
  empty `Unreleased` → refused, exit 1; one entry added → `cut Unreleased into
  '## 0.9.1 — 2026-08-07'`, exit 0, fresh empty `Unreleased` left above it;
  re-run → refused as duplicate, exit 1.
- **`Unreleased` heading count**: exactly 1.
- All three workflow files parse as YAML.

One reproduction note that cost time here and may cost a reviewer the same:
the workspace-symlinked `membrane` and `context-manager` checkouts had stale
`dist/` (membrane's dated June, against 0.5.78 sources), which fails AF's
build on the `retrying` event type with 5 `TS2678`/`TS2339` errors in
`framework.ts`. Rebuild those two first — it is a local-environment artifact,
not a branch or `main` defect, and CI installs from the registry so it cannot
hit this.

## Not verified

- **No agent was run.** Nothing in this branch touches a runtime path, so no
  live inference, MCPL connection or store was exercised.
- The `changelog.yml` check has not run yet — this PR touches no `src/` files,
  so it will pass trivially rather than exercising its failure path. The
  equivalent workflow was verified live on connectome-host #49.
- The tag guard and `github-release` job cannot run until the next release and
  stay unexercised on real infrastructure until then, as on the previous two
  rollouts. The next `npm version <level> && git push --follow-tags` will be
  this repo's first GitHub release since v0.3.0.
- The 0.7.4–0.9.0 entries are reconstructed from commit messages and the
  measurements quoted in them, not re-measured. Incident details (token
  counts, outage durations, crash-cycle counts, dates) are as their authors
  reported them. Where a commit body and a release body disagreed on framing,
  I took the release body.
- I did not audit whether any consumer actually calls
  `McplServerConnection.sendAfterInference`; the changelog repeats #86's own
  14-tree grep rather than re-running it.

---

- [x] `CHANGELOG.md` updated under `## Unreleased` — or this change is
      internal-only / test-only / docs-only (apply the `no-changelog` label).

Docs-only by the letter of the check, but the file ships with three releases
written up rather than empty, per the self-conformance point above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
