### PR TITLE
gate: intuitive wake-rule composition (closes #105)

### DIFF
--- a/src/framework.ts
+++ b/src/framework.ts
@@ -329,7 +329,7 @@ function validateUtilityArgs(
 }
 import { CheckpointManager } from './mcpl/checkpoint-manager.js';
 import { isToolAllowed } from './mcpl/tool-policy.js';
-import { EventGate } from './gate/event-gate.js';
+import { EventGate, formatShadowWarning } from './gate/event-gate.js';
 import { UsageTracker, type PersistedUsageState } from './usage/usage-tracker.js';
 import type { SessionUsageSnapshot, UsageUpdatedEvent } from './usage/types.js';
 import type { McplServerConnection } from './mcpl/server-connection.js';
@@ -1968,12 +1968,14 @@ export class AgentFramework {
   /**
    * Add or replace (upsert) a gate policy at runtime. Validated and persisted
    * to gate.json; hot-applied in memory. Throws if no gate is configured or the
-   * policy is invalid. `position: 'prepend'` puts a wake rule ahead of broad
-   * defer/debounce rules (first match wins).
+   * policy is invalid. Placement: `'prepend'` puts a rule ahead of EVERYTHING
+   * (including addressed-message wake rules — see EventGate.lintShadows);
+   * `{before: name}` / `{after: name}` anchor it against a specific rule,
+   * which is usually what a sampler or debounce actually wants.
    */
   addGatePolicy(
     rawPolicy: unknown,
-    options?: { position?: 'append' | 'prepend' },
+    options?: { position?: 'append' | 'prepend' | { before: string } | { after: string } },
   ): import('./gate/types.js').GatePolicy {
     if (!this.eventGate) {
       throw new Error('No EventGate configured (FrameworkConfig.gate is unset).');
@@ -2350,9 +2352,17 @@ export class AgentFramework {
       description:
         'Add or replace a wake rule (a gate.json policy) at runtime — no need to ' +
         'hand-edit the file. The rule is validated and hot-applied immediately. ' +
-        'A rule with the same `name` replaces the existing one in place. Use ' +
-        '`position: "prepend"` to put a wake rule ahead of broad defer/debounce ' +
-        'rules (first match wins). Two common shapes:\n' +
+        'A rule with the same `name` replaces the existing one in place (add a ' +
+        'position to move it). ⚠️ ORDERING IS SEMANTICS: first match wins, and a ' +
+        'matched rule CONSUMES the event — a broad rule placed early makes every ' +
+        'later rule unreachable for its scope, including your addressed-message ' +
+        '(DM/mention) wake rules. Prefer `insertBefore`/`insertAfter` to place a ' +
+        'rule relative to a specific existing rule; use `position: "prepend"` only ' +
+        'when the rule really must beat EVERYTHING. For "additionally wake me ' +
+        'every Nth event / at most N per hour" governors, set `passthrough: true` ' +
+        'so non-firing matches fall through to your normal rules instead of ' +
+        'swallowing them. The result includes a before/after probe table and any ' +
+        'shadow warnings — READ THEM before ending the turn. Two common shapes:\n' +
         '• Watch a FILE/workspace path: match on `mount` + `pathGlob`, e.g. ' +
         '`{ name: "watch-notes", match: { scope: ["workspace:modified"], mount: "project", pathGlob: "notes/*.md" }, behavior: "always" }`.\n' +
         '• Watch a CHANNEL: match on `source` + `channel` (and/or `tagsAny: ["chat:ambient"]`), ' +
@@ -2420,7 +2430,30 @@ export class AgentFramework {
           position: {
             type: 'string',
             enum: ['append', 'prepend'],
-            description: 'Where to insert a NEW rule (ignored when replacing by name). Default "append".',
+            description:
+              'Coarse placement. "append" (default) adds at the end; "prepend" puts the rule ' +
+              'ahead of EVERYTHING — including addressed-message wake rules — so prefer ' +
+              'insertBefore/insertAfter unless the rule really must beat every other rule. ' +
+              'When replacing an existing name, giving any placement MOVES the rule there; ' +
+              'omit all placement fields to update it in place.',
+          },
+          insertBefore: {
+            type: 'string',
+            description:
+              'Insert the rule immediately BEFORE the named existing rule (error if absent). ' +
+              'The safe way to order against a specific catch-all, e.g. insertBefore: "discord-ambient".',
+          },
+          insertAfter: {
+            type: 'string',
+            description: 'Insert the rule immediately AFTER the named existing rule (error if absent).',
+          },
+          passthrough: {
+            type: 'boolean',
+            description:
+              'Observer semantics for rateLimit/passiveSample rules: when the rule matches but ' +
+              'does not fire (below N, bucket empty), the event FALLS THROUGH to later rules ' +
+              'instead of being consumed. Use for "additionally wake me every Nth event" ' +
+              'governors so they never swallow DM/mention wakes.',
           },
           resets: {
             type: 'array',
@@ -9960,6 +9993,7 @@ export class AgentFramework {
       // range/shape checks.
       const input = (call.input ?? {}) as {
         name?: unknown; match?: unknown; resets?: unknown; position?: unknown;
+        insertBefore?: unknown; insertAfter?: unknown; passthrough?: unknown;
         behavior?: unknown; debounceMs?: unknown; rateLimit?: unknown; passiveSample?: unknown;
       };
       const behaviorSources = [
@@ -9990,17 +10024,72 @@ export class AgentFramework {
         : input.passiveSample !== undefined ? { passive_sample: input.passiveSample }
         : input.behavior;
 
-      const position = input.position === 'prepend' ? 'prepend' : 'append';
+      // Placement: at most one of position / insertBefore / insertAfter.
+      // With none given, a replaced rule stays where it was and a new rule
+      // appends (addPolicy's contract).
+      const placementSources = [
+        input.position !== undefined ? 'position' : null,
+        input.insertBefore !== undefined ? 'insertBefore' : null,
+        input.insertAfter !== undefined ? 'insertAfter' : null,
+      ].filter((s): s is string => s !== null);
+      if (placementSources.length > 1) {
+        finish({
+          success: false,
+          error: `wake_add_rule: give at most one placement, got [${placementSources.join(', ')}].`,
+          isError: true,
+        });
+        return;
+      }
+      let position: 'append' | 'prepend' | { before: string } | { after: string } | undefined;
+      if (typeof input.insertBefore === 'string' && input.insertBefore) {
+        position = { before: input.insertBefore };
+      } else if (typeof input.insertAfter === 'string' && input.insertAfter) {
+        position = { after: input.insertAfter };
+      } else if (input.position === 'prepend' || input.position === 'append') {
+        position = input.position;
+      }
+
       const rawPolicy = {
         name: input.name,
         match: input.match ?? {},
         behavior,
+        ...(input.passthrough !== undefined ? { passthrough: input.passthrough } : {}),
         ...(input.resets !== undefined ? { resets: input.resets } : {}),
       };
-      const policy = this.addGatePolicy(rawPolicy, { position });
+
+      // Before/after probe table + shadow lint: the moment a rule changes the
+      // evaluation order is the moment its real semantics must be legible
+      // (af#105 — a prepended catch-all sampler silently disabled the
+      // addressed-message wakes for 12h before anyone could see why).
+      const before = new Map(
+        this.eventGate!.probeTable().map((r) => [r.probe, r]),
+      );
+      const policy = this.addGatePolicy(rawPolicy, position ? { position } : undefined);
+      const after = this.eventGate!.probeTable();
+      const probes = after.map((r) => {
+        const prev = before.get(r.probe);
+        const changed = !!prev && (prev.policy !== r.policy || prev.wouldWake !== r.wouldWake);
+        return {
+          probe: r.probe,
+          rule: r.policy ?? '(default)',
+          behavior: r.behavior,
+          wouldWake: r.wouldWake,
+          ...(changed ? { changed: true, was: `${prev!.policy ?? '(default)'} (wouldWake=${prev!.wouldWake})` } : {}),
+        };
+      });
+      const shadowWarnings = this.eventGate!.lintShadows()
+        .map((w) => formatShadowWarning(w));
       finish({
         success: true,
-        data: { added: policy.name, policies: this.getGatePolicyNames() },
+        data: {
+          added: policy.name,
+          policies: this.getGatePolicyNames(),
+          ...(shadowWarnings.length > 0 ? { shadowWarnings } : {}),
+          probes,
+          ...(probes.some((p) => 'changed' in p)
+            ? {}
+            : { note: 'No canonical probe changed its winning rule — the new rule affects none of the common chat/heartbeat shapes, or only channel/path-specific events the probes do not model.' }),
+        },
       });
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/src/gate/event-gate.ts
+++ b/src/gate/event-gate.ts
@@ -25,6 +25,8 @@ import type {
   GateEventInfo,
   GatePolicyStats,
   GateStatus,
+  ShadowWarning,
+  GateProbeRow,
 } from './types.js';
 
 // Re-export types consumers need
@@ -310,9 +312,135 @@ function validatePolicy(raw: unknown): GatePolicy {
     if (names.length > 0) resets = names;
   }
 
+  // Validate passthrough — only meaningful on the counting behaviors, where
+  // "matched but didn't fire" is a distinct outcome that can fall through.
+  // On always/defer/skip/debounce the flag would be a no-op at best and a
+  // misleading promise at worst, so reject it loudly instead of ignoring it.
+  let passthrough: boolean | undefined;
+  if (obj.passthrough !== undefined) {
+    if (typeof obj.passthrough !== 'boolean') {
+      throw new Error(`Policy "${obj.name}": passthrough must be a boolean`);
+    }
+    if (obj.passthrough) {
+      const counting = typeof behavior === 'object'
+        && ('rate_limit' in behavior || 'passive_sample' in behavior);
+      if (!counting) {
+        throw new Error(
+          `Policy "${obj.name}": passthrough is only valid with rate_limit or `
+          + `passive_sample behaviors — for "${formatBehavior(behavior)}" there is `
+          + 'no non-firing match to fall through on',
+        );
+      }
+      passthrough = true;
+    }
+  }
+
   const policy: GatePolicy = { name: obj.name, match, behavior };
   if (resets) policy.resets = resets;
+  if (passthrough) policy.passthrough = passthrough;
   return policy;
+}
+
+// ---------------------------------------------------------------------------
+// Shadow lint — prove (conservatively) when rule ordering makes a rule dead
+// ---------------------------------------------------------------------------
+
+/** Set-inclusion helper for exact-string lists. */
+function subsetOf(a: string[], b: string[]): boolean {
+  return a.every((x) => b.includes(x));
+}
+
+/** A glob field on the EARLIER rule is at least as broad as the LATER rule's
+ *  when it's absent, the universal "*", or literally identical. Anything
+ *  cleverer (real glob subsumption) is out of conservative scope. */
+function globAtLeastAsBroad(earlier: string | undefined, later: string | undefined): boolean {
+  if (earlier === undefined || earlier === '*') return true;
+  return earlier === later;
+}
+
+/**
+ * Event types for which `earlier` provably matches EVERY event that `later`
+ * would match — i.e. the types for which `later` is unreachable when
+ * `earlier` sits before it and consumes its matches. Returns null when
+ * subsumption can't be proven (which is not proof of safety — the lint is
+ * deliberately one-sided so every warning it emits is true).
+ */
+function subsumedEventTypes(earlier: GatePolicy, later: GatePolicy): string[] | 'all' | null {
+  const e = earlier.match;
+  const l = later.match;
+
+  // Scope: which of `later`'s event types does `earlier` cover?
+  let covered: string[] | 'all';
+  if (!e.scope || e.scope.length === 0) {
+    covered = l.scope && l.scope.length > 0 ? l.scope : 'all';
+  } else if (!l.scope || l.scope.length === 0) {
+    // `later` matches all types; `earlier` only consumes its own scope, so
+    // the shadow is partial — exactly those types.
+    covered = e.scope;
+  } else {
+    const overlap = l.scope.filter((t) => e.scope!.includes(t));
+    if (overlap.length === 0) return null;
+    covered = overlap;
+  }
+
+  // Every remaining discriminator on `earlier` must be at least as broad as
+  // `later`'s, otherwise some `later` events slip past `earlier`.
+  if (!globAtLeastAsBroad(e.source, l.source)) return null;
+  if (!globAtLeastAsBroad(e.channel, l.channel)) return null;
+  if (!globAtLeastAsBroad(e.mount, l.mount)) return null;
+  if (!globAtLeastAsBroad(e.pathGlob, l.pathGlob)) return null;
+
+  if (e.filter) {
+    if (!l.filter || e.filter.type !== l.filter.type || e.filter.pattern !== l.filter.pattern) {
+      return null;
+    }
+  }
+
+  // metadataTrue / tagsAny are OR-lists: earlier subsumes when later's list
+  // is a subset of earlier's (any event satisfying later then satisfies
+  // earlier too). tagsAll / tagsNone are AND/NOT constraints: earlier
+  // subsumes when its constraints are a subset of later's.
+  if (e.metadataTrue && e.metadataTrue.length > 0) {
+    if (!l.metadataTrue || !subsetOf(l.metadataTrue, e.metadataTrue)) return null;
+  }
+  if (e.tagsAny && e.tagsAny.length > 0) {
+    if (!l.tagsAny || !subsetOf(l.tagsAny, e.tagsAny)) return null;
+  }
+  if (e.tagsAll && !subsetOf(e.tagsAll, l.tagsAll ?? [])) return null;
+  if (e.tagsNone && !subsetOf(e.tagsNone, l.tagsNone ?? [])) return null;
+
+  return covered;
+}
+
+/**
+ * Find rules made unreachable by earlier, broader rules (first match wins).
+ * The 2026-08-08 Mythos incident is the canonical catch: a prepended
+ * `{scope:[mcpl:channel-incoming]}` sampler silently made the
+ * direct-address and mention rules dead for the whole incoming lane.
+ * `passthrough` observers shadow nothing — non-firing matches fall through.
+ */
+export function findShadowedPolicies(policies: GatePolicy[]): ShadowWarning[] {
+  const out: ShadowWarning[] = [];
+  for (let i = 0; i < policies.length; i++) {
+    const earlier = policies[i];
+    if (earlier.passthrough) continue;
+    for (let j = i + 1; j < policies.length; j++) {
+      const covered = subsumedEventTypes(earlier, policies[j]);
+      if (covered) {
+        out.push({ earlier: earlier.name, later: policies[j].name, eventTypes: covered });
+      }
+    }
+  }
+  return out;
+}
+
+/** Human-readable one-liner for a ShadowWarning, used in tool results,
+ *  traces, and gate_status alike so the same hazard reads the same way
+ *  everywhere. */
+export function formatShadowWarning(w: ShadowWarning): string {
+  const types = w.eventTypes === 'all' ? 'ALL event types' : w.eventTypes.join(', ');
+  return `rule "${w.earlier}" makes "${w.later}" unreachable for ${types} `
+    + `(first match wins — every event "${w.later}" would match is consumed by "${w.earlier}" first)`;
 }
 
 // ---------------------------------------------------------------------------
@@ -348,6 +476,11 @@ export class EventGate {
 
   // Per-policy stats
   private stats = new Map<string, PolicyStats>();
+
+  // Shadow-lint cache (see refreshShadowWarnings) — recomputed on every
+  // config change, fingerprinted so an unchanged hazard set doesn't re-trace.
+  private shadowWarningsCache: ShadowWarning[] = [];
+  private shadowWarningsFingerprint = '[]';
 
   // Observability counters for events that didn't match any policy
   private totalEvaluations = 0;
@@ -455,6 +588,7 @@ export class EventGate {
     // Load config
     this.config = this.loadConfig() ?? opts.initialConfig ?? { ...DEFAULT_CONFIG };
     this.compiledPolicies = this.compilePolicies(this.config);
+    this.refreshShadowWarnings('startup');
 
     // Programmable gate: an optional agent-authored `gate.js` next to gate.json.
     // Absent ⇒ inactive (zero overhead beyond a throttled stat check).
@@ -568,6 +702,7 @@ export class EventGate {
       this.config = newConfig;
       this.compiledPolicies = this.compilePolicies(newConfig);
       this.lastReloadTimestamp = now;
+      this.refreshShadowWarnings('reload');
 
       this.emitTrace({
         type: 'gate:config-reloaded',
@@ -598,23 +733,46 @@ export class EventGate {
    * without waiting for the throttled mtime reload.
    *
    * The freshest on-disk config is re-read first, so a concurrent operator edit
-   * isn't clobbered. A policy with the same `name` is replaced IN PLACE (order
-   * preserved); otherwise it is appended, or prepended when `position:'prepend'`
-   * — first match wins, so a wake rule that must beat a broad defer/debounce
-   * belongs at the front.
+   * isn't clobbered. A policy with the same `name` is replaced IN PLACE when no
+   * `position` is given (order preserved); WITH a `position` it is moved there
+   * — so re-issuing a rule is also how you reposition it. New policies append
+   * by default; `'prepend'` puts one at the very front (ahead of EVERYTHING,
+   * including addressed-message wake rules — see the shadow lint), and the
+   * anchored forms `{before: name}` / `{after: name}` insert relative to an
+   * existing rule, which is almost always the safer way to order a sampler
+   * or debounce against a specific catch-all.
    */
-  addPolicy(rawPolicy: unknown, options?: { position?: 'append' | 'prepend' }): GatePolicy {
+  addPolicy(
+    rawPolicy: unknown,
+    options?: { position?: 'append' | 'prepend' | { before: string } | { after: string } },
+  ): GatePolicy {
     const policy = validatePolicy(rawPolicy);
     const current = this.loadConfig() ?? this.config;
     const policies = [...current.policies];
     const idx = policies.findIndex((p) => p.name === policy.name);
-    if (idx >= 0) {
-      policies[idx] = policy;
-    } else if (options?.position === 'prepend') {
-      policies.unshift(policy);
+    const position = options?.position;
+
+    if (idx >= 0 && position === undefined) {
+      policies[idx] = policy; // replace in place, order preserved
     } else {
-      policies.push(policy);
+      if (idx >= 0) policies.splice(idx, 1); // repositioning a known rule
+      if (position === 'prepend') {
+        policies.unshift(policy);
+      } else if (position !== undefined && typeof position === 'object') {
+        const anchorName = 'before' in position ? position.before : position.after;
+        const anchorIdx = policies.findIndex((p) => p.name === anchorName);
+        if (anchorIdx < 0) {
+          throw new Error(
+            `addPolicy: no policy named "${anchorName}" to anchor on — `
+            + `have: [${policies.map((p) => p.name).join(', ')}]`,
+          );
+        }
+        policies.splice('before' in position ? anchorIdx : anchorIdx + 1, 0, policy);
+      } else {
+        policies.push(policy);
+      }
     }
+
     this.writeConfig({ ...current, policies });
     this.emitTrace({
       type: 'gate:policy-added',
@@ -672,6 +830,7 @@ export class EventGate {
     writeFileSync(this.configPath, JSON.stringify(config, null, 2) + '\n');
     this.config = config;
     this.compiledPolicies = this.compilePolicies(config);
+    this.refreshShadowWarnings('policy-mutation');
     this.configSource = 'file';
     this.configErrors = [];
     this.lastReloadTimestamp = Date.now();
@@ -683,17 +842,9 @@ export class EventGate {
   }
 
   // =========================================================================
-  // Policy matching — first match wins
+  // Policy matching — first match wins (passthrough observers excepted; the
+  // match/decide loop lives inline in evaluate() and probe())
   // =========================================================================
-
-  private matchPolicy(info: GateEventInfo): GatePolicy | null {
-    for (const compiled of this.compiledPolicies) {
-      if (this.compiledMatches(compiled, info)) {
-        return compiled.policy;
-      }
-    }
-    return null;
-  }
 
   private compiledMatches(compiled: CompiledPolicy, info: GateEventInfo): boolean {
     const match = compiled.policy.match;
@@ -804,13 +955,32 @@ export class EventGate {
     // Programmable gate (gate.js) takes precedence when present and returns a
     // behavior; null/undefined (inactive, error, or a deliberate pass) falls
     // through to the declarative gate.json policies below.
+    //
+    // Declarative policies: first match wins — EXCEPT `passthrough` observers,
+    // which consume the event only when their counting behavior actually
+    // fires. A passthrough policy that matched-but-didn't-fire records its
+    // count and evaluation continues, so a density sampler placed early can
+    // no longer swallow the addressed-message rules behind it.
     const scripted = this.gateScript.evaluate(info);
-    const policy: GatePolicy | null =
-      scripted != null ? { name: 'gate.js', match: {}, behavior: scripted } : this.matchPolicy(info);
-    const decision = this.computeDecision(policy, info);
+    let decision: GateDecision | null = null;
+    const observed: string[] = [];
+    if (scripted != null) {
+      decision = this.computeDecision({ name: 'gate.js', match: {}, behavior: scripted }, info);
+    } else {
+      for (const compiled of this.compiledPolicies) {
+        if (!this.compiledMatches(compiled, info)) continue;
+        const candidate = this.computeDecision(compiled.policy, info);
+        if (candidate.trigger || !compiled.policy.passthrough) {
+          decision = candidate;
+          break;
+        }
+        observed.push(compiled.policy.name); // counted, didn't fire, fell through
+      }
+    }
 
     this.totalEvaluations++;
-    if (!policy) {
+    if (!decision) {
+      decision = this.computeDecision(null, info);
       const bucket = this.defaultByEventType.get(info.eventType)
         ?? { triggered: 0, skipped: 0 };
       if (decision.trigger) {
@@ -822,6 +992,7 @@ export class EventGate {
       }
       this.defaultByEventType.set(info.eventType, bucket);
     }
+    if (observed.length > 0) decision.observed = observed;
 
     this.emitTrace({
       type: 'gate:decision',
@@ -831,6 +1002,7 @@ export class EventGate {
       matchedPolicy: decision.policyName,
       trigger: decision.trigger,
       behavior: formatBehavior(decision.behavior),
+      ...(observed.length > 0 ? { observed } : {}),
       timestamp: this.now(),
     });
 
@@ -1000,6 +1172,164 @@ export class EventGate {
     this.passiveSampleCounters.delete(name);
     this.rateLimitDenied.delete(name);
     this.passiveSampleFires.delete(name);
+  }
+
+  // =========================================================================
+  // Dry-run probes — side-effect-free "what would this event do right now"
+  // =========================================================================
+
+  /**
+   * Non-mutating twin of the behavior decision: would this policy trigger for
+   * this event, given CURRENT counter/bucket state? Reads state, never writes
+   * it — no stats, no traces, no counter increments, no debounce batching.
+   */
+  private wouldTrigger(policy: GatePolicy, info: GateEventInfo): boolean {
+    const b = policy.behavior;
+    if (b === 'always') return true;
+    if (b === 'defer' || b === 'skip') return false;
+    if (typeof b === 'object') {
+      if ('debounce' in b) return false; // batches; never triggers inline
+      if ('rate_limit' in b) {
+        const cfg = b.rate_limit;
+        const key = this.resolveKey(info.metadata, cfg.keyBy);
+        const bucket = this.rateLimitBuckets.get(policy.name)?.get(key);
+        if (!bucket) return true; // fresh bucket starts full
+        let tokens = bucket.tokens;
+        if (tokens < cfg.tokens) {
+          const elapsed = Math.max(0, this.now() - bucket.lastRefill);
+          tokens = Math.min(cfg.tokens, tokens + Math.floor(elapsed / cfg.refillIntervalMs));
+        }
+        return tokens > 0;
+      }
+      if ('passive_sample' in b) {
+        const cfg = b.passive_sample;
+        const key = this.resolveKey(info.metadata, cfg.keyBy);
+        const count = this.passiveSampleCounters.get(policy.name)?.get(key) ?? 0;
+        return count + 1 >= cfg.every;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Evaluate an event against the declarative policy table WITHOUT side
+   * effects: no counters advance, no debounce batches form, no stats or
+   * traces are recorded, and sleep suppression is ignored (a probe asks
+   * about the table, not the moment). gate.js is not consulted — a script
+   * may be stateful, and a probe must never perturb state.
+   */
+  probe(info: GateEventInfo): GateDecision {
+    for (const compiled of this.compiledPolicies) {
+      if (!this.compiledMatches(compiled, info)) continue;
+      const trigger = this.wouldTrigger(compiled.policy, info);
+      if (trigger || !compiled.policy.passthrough) {
+        return { trigger, policyName: compiled.policy.name, behavior: compiled.policy.behavior };
+      }
+    }
+    const trigger = (this.config.default ?? 'always') === 'always';
+    return { trigger, policyName: null, behavior: this.config.default ?? 'always' };
+  }
+
+  /**
+   * Probe a canonical set of synthetic chat/heartbeat events and report which
+   * rule wins each and whether it would wake. Backs the before/after table in
+   * the wake_add_rule result — the point where a rule change's real semantics
+   * must become legible (af#105; the Mythos stand-back-density incident would
+   * have been visible as `dm: discord-direct-address → stand-back-density`).
+   * Probes are representative shapes, not an exhaustive event space — rules
+   * keyed on specific channels/mounts may not match any probe.
+   */
+  probeTable(): GateProbeRow[] {
+    const chat = (
+      label: string,
+      eventType: string,
+      metadata: Record<string, unknown>,
+      tags: string[],
+    ): { label: string; info: GateEventInfo } => ({
+      label,
+      info: {
+        content: `[probe] ${label}`,
+        eventType,
+        serverId: 'discord',
+        channelId: '',
+        metadata: { ...metadata, eventType },
+        tags,
+      },
+    });
+
+    const probes = [
+      chat('dm (open channel)', 'mcpl:channel-incoming', { isDM: true, isMention: true },
+        ['chat:dm', 'chat:private', 'chat:addressed', 'chat:from-human']),
+      chat('dm (closed channel)', 'mcpl:push-event', { isDM: true, isMention: true },
+        ['chat:dm', 'chat:private', 'chat:addressed', 'chat:from-human']),
+      chat('explicit mention (open channel)', 'mcpl:channel-incoming',
+        { isMention: true, isExplicitMention: true },
+        ['chat:mention', 'chat:addressed', 'chat:from-human']),
+      chat('explicit mention (closed channel)', 'mcpl:push-event',
+        { isMention: true, isExplicitMention: true },
+        ['chat:mention', 'chat:addressed', 'chat:from-human']),
+      chat('reply to you', 'mcpl:channel-incoming', { isMention: true, isReplyToBot: true },
+        ['chat:reply', 'chat:addressed', 'chat:from-human']),
+      chat('ambient (human)', 'mcpl:channel-incoming', {},
+        ['chat:ambient', 'chat:from-human']),
+      chat('ambient (bot)', 'mcpl:channel-incoming', { isBot: true },
+        ['chat:ambient', 'chat:from-bot']),
+      {
+        label: 'heartbeat',
+        info: {
+          content: '[probe] heartbeat',
+          eventType: 'mcpl:push-event',
+          serverId: 'heartbeat',
+          channelId: '',
+          metadata: { source: 'heartbeat', eventType: 'mcpl:push-event' },
+        } as GateEventInfo,
+      },
+    ];
+
+    return probes.map(({ label, info }) => {
+      const d = this.probe(info);
+      return {
+        probe: label,
+        eventType: info.eventType,
+        policy: d.policyName,
+        behavior: d.policyName === null
+          ? `default:${formatBehavior(d.behavior)}`
+          : formatBehavior(d.behavior),
+        wouldWake: d.trigger,
+      };
+    });
+  }
+
+  // =========================================================================
+  // Shadow lint surface
+  // =========================================================================
+
+  /** Current shadow-lint findings for the live policy order. Fresh compute —
+   *  cheap (policy lists are tens of entries at most). */
+  lintShadows(): ShadowWarning[] {
+    return findShadowedPolicies(this.config.policies);
+  }
+
+  /**
+   * Recompute shadow warnings and, when the set changed and is non-empty,
+   * emit a `gate:shadow-warnings` trace so the hazard lands in ops
+   * observability at the moment the order changed — not at the next missed
+   * DM. Called from writeConfig and reloadIfChanged.
+   */
+  private refreshShadowWarnings(reason: string): void {
+    const warnings = this.lintShadows();
+    const fingerprint = JSON.stringify(warnings);
+    if (fingerprint === this.shadowWarningsFingerprint) return;
+    this.shadowWarningsFingerprint = fingerprint;
+    this.shadowWarningsCache = warnings;
+    if (warnings.length > 0) {
+      this.emitTrace({
+        type: 'gate:shadow-warnings',
+        reason,
+        warnings: warnings.map(formatShadowWarning),
+        timestamp: this.now(),
+      });
+    }
   }
 
   // =========================================================================
@@ -1436,6 +1766,7 @@ export class EventGate {
       script: this.gateScript.status(),
       policies,
       errors: [...this.configErrors],
+      shadowWarnings: this.shadowWarningsCache.map(formatShadowWarning),
       totalEvaluations: this.totalEvaluations,
       defaultDecisions: {
         triggered: this.defaultTriggered,

--- a/src/gate/types.ts
+++ b/src/gate/types.ts
@@ -118,6 +118,22 @@ export interface GatePolicy {
    * coupling the behaviors to each other in code. Unknown names are ignored.
    */
   resets?: string[];
+  /**
+   * Observer semantics for the counting behaviors (`passive_sample`,
+   * `rate_limit`): when the behavior does NOT fire for a matching event
+   * (sampler below N, bucket empty), evaluation CONTINUES to later policies
+   * instead of consuming the event with trigger=false. When it DOES fire,
+   * it triggers as usual and evaluation stops.
+   *
+   * This is how to express "additionally wake me every Nth event" without
+   * silently swallowing the events in between — a plain (consuming)
+   * `passive_sample` placed early makes every later rule unreachable for
+   * its scope, which is almost never what a density governor intends
+   * (2026-08-08 Mythos stand-back-density incident). Validation rejects
+   * `passthrough` on `always`/`defer`/`skip`/`debounce`, where "didn't
+   * fire" has no meaning distinct from the behavior itself.
+   */
+  passthrough?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -162,6 +178,42 @@ export interface GateDecision {
   policyName: string | null;
   /** The behavior that was applied. */
   behavior: GateBehavior;
+  /**
+   * Names of `passthrough` policies that matched and counted this event but
+   * did not fire, so evaluation continued past them. Absent when none did.
+   */
+  observed?: string[];
+}
+
+/**
+ * A rule-ordering hazard: `earlier` matches (and consumes) every event that
+ * `later` would match, for the listed event types — so `later` can never
+ * fire for them. Produced by the conservative shadow lint; a warning here is
+ * always a true statement about the config, but a config with no warnings is
+ * not guaranteed hazard-free (the lint only proves what it can prove).
+ */
+export interface ShadowWarning {
+  /** Name of the earlier (consuming) policy. */
+  earlier: string;
+  /** Name of the later policy it makes unreachable. */
+  later: string;
+  /** Event types affected — 'all' when both rules are unscoped. */
+  eventTypes: string[] | 'all';
+}
+
+/** One row of the dry-run probe table (see EventGate.probeTable). */
+export interface GateProbeRow {
+  /** Short label for the synthetic event probed (e.g. "dm", "mention"). */
+  probe: string;
+  /** Event type the probe used. */
+  eventType: string;
+  /** Winning policy name, or null when the default applied. */
+  policy: string | null;
+  /** Compact behavior description (formatBehavior output or the default). */
+  behavior: string;
+  /** Whether this event WOULD trigger inference right now. For counting
+   *  behaviors this reflects current counter/bucket state. */
+  wouldWake: boolean;
 }
 
 /** Information about an event being evaluated. */
@@ -211,6 +263,12 @@ export interface GateStatus {
   script: import('./gate-script.js').GateScriptStatus;
   policies: GatePolicyStats[];
   errors: string[];
+  /**
+   * Active shadow-lint findings for the current policy order (see
+   * ShadowWarning). Rendered so an agent inspecting gate_status sees the
+   * same hazards wake_add_rule warns about at install time.
+   */
+  shadowWarnings: string[];
   /** Total events the gate has evaluated since startup. */
   totalEvaluations: number;
   /**

--- a/test/event-gate-passthrough.test.ts
+++ b/test/event-gate-passthrough.test.ts
@@ -1,0 +1,345 @@
+/**
+ * af#105 — intuitive wake-gate composition.
+ *
+ * Covers the four pieces that grew out of the 2026-08-08 Mythos
+ * stand-back-density incident (a prepended catch-all passive_sample silently
+ * made the DM/mention wake rules unreachable for the whole incoming lane):
+ *
+ *   ① `passthrough` observer rules — non-firing counting behaviors fall
+ *     through to later policies instead of consuming the event;
+ *   ② shadow lint — provably-dead rules are reported at config time;
+ *   ③ dry-run probes — side-effect-free "who would win" evaluation;
+ *   ④ anchored positions — addPolicy({before}/{after}) placement.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { EventGate, findShadowedPolicies, formatShadowWarning } from '../src/gate/event-gate.js';
+import type { GateConfig, GateEventInfo, GatePolicy } from '../src/gate/types.js';
+
+const TMP_DIR = join(import.meta.dirname, '../.test-tmp-gate-passthrough');
+
+interface TraceEntry {
+  type: string;
+  [key: string]: unknown;
+}
+
+interface Harness {
+  gate: EventGate;
+  configPath: string;
+  traces: TraceEntry[];
+}
+
+function makeGate(initialConfig: GateConfig): Harness {
+  mkdirSync(TMP_DIR, { recursive: true });
+  const configPath = join(TMP_DIR, `gate-${Math.random().toString(36).slice(2)}.json`);
+  const traces: TraceEntry[] = [];
+  const gate = new EventGate({
+    configPath,
+    initialConfig,
+    emitTrace: (e) => traces.push(e as TraceEntry),
+    addMessage: () => '',
+    requestInference: () => {},
+    getAgentNames: () => ['agent'],
+    now: () => 1_000_000,
+  });
+  return { gate, configPath, traces };
+}
+
+function event(overrides?: Partial<GateEventInfo>): GateEventInfo {
+  return {
+    content: 'test',
+    eventType: 'mcpl:channel-incoming',
+    serverId: 'discord',
+    channelId: 'discord:dm:1',
+    metadata: {},
+    ...overrides,
+  };
+}
+
+/** The Mythos incident's policy shapes, reusable across cases. */
+const SAMPLER: GatePolicy = {
+  name: 'stand-back-density',
+  match: { scope: ['mcpl:channel-incoming'] },
+  behavior: { passive_sample: { every: 3 } },
+};
+const DIRECT_ADDRESS: GatePolicy = {
+  name: 'discord-direct-address',
+  match: { scope: ['mcpl:push-event', 'mcpl:channel-incoming'], metadataTrue: ['isMention', 'isDM'] },
+  behavior: 'always',
+};
+const AMBIENT: GatePolicy = {
+  name: 'discord-ambient',
+  match: { scope: ['mcpl:push-event', 'mcpl:channel-incoming'] },
+  behavior: 'skip',
+};
+
+beforeEach(() => {
+  mkdirSync(TMP_DIR, { recursive: true });
+});
+
+afterEach(() => {
+  if (existsSync(TMP_DIR)) {
+    rmSync(TMP_DIR, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// ① passthrough
+// ---------------------------------------------------------------------------
+
+describe('passthrough observer rules', () => {
+  it('non-firing passthrough sampler falls through to a later always rule (the incident, fixed)', () => {
+    const { gate } = makeGate({
+      policies: [
+        { ...SAMPLER, passthrough: true },
+        DIRECT_ADDRESS,
+        AMBIENT,
+      ],
+      default: 'skip',
+    });
+
+    // A DM: with the consuming sampler this was swallowed 149/150 times.
+    // With passthrough it must reach discord-direct-address every time the
+    // sampler doesn't fire.
+    const d1 = gate.evaluate(event({ metadata: { isDM: true } }));
+    assert.strictEqual(d1.trigger, true);
+    assert.strictEqual(d1.policyName, 'discord-direct-address');
+    assert.deepStrictEqual(d1.observed, ['stand-back-density']);
+  });
+
+  it('passthrough sampler still fires every Nth match, and consumes on fire', () => {
+    const { gate } = makeGate({
+      policies: [{ ...SAMPLER, passthrough: true }, AMBIENT],
+      default: 'skip',
+    });
+
+    // every:3 — two ambient events fall through to the ambient skip, the
+    // third fires the sampler itself.
+    const d1 = gate.evaluate(event());
+    const d2 = gate.evaluate(event());
+    const d3 = gate.evaluate(event());
+    assert.strictEqual(d1.trigger, false);
+    assert.strictEqual(d1.policyName, 'discord-ambient');
+    assert.strictEqual(d2.policyName, 'discord-ambient');
+    assert.strictEqual(d3.trigger, true);
+    assert.strictEqual(d3.policyName, 'stand-back-density');
+    assert.strictEqual(d3.observed, undefined);
+  });
+
+  it('counts every matching event even when a later rule wakes anyway', () => {
+    const { gate } = makeGate({
+      policies: [{ ...SAMPLER, passthrough: true }, DIRECT_ADDRESS, AMBIENT],
+      default: 'skip',
+    });
+
+    // Two DMs (wake via direct-address, sampler counts both), then one
+    // ambient event: sampler is at 2, the ambient event is its 3rd → fires.
+    gate.evaluate(event({ metadata: { isDM: true } }));
+    gate.evaluate(event({ metadata: { isDM: true } }));
+    const d3 = gate.evaluate(event());
+    assert.strictEqual(d3.trigger, true);
+    assert.strictEqual(d3.policyName, 'stand-back-density');
+  });
+
+  it('falls through to the gate default when nothing later matches', () => {
+    const { gate } = makeGate({
+      policies: [{ ...SAMPLER, passthrough: true }],
+      default: 'skip',
+    });
+    const d = gate.evaluate(event());
+    assert.strictEqual(d.trigger, false);
+    assert.strictEqual(d.policyName, null);
+    assert.deepStrictEqual(d.observed, ['stand-back-density']);
+    // The fall-to-default is counted in default decision stats.
+    assert.strictEqual(gate.getStatus().defaultDecisions.skipped, 1);
+  });
+
+  it('rejects passthrough on non-counting behaviors', () => {
+    for (const behavior of ['always', 'skip', { debounce: 1000 }] as const) {
+      const { gate } = makeGate({
+        policies: [{ name: 'p', match: {}, behavior, passthrough: true } as unknown as GatePolicy],
+      });
+      const errors = gate.getStatus().errors;
+      assert.ok(
+        errors.some((e) => /passthrough is only valid/.test(e)),
+        `expected passthrough validation error for ${JSON.stringify(behavior)}, got: ${JSON.stringify(errors)}`,
+      );
+    }
+  });
+
+  it('accepts passthrough on rate_limit and falls through when the bucket is empty', () => {
+    const { gate } = makeGate({
+      policies: [
+        {
+          name: 'burst-governor',
+          match: {},
+          behavior: { rate_limit: { tokens: 1, refillIntervalMs: 60_000 } },
+          passthrough: true,
+        },
+        { name: 'catch-all', match: {}, behavior: 'skip' },
+      ],
+      default: 'always',
+    });
+    const d1 = gate.evaluate(event());
+    assert.strictEqual(d1.trigger, true); // token available → fires
+    const d2 = gate.evaluate(event());
+    assert.strictEqual(d2.trigger, false); // bucket empty → falls through
+    assert.strictEqual(d2.policyName, 'catch-all');
+    assert.deepStrictEqual(d2.observed, ['burst-governor']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ② shadow lint
+// ---------------------------------------------------------------------------
+
+describe('shadow lint', () => {
+  it('flags the incident shape: prepended scope catch-all shadows direct-address for the overlapped scope', () => {
+    const warnings = findShadowedPolicies([SAMPLER, DIRECT_ADDRESS, AMBIENT]);
+    const hit = warnings.find((w) => w.later === 'discord-direct-address');
+    assert.ok(hit, `expected direct-address shadow warning, got ${JSON.stringify(warnings)}`);
+    assert.strictEqual(hit.earlier, 'stand-back-density');
+    assert.deepStrictEqual(hit.eventTypes, ['mcpl:channel-incoming']);
+    assert.match(formatShadowWarning(hit), /unreachable for mcpl:channel-incoming/);
+  });
+
+  it('a passthrough observer shadows nothing', () => {
+    const warnings = findShadowedPolicies([
+      { ...SAMPLER, passthrough: true },
+      DIRECT_ADDRESS,
+      AMBIENT,
+    ]);
+    assert.ok(!warnings.some((w) => w.earlier === 'stand-back-density'));
+  });
+
+  it('does not flag rules the earlier one cannot fully cover', () => {
+    // direct-address has a metadataTrue discriminator ambient lacks: events
+    // with no truthy flags slip past it, so ambient stays reachable.
+    const warnings = findShadowedPolicies([DIRECT_ADDRESS, AMBIENT]);
+    assert.deepStrictEqual(warnings, []);
+  });
+
+  it('subset metadataTrue IS flagged (earlier OR-list covers later)', () => {
+    const warnings = findShadowedPolicies([
+      { name: 'broad', match: { metadataTrue: ['isMention', 'isDM'] }, behavior: 'skip' },
+      { name: 'narrow', match: { metadataTrue: ['isDM'] }, behavior: 'always' },
+    ]);
+    assert.strictEqual(warnings.length, 1);
+    assert.strictEqual(warnings[0].later, 'narrow');
+    assert.strictEqual(warnings[0].eventTypes, 'all');
+  });
+
+  it('surfaces via gate:shadow-warnings trace and getStatus on mutation', () => {
+    const { gate, traces } = makeGate({ policies: [DIRECT_ADDRESS, AMBIENT], default: 'skip' });
+    assert.deepStrictEqual(gate.getStatus().shadowWarnings, []);
+    gate.addPolicy(SAMPLER, { position: 'prepend' });
+    const status = gate.getStatus();
+    assert.ok(
+      status.shadowWarnings.some((w) => /discord-direct-address/.test(w)),
+      `expected shadow warning in status, got ${JSON.stringify(status.shadowWarnings)}`,
+    );
+    assert.ok(traces.some((t) => t.type === 'gate:shadow-warnings'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ③ dry-run probes
+// ---------------------------------------------------------------------------
+
+describe('dry-run probes', () => {
+  it('probe reports the winner without advancing counters', () => {
+    const { gate } = makeGate({ policies: [SAMPLER, DIRECT_ADDRESS], default: 'skip' });
+
+    // Probe the same DM three times — a MUTATING evaluate would fire the
+    // every:3 sampler on the third call; probes must not.
+    for (let i = 0; i < 3; i++) {
+      const p = gate.probe(event({ metadata: { isDM: true } }));
+      assert.strictEqual(p.policyName, 'stand-back-density');
+      assert.strictEqual(p.trigger, false);
+    }
+    // Real evaluation still starts from a cold counter.
+    const d = gate.evaluate(event({ metadata: { isDM: true } }));
+    assert.strictEqual(d.trigger, false);
+  });
+
+  it('probe honors passthrough fall-through', () => {
+    const { gate } = makeGate({
+      policies: [{ ...SAMPLER, passthrough: true }, DIRECT_ADDRESS],
+      default: 'skip',
+    });
+    const p = gate.probe(event({ metadata: { isDM: true } }));
+    assert.strictEqual(p.policyName, 'discord-direct-address');
+    assert.strictEqual(p.trigger, true);
+  });
+
+  it('probeTable makes the incident visible as a changed dm row', () => {
+    const { gate } = makeGate({ policies: [DIRECT_ADDRESS, AMBIENT], default: 'skip' });
+    const before = gate.probeTable();
+    const dmBefore = before.find((r) => r.probe === 'dm (open channel)');
+    assert.ok(dmBefore);
+    assert.strictEqual(dmBefore.policy, 'discord-direct-address');
+    assert.strictEqual(dmBefore.wouldWake, true);
+
+    gate.addPolicy(SAMPLER, { position: 'prepend' });
+    const after = gate.probeTable();
+    const dmAfter = after.find((r) => r.probe === 'dm (open channel)');
+    assert.ok(dmAfter);
+    assert.strictEqual(dmAfter.policy, 'stand-back-density');
+    assert.strictEqual(dmAfter.wouldWake, false);
+    // The closed-channel (push/event) dm row is untouched — exactly the
+    // asymmetry that made the incident look intermittent.
+    const dmPush = after.find((r) => r.probe === 'dm (closed channel)');
+    assert.ok(dmPush);
+    assert.strictEqual(dmPush.policy, 'discord-direct-address');
+    assert.strictEqual(dmPush.wouldWake, true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ④ anchored positions
+// ---------------------------------------------------------------------------
+
+describe('anchored positions', () => {
+  it('inserts before/after a named anchor', () => {
+    const { gate } = makeGate({ policies: [DIRECT_ADDRESS, AMBIENT], default: 'skip' });
+    gate.addPolicy(SAMPLER, { position: { before: 'discord-ambient' } });
+    assert.deepStrictEqual(gate.listPolicyNames(), [
+      'discord-direct-address', 'stand-back-density', 'discord-ambient',
+    ]);
+    gate.addPolicy(
+      { name: 'after-anchor', match: {}, behavior: 'skip' },
+      { position: { after: 'discord-direct-address' } },
+    );
+    assert.deepStrictEqual(gate.listPolicyNames(), [
+      'discord-direct-address', 'after-anchor', 'stand-back-density', 'discord-ambient',
+    ]);
+  });
+
+  it('throws on a missing anchor, naming the available rules', () => {
+    const { gate } = makeGate({ policies: [AMBIENT], default: 'skip' });
+    assert.throws(
+      () => gate.addPolicy(SAMPLER, { position: { before: 'no-such-rule' } }),
+      /no policy named "no-such-rule".*discord-ambient/s,
+    );
+  });
+
+  it('replacement without a position stays in place; with a position it moves', () => {
+    const { gate } = makeGate({
+      policies: [SAMPLER, DIRECT_ADDRESS, AMBIENT],
+      default: 'skip',
+    });
+    // In-place update keeps the (bad) prepended slot.
+    gate.addPolicy({ ...SAMPLER, behavior: { passive_sample: { every: 5 } } });
+    assert.deepStrictEqual(gate.listPolicyNames(), [
+      'stand-back-density', 'discord-direct-address', 'discord-ambient',
+    ]);
+    // Re-issuing WITH an anchor is the repair path for the incident.
+    gate.addPolicy(SAMPLER, { position: { before: 'discord-ambient' } });
+    assert.deepStrictEqual(gate.listPolicyNames(), [
+      'discord-direct-address', 'stand-back-density', 'discord-ambient',
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #105. Implements all four pieces, authorized by antra in #operating_room tonight ("Yes, please implement and deploy") after the Mythos stand-back-density incident.

## What changed

**① `passthrough: true` observer rules** — on the counting behaviors (`passive_sample`, `rate_limit`): a matched rule that doesn't fire counts the event and evaluation continues to later policies; when it fires it consumes as usual. `evaluate()` now runs an inline match/decide loop (first terminal match wins; passthrough non-fires accumulate in `decision.observed` and the `gate:decision` trace). Validation rejects the flag on `always`/`defer`/`skip`/`debounce`.

**② Shadow lint** — `findShadowedPolicies()` does conservative per-event-type subsumption over the match language (scope overlap, glob equal-or-absent-or-`*`, OR-list subset for `metadataTrue`/`tagsAny`, constraint subset for `tagsAll`/`tagsNone`, identical filter). Every warning is a provably true "rule X makes rule Y unreachable for <event types>"; no warning ≠ proven safe. Surfaced in the `wake_add_rule` result, as a `gate:shadow-warnings` trace on any config change (startup/reload/mutation, fingerprinted so unchanged sets don't re-trace), and in `gate_status`.

**③ Dry-run probes** — `EventGate.probe()` / `probeTable()`: side-effect-free evaluation (no counter/bucket mutation, no stats/traces, no debounce batching; sleep and gate.js deliberately ignored). `wake_add_rule` returns a before/after winners table over canonical shapes (dm open/closed, mention open/closed, reply, ambient human/bot, heartbeat) with changed rows flagged. The incident would have shown `dm (open channel): discord-direct-address → stand-back-density, wouldWake false` at install time.

**④ Anchored positions** — `addPolicy` accepts `{before: name}` / `{after: name}` (tool fields `insertBefore` / `insertAfter`, mutually exclusive with `position`); a missing anchor throws naming the available rules. Replacement without placement stays in place (unchanged); replacement WITH placement moves the rule — the repair path for a mis-placed rule. Tool description rewritten: ordering-is-semantics warning, steer to anchors/passthrough, prepend demoted to "only when it must beat everything".

## Compat

- `addPolicy`/`addGatePolicy` signatures widen (existing `'append'`/`'prepend'` callers unaffected; ChannelModeModule untouched).
- `GateStatus` gains `shadowWarnings: string[]`; `GateDecision` gains optional `observed`.
- No behavior change for configs without `passthrough` — the evaluate loop is first-match-wins exactly as before.

## Tests

New `test/event-gate-passthrough.test.ts` (17 tests) covering all four pieces, including the exact incident config shape, the passthrough fix, the probe-table diff that makes it visible, and the anchored-reissue repair. All 7 pre-existing gate suites green individually (100 tests); full suite 558 tests, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)