### PR TITLE
feat(tool-results): raise the house inline cap 5000 → 24000

### DIFF
--- a/src/framework.ts
+++ b/src/framework.ts
@@ -7334,7 +7334,7 @@ export class AgentFramework {
   /**
    * Effective tool-result inline cap for an agent, with provenance. Desired
    * value: resident's durable agent_settings value → residence
-   * FrameworkConfig.toolResultInlineMaxChars → house default (5000).
+   * FrameworkConfig.toolResultInlineMaxChars → house default (24000).
    * Effective value: min(desired, strategy bound) for EVERY source — the
    * strategy's per-message safety limit is a ceiling, not a suggestion
    * (Sol's #94 ruling: a durable preference must not be a durable path for

--- a/src/tool-result-history.ts
+++ b/src/tool-result-history.ts
@@ -20,10 +20,20 @@ import { safeSlice } from './safe-slice.js';
  * House-safe default inline cap (chars) for tool results, error results, and
  * background-script wake payloads (issue #89: a resident should never eat a
  * 42k blob they didn't ask for). Durable per-residence value comes from
- * `FrameworkConfig.toolResultInlineMaxChars`; a temporary per-agent lift from
+ * `FrameworkConfig.toolResultInlineMaxChars`; a per-agent value from
  * agent_settings `tool_result_inline_max_chars`.
+ *
+ * Raised 5000 → 24000 (2026-08-07) on production evidence rather than taste.
+ * The first residence to actually run the 5000 default spilled 48 results in
+ * 23h, 71% of them ordinary shell output from source review — `git diff`, test
+ * runs, `sed -n '450,590p'`-style excerpts, which routinely land at 5–15k. A
+ * 5000-char cap is tuned for conversation and turns every file read into a
+ * spill round-trip for a resident doing code work. Measured on that corpus:
+ * 20000 keeps 76% inline, 24000 keeps 88%, 32000 only reaches 90% — 24000 is
+ * the elbow. Genuinely large payloads (full histories, channel registries,
+ * broad greps) still spill, which is the point.
  */
-export const DEFAULT_TOOL_RESULT_INLINE_MAX_CHARS = 5000;
+export const DEFAULT_TOOL_RESULT_INLINE_MAX_CHARS = 24000;
 
 export function toolResultDataToHistoryString(data: unknown, maxChars?: number): string {
   const fromArray = tryHistoryStringFromContentArray(data);

--- a/src/types/framework.ts
+++ b/src/types/framework.ts
@@ -145,7 +145,7 @@ export interface FrameworkConfig {
    * name, overwritten on collision, retained until the workspace owner
    * deletes it — never auto-GC'd) and replaced inline by a bounded preview
    * plus the file reference; with no writable workspace the fallback is
-   * explicit plain truncation. Default 5000 (house-safe; issue #89). Must be
+   * explicit plain truncation. Default 24000 (house-safe; issue #89). Must be
    * >= 1000. A resident's own agent_settings value
    * `tool_result_inline_max_chars` (durable, persisted in framework state)
    * takes precedence over this for that agent; the EFFECTIVE cap for every

--- a/test/tool-result-spill.test.ts
+++ b/test/tool-result-spill.test.ts
@@ -2,7 +2,7 @@
  * Oversized tool-result spill — completion coverage for issue #89.
  *
  * The mechanism (spill to workspace file + bounded preview) landed in
- * f231bbf; these tests pin the completion semantics: the house-safe 5000
+ * f231bbf; these tests pin the completion semantics: the house-safe 24000
  * default (no more 42k accidental ingests), the durable
  * FrameworkConfig.toolResultInlineMaxChars cap, hot-override provenance and
  * restart behavior, error results under the same policy, the explicit
@@ -23,8 +23,18 @@ import type {
   ToolResult,
 } from '../src/index.js';
 import { AgentFramework, PassthroughStrategy } from '../src/index.js';
+import { DEFAULT_TOOL_RESULT_INLINE_MAX_CHARS } from '../src/tool-result-history.js';
 import { WorkspaceModule } from '../src/modules/workspace/index.js';
 import { createMockResponse, MockMembrane } from './helpers/mock-membrane.js';
+
+/**
+ * Bound for "inline copy is capped" assertions: the cap itself plus room for
+ * the truncation notice. Derived from the constant on purpose — these bounds
+ * were once hardcoded at the 5000-era value and so silently pinned the old
+ * default; raising it broke three tests that were only ever checking that
+ * SOMETHING capped the payload.
+ */
+const CAPPED = DEFAULT_TOOL_RESULT_INLINE_MAX_CHARS + 1000;
 
 class CappedPassthroughStrategy extends PassthroughStrategy {
   readonly maxMessageTokens = 1000;
@@ -179,7 +189,7 @@ function frameworkExtension(framework: AgentFramework): {
 }
 
 describe('tool-result spill completion (issue #89)', () => {
-  it('caps at the house default 5000 with no config and no strategy bound', async () => {
+  it('caps at the house default 24000 with no config and no strategy bound', async () => {
     // Pre-#89 behavior: PassthroughStrategy has no maxMessageTokens, so the
     // cap was undefined and a 42k result went inline whole. This pins the fix.
     const h = await startSpillTurn({
@@ -190,11 +200,11 @@ describe('tool-result spill completion (issue #89)', () => {
     try {
       const stored = await waitForStoredToolResult(h.framework);
       assert.ok(stored, 'tool result should be stored');
-      assert.ok(stored.content.length < 6_000, `inline copy must be near the 5000 cap, got ${stored.content.length}`);
-      assert.match(stored.content, /showing 5000 of \d+ chars; full content: workspace file files\/tool-results\//);
+      assert.ok(stored.content.length < CAPPED, `inline copy must be near the cap, got ${stored.content.length}`);
+      assert.match(stored.content, /showing 24000 of \d+ chars; full content: workspace file files\/tool-results\//);
       const prov = capProvenance(h.framework);
       assert.strictEqual(prov.tool_result_inline_max_chars, null);
-      assert.strictEqual(prov.tool_result_inline_max_chars_effective, 5000);
+      assert.strictEqual(prov.tool_result_inline_max_chars_effective, 24000);
       assert.strictEqual(prov.tool_result_inline_max_chars_source, 'default');
       // Full content is recoverable from the spill file.
       const refMatch = stored.content.match(/workspace file (files\/tool-results\/\S+\.txt)/);
@@ -263,7 +273,7 @@ describe('tool-result spill completion (issue #89)', () => {
       const stored = await waitForStoredToolResult(h.framework);
       assert.ok(stored, 'error tool result should be stored');
       assert.strictEqual(stored.isError, true);
-      assert.ok(stored.content.length < 6_000, `inline error copy must be capped, got ${stored.content.length}`);
+      assert.ok(stored.content.length < CAPPED, `inline error copy must be capped, got ${stored.content.length}`);
       assert.match(stored.content, /full content: workspace file files\/tool-results\//);
       // Wire copy byte-matches the stored copy.
       const wire = h.membrane.lastStream?.receivedToolResults[0] as
@@ -305,7 +315,7 @@ describe('tool-result spill completion (issue #89)', () => {
     try {
       const stored = await waitForStoredToolResult(h.framework);
       assert.ok(stored, 'tool result should be stored');
-      assert.ok(stored.content.length < 6_000, 'inline copy must be capped');
+      assert.ok(stored.content.length < CAPPED, 'inline copy must be capped');
       assert.match(stored.content, /no writable workspace, full content not retained/);
       assert.doesNotMatch(stored.content, /workspace file/);
     } finally {
@@ -356,7 +366,7 @@ describe('tool-result spill completion (issue #89)', () => {
       assert.strictEqual(image.source?.data, png, 'base64 must be byte-intact');
       const text = blocks.find((b) => b.type === 'text');
       assert.ok(text?.text, 'text block expected');
-      assert.ok(text.text.length < 6_000, 'text block must be capped');
+      assert.ok(text.text.length < CAPPED, 'text block must be capped');
       assert.match(text.text, /full serialized result: workspace file files\/tool-results\//);
     } finally {
       await h.framework.stop();
@@ -397,7 +407,7 @@ describe('tool-result spill completion (issue #89)', () => {
   });
 
   it('clamps the default down to the strategy bound and reports it', async () => {
-    // maxMessageTokens=1000 → strategy bound 4000 < default 5000. This branch
+    // maxMessageTokens=1000 → strategy bound 4000 < default 24000. This branch
     // decides the cap for every resident on a bounded strategy — pin it.
     const h = await startSpillTurn({
       prefix: 'spill-clamp-',


### PR DESCRIPTION
Raises `DEFAULT_TOOL_RESULT_INLINE_MAX_CHARS` from 5000 to 24000, per antra's call in #upkeep.

## Why — production evidence, not taste

**Mica is the first residence to actually run the 5000 default** (restarted 08-06 11:52:55, six minutes after `b4fca7a` landed). In 23 hours she produced **48 spills**, classified by content shape:

| tool | n | MB |
|---|---|---|
| **terminal-sessions `runCommand`** | **34** | 0.46 |
| array results (test output / diff lines) | 5 | 0.04 |
| eidoverse world observation | 4 | 0.05 |
| portal `fetch_history` | 2 | 0.18 |
| MCPL channel list/reconcile | 2 | 0.13 |
| grep over her own `tool-results/` | 1 | 0.02 |

Those 34 are ordinary source review — `git diff`, test runs, `sed -n '450,590p'` and `nl -ba …` excerpts. A 140-line source excerpt is 5–15 kB, so it clears 5000 as a matter of course. **A 5000-char cap turns nearly every file read into a spill round-trip for a resident doing code work.**

Mica's own measurement on that corpus picked the number: **20000 keeps 76% inline, 24000 keeps 88%, 32000 only reaches 90%.** 24000 is the elbow. Genuinely large payloads — full channel histories, registry dumps, broad greps — still spill, which is the point.

## What does *not* change

The mechanism is untouched: spill target and naming, provenance quartet, the #94 hard clamp to the strategy bound, and the explicit no-writable-workspace fallback. Residences (`FrameworkConfig.toolResultInlineMaxChars`) and residents (`agent_settings tool_result_inline_max_chars`) can still override in either direction.

Worth stating plainly: this **weakens** the #89 protection by ~5×. The original bug was a 42k blob going inline whole; 24000 still bounds that, and 42k remains the canonical test fixture. But a residence that wants the tighter old value should set it explicitly.

## Test-quality fix included

Three spill tests asserted `stored.content.length < 6_000` — magic numbers derived from the 5000 era that **silently pinned the old default**. They only ever meant "something capped this payload", but they failed on the raise. Replaced with a `CAPPED` constant derived from `DEFAULT_TOOL_RESULT_INLINE_MAX_CHARS`, so the next change to the default doesn't have to chase them.

## Verification

- `tsc --noEmit` clean; `npm run build` clean.
- Spill suite **12/12**.
- Full suite (`npm test`, the real `dist/test/*.js` path): **542 tests / 540 pass / 1 fail / 1 skipped**.
- The single failure is `startup globally gates channels/incoming with heartbeat-first config` in `mcpl-awareness-barrier` — the **known af#80 full-suite-load flake**. Verified: that suite passes **25/25 in isolation**, and nothing in this change touches MCPL startup choreography.
- Per **af#96** (nondeterministic collection), I confirmed the spill suite actually *executed inside* the full run rather than inferring it from the total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)