### PR TITLE
Hybrid cross-surface prose routing

### DIFF
--- a/docs/hybrid-prose-routing.md
+++ b/docs/hybrid-prose-routing.md
@@ -1,0 +1,30 @@
+# Hybrid prose routing (`>>>destination`)
+
+Hybrid routing preserves ordinary frozen-locus speech while allowing a resident
+to explicitly publish one or more prose envelopes elsewhere.
+
+```text
+ordinary prose                         # current frozen locus
+>>>#cafe prose for the café            # unique authorized channel by name
+>>> world:commons prose for the world  # canonical channel id
+```
+
+The grammar is permissive about leading whitespace and whitespace after `>>>`.
+Resolution and authority are not permissive: the normal channel registry must
+resolve exactly one authorized destination. Missing, ambiguous, malformed, or
+unauthorized envelopes publish nowhere and create a model-visible bounce.
+
+Two views are intentionally preserved:
+
+- **author/source:** exact assistant text, including `>>>destination`, is stored
+  in Chronicle and remains in recent context;
+- **publication:** recipients receive only the envelope body.
+
+At logical turn end, a `[delivered]` receipt names canonical destinations (or a
+bounce explains failure), so authored intent cannot impersonate delivery.
+Unprefixed prose after a successful envelope follows that explicit destination
+for the remainder of the turn; a fresh turn begins at its ordinary locus.
+
+This is publication routing only. It creates no privacy meaning for `<think>`
+or other prose tags, and grants no channel authority beyond the existing
+registry/resolver.

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -67,7 +67,7 @@ export class Agent {
   /** Refusal auto-rewind policy (see AgentConfig.refusalHandling). */
   readonly refusalHandling: AgentConfig['refusalHandling'];
   /** Prose delivery mode (see AgentConfig.proseRouting). Default 'locus'. */
-  readonly proseRouting: 'locus' | 'explicit';
+  readonly proseRouting: 'locus' | 'explicit' | 'hybrid';
   /** Prompt-cache TTL forwarded to the provider (see AgentConfig.cacheTtl). */
   readonly cacheTtl: NonNullable<AgentConfig['cacheTtl']>;
   /** Emit prompt-cache markers on requests (see AgentConfig.promptCaching). */

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -62,7 +62,7 @@ import { computeGrant, CapabilityGrant, expandAdvertisementShorthand } from './m
 import { maskNegotiatedCapabilities } from './mcpl/capability-mask.js';
 import { HookOrchestrator } from './mcpl/hook-orchestrator.js';
 import { PushHandler, type McplPushEvent } from './mcpl/push-handler.js';
-import { parseProsePrefix } from './mcpl/prose-grammar.js';
+import { parseProsePrefix, parseHybridProsePrefix } from './mcpl/prose-grammar.js';
 import { ProseStreamRouter } from './mcpl/prose-stream-router.js';
 import { InferenceRouter } from './mcpl/inference-router.js';
 import { ChannelRegistry, type ChannelToolOrigin } from './mcpl/channel-registry.js';
@@ -125,6 +125,9 @@ function sniffImageMediaType(data: Buffer): string | undefined {
 const SILENCING_TOOLS = new Set([
   'skip_reply', 'channel_publish', 'send_message', 'reply_message', 'send_dm',
 ]);
+
+/** World-surface publication names that outrank hybrid prose envelopes. */
+const HYBRID_PUBLICATION_TOOLS = new Set(['say', 'whisper']);
 
 /**
  * True when an injected message is real conversational input — something the
@@ -225,10 +228,17 @@ const isAddressedMessage = (
 // envelopes can never disagree on what is a prefix.
 
 /** One-time primer appended when an agent's proseRouting mode changes. */
-function proseModePrimer(mode: 'explicit' | 'locus'): string {
+function proseModePrimer(mode: 'explicit' | 'hybrid' | 'locus'): string {
   if (mode === 'locus') {
     return '[prose-routing] Mode change: your plain text auto-routes to the ' +
       'conversational locus again. `>>` destination prefixes are no longer needed.';
+  }
+  if (mode === 'hybrid') {
+    return '[prose-routing] Hybrid routing enabled: unprefixed text still lands in the ' +
+      'current conversational locus. A leading `>>>destination` envelope instead routes ' +
+      'that prose to one uniquely resolved authorized Discord or Eidoverse channel. The ' +
+      'envelope remains in your memory but recipients see only its body; delivery or failure ' +
+      'is reported back to you.';
   }
   // Deliberately terse: a short event-style notice is classifier-safe from
   // the user role (ablation D, 2026-07-24), while the full grammar as a user
@@ -684,6 +694,8 @@ export class AgentFramework {
   /** Sticky per-TURN delivery target set by the turn's first `>>` prefix.
    *  Cleared at every non-restart turn start; survives context restarts. */
   private proseTargetPins: Map<string, string> = new Map();
+  /** Hybrid router is fail-closed after a malformed/unresolved envelope until a new valid target. */
+  private proseHybridSuppressed: Set<string> = new Set();
   /** Agents whose current turn requested `!` continuation — re-woken when the
    *  turn completes instead of pausing until the next external event. */
   private proseContinuations: Set<string> = new Set();
@@ -5143,6 +5155,97 @@ export class AgentFramework {
     }
   }
 
+  /** Locus-preserving explicit publication. Source remains byte-identical in Chronicle. */
+  private async deliverHybridProse(
+    agent: Agent,
+    rawText: string,
+    locus: string | null,
+    allowLocus: boolean,
+  ): Promise<void> {
+    const lines = rawText.split('\n');
+    const envelopes: string[] = [];
+    let current: string[] = [];
+    for (const line of lines) {
+      if (line.trimStart().startsWith('>>>') && current.length > 0) {
+        envelopes.push(current.join('\n'));
+        current = [];
+      }
+      current.push(line);
+    }
+    if (current.length > 0) envelopes.push(current.join('\n'));
+
+    for (const envelope of envelopes) {
+      if (!envelope.trim()) continue;
+      const normalized = envelope.replace(/^\s+(?=>>>)/, '');
+      const attempted = normalized.startsWith('>>>');
+      const parsed = parseHybridProsePrefix(normalized);
+      if (parsed.continueTurn) this.proseContinuations.add(agent.name);
+      if (parsed.kind === 'private') {
+        this.proseTargetPins.delete(agent.name);
+        this.proseHybridSuppressed.add(agent.name);
+        console.error(`[prose] ${agent.name}: >>>skip_reply — ${parsed.body.length} chars kept in context (not sent)`);
+        continue;
+      }
+      if (parsed.kind === 'target') {
+        const resolved = this.channelRegistry!.resolveProseTarget(parsed.target!);
+        if ('error' in resolved) {
+          this.proseTargetPins.delete(agent.name);
+          this.proseHybridSuppressed.add(agent.name);
+          this.bounceProse(agent, parsed.body, resolved.error, resolved.candidates, '>>>');
+          continue;
+        }
+        let body = parsed.body;
+        const usedClipboard = body.includes('{{unsent}}');
+        if (usedClipboard) body = body.replaceAll('{{unsent}}', this.proseClipboards.get(agent.name) ?? '');
+        this.proseTargetPins.set(agent.name, resolved.channelId);
+        this.proseHybridSuppressed.delete(agent.name);
+        if (!body.trim()) {
+          console.error(`[prose] ${agent.name}: >>>${parsed.target} established target; empty body — nothing sent yet`);
+          continue;
+        }
+        try {
+          const outcome = await this.channelRegistry!.routeSpeech(agent.name, body, resolved.channelId);
+          this.recordProseDelivery(agent.name, outcome);
+          if (outcome?.delivered) {
+            this.proseBounceStreaks.delete(agent.name);
+            if (usedClipboard) this.proseClipboards.delete(agent.name);
+          } else {
+            this.proseTargetPins.delete(agent.name);
+            this.proseHybridSuppressed.add(agent.name);
+            this.bounceProse(agent, parsed.body, `delivery to ${resolved.channelId} was not confirmed`, undefined, '>>>');
+          }
+        } catch (err) {
+          this.proseTargetPins.delete(agent.name);
+          this.proseHybridSuppressed.add(agent.name);
+          this.bounceProse(agent, parsed.body, `delivery to ${resolved.channelId} failed: ${err instanceof Error ? err.message : String(err)}`, undefined, '>>>');
+        }
+        continue;
+      }
+      if (attempted) {
+        this.proseTargetPins.delete(agent.name);
+        this.proseHybridSuppressed.add(agent.name);
+        this.bounceProse(agent, normalized, 'malformed >>> routing envelope: destination is missing', undefined, '>>>');
+        continue;
+      }
+      if (this.proseHybridSuppressed.has(agent.name)) {
+        this.recordProseSuppression(agent.name, 1);
+        continue;
+      }
+      const sticky = this.proseTargetPins.get(agent.name);
+      if (!allowLocus && !sticky) {
+        this.recordProseSuppression(agent.name, 1);
+        continue;
+      }
+      const target = sticky ?? locus;
+      try {
+        const outcome = await this.channelRegistry!.routeSpeech(agent.name, envelope, target);
+        this.recordProseDelivery(agent.name, outcome);
+      } catch (err) {
+        console.error('hybrid locus delivery failed:', err);
+      }
+    }
+  }
+
   private async deliverProseEnvelope(agent: Agent, rawText: string): Promise<void> {
     const name = agent.name;
     const parsed = parseProsePrefix(rawText);
@@ -5202,7 +5305,7 @@ export class AgentFramework {
   /** Cap on consecutive bounce-triggered wakes (notices still append after). */
   private static readonly PROSE_BOUNCE_WAKE_CAP = 2;
 
-  private bounceProse(agent: Agent, text: string, reason: string, candidates?: string[]): void {
+  private bounceProse(agent: Agent, text: string, reason: string, candidates?: string[], prefix: '>>' | '>>>' = '>>'): void {
     const name = agent.name;
     this.proseClipboards.set(name, text);
     const streak = (this.proseBounceStreaks.get(name) ?? 0) + 1;
@@ -5211,8 +5314,9 @@ export class AgentFramework {
     const notice =
       `[prose-routing] Your text (${text.length} chars) was not delivered — ${reason}.${cand} ` +
       'The text is retained; nothing is lost. To deliver it unchanged, reply with a ' +
-      'destination plus the token {{unsent}}, e.g. ">>#channel {{unsent}}" or ">>@person {{unsent}}". ' +
-      '">>skip_reply {{unsent}}" keeps it in context only. The prose_help tool shows the full syntax.';
+      `destination plus the token {{unsent}}, e.g. "${prefix}#channel {{unsent}}" or "${prefix}@person {{unsent}}". ` +
+      `"${prefix}skip_reply {{unsent}}" keeps it in context only.` +
+      (prefix === '>>' ? ' The prose_help tool shows the full syntax.' : '');
     try {
       // Through framework.addMessage, NOT the context manager directly: while
       // the turn is still streaming this defers the notice to the next tool
@@ -5414,6 +5518,8 @@ export class AgentFramework {
       this.turnEngagedChannels.delete(agent.name);
       this.turnProseDeliveries.delete(agent.name);
       this.turnProseSuppressed.delete(agent.name);
+      this.proseHybridSuppressed.delete(agent.name);
+      if (agent.proseRouting === 'hybrid') this.proseTargetPins.delete(agent.name);
       if (agent.proseRouting === 'explicit') {
         // Explicit prose routing: there is no locus. The model names every
         // destination in-band (`>>` prefixes); the only turn state is the
@@ -5682,7 +5788,7 @@ export class AgentFramework {
     });
     const proseStream = this.channelRegistry
       ? new ProseStreamRouter({
-          mode: agent.proseRouting === 'explicit' ? 'explicit' : 'locus',
+          mode: agent.proseRouting === 'explicit' ? 'explicit' : agent.proseRouting === 'hybrid' ? 'hybrid' : 'locus',
           initialTarget: typingChannel,
           resolve: (spec) => {
             const r = this.channelRegistry!.resolveProseTarget(spec);
@@ -5862,14 +5968,28 @@ export class AgentFramework {
               const hasSameRoundPrivateThink =
                 roundToolNames.includes('think') &&
                 requestSnapshot.sameRoundThinkTextPolicy === 'private';
-              if (roundToolNames.some((n) => SILENCING_TOOLS.has(bareToolName(n)))) {
+              if (roundToolNames.some((n) =>
+                SILENCING_TOOLS.has(bareToolName(n)) ||
+                (agent.proseRouting === 'hybrid' && HYBRID_PUBLICATION_TOOLS.has(bareToolName(n)))
+              )) {
                 turnSilenced = true;
               }
               if (roundContent && roundContent.length > 0) {
                 liveProseRouting = true;
                 const roundSegments = splitProseSegments(assistantBlocks);
                 if (roundSegments.length > 0) {
-                  if (agent.proseRouting === 'explicit') {
+                  if (agent.proseRouting === 'hybrid') {
+                    if (turnSilenced) {
+                      this.recordProseSuppression(agent.name, roundSegments.length);
+                    } else if (!hasSameRoundPrivateThink) {
+                      const locus = resolveTurnLocus();
+                      for (const seg of roundSegments) {
+                        turnSpeechChain = turnSpeechChain
+                          .then(() => this.deliverHybridProse(agent, seg, locus, true))
+                          .catch((err) => console.error('mid-turn hybrid prose delivery failed:', err));
+                      }
+                    }
+                  } else if (agent.proseRouting === 'explicit') {
                     // Explicit mode: every segment through the prose gateway.
                     // Silencing does not apply — unprefixed prose bounces and
                     // prefixed prose is deliberate; think-privacy still holds.
@@ -6199,7 +6319,15 @@ export class AgentFramework {
                 .join('\n')
                 .trim();
               if (speechText) {
-                if (agent.proseRouting === 'explicit') {
+                if (agent.proseRouting === 'hybrid') {
+                  const locus = resolveTurnLocus();
+                  console.error(`[prose] ${agent.name}: text-only turn -> hybrid prose gateway`);
+                  try {
+                    await this.deliverHybridProse(agent, speechText, locus, true);
+                  } catch (err) {
+                    console.error('text-only hybrid prose delivery failed:', err);
+                  }
+                } else if (agent.proseRouting === 'explicit') {
                   console.error(`[prose] ${agent.name}: text-only turn -> prose gateway`);
                   try {
                     await this.deliverProse(agent, speechText);
@@ -6246,7 +6374,10 @@ export class AgentFramework {
                 .filter((n): n is string => typeof n === 'string');
               const silenced = liveProseRouting
                 ? turnSilenced
-                : turnSilenced || toolNames.some((n) => SILENCING_TOOLS.has(bareToolName(n)));
+                : turnSilenced || toolNames.some((n) =>
+                  SILENCING_TOOLS.has(bareToolName(n)) ||
+                  (agent.proseRouting === 'hybrid' && HYBRID_PUBLICATION_TOOLS.has(bareToolName(n)))
+                );
 
               const segments = splitProseSegments(liveProseRouting ? terminalContent : response.content);
 
@@ -6255,7 +6386,20 @@ export class AgentFramework {
               // the chain may still be flushing earlier rounds' posts.
               await turnSpeechChain;
 
-              if (agent.proseRouting === 'explicit') {
+              if (agent.proseRouting === 'hybrid') {
+                if (silenced && segments.length > 0) {
+                  this.recordProseSuppression(agent.name, segments.length);
+                } else if (segments.length > 0) {
+                  const locus = resolveTurnLocus();
+                  for (const seg of segments) {
+                    try {
+                      await this.deliverHybridProse(agent, seg, locus, true);
+                    } catch (err) {
+                      console.error('trailing hybrid prose delivery failed:', err);
+                    }
+                  }
+                }
+              } else if (agent.proseRouting === 'explicit') {
                 if (segments.length > 0) {
                   console.error(
                     `[prose] ${agent.name}: tool-call turn [${toolNames.join(', ')}] -> ${segments.length} trailing segment(s) via prose gateway`,

--- a/src/mcpl/prose-grammar.ts
+++ b/src/mcpl/prose-grammar.ts
@@ -38,3 +38,24 @@ export function parseProsePrefix(text: string): ProsePrefix {
   }
   return { kind: 'target', target, continueTurn, body };
 }
+
+/** A real hybrid routing line: exact triple-arrow plus an optional whitespace
+ * run and a non-whitespace target token. */
+export const HYBRID_PROSE_PREFIX_LINE = /^>>>[ \t]*\S/;
+
+/**
+ * Hybrid/locus-preserving routing grammar.
+ *
+ * `>>>#cafe body` and `>>> #cafe body` route this envelope explicitly while
+ * unprefixed prose remains ordinary frozen-locus speech. The authored source
+ * is never rewritten; callers consume this view only for publication.
+ */
+export function parseHybridProsePrefix(text: string): ProsePrefix {
+  const m = /^>>>[ \t]*(\S+)([ \t]+!)?[ \t]*\n?/.exec(text);
+  if (!m) return { kind: 'none', continueTurn: false, body: text };
+  const target = m[1]!;
+  const continueTurn = m[2] !== undefined;
+  const body = text.slice(m[0].length);
+  if (target === 'skip_reply') return { kind: 'private', continueTurn, body };
+  return { kind: 'target', target, continueTurn, body };
+}

--- a/src/mcpl/prose-stream-router.ts
+++ b/src/mcpl/prose-stream-router.ts
@@ -30,7 +30,7 @@ export interface RoutedDelta {
   delta: string;
 }
 
-type State = 'line-start' | 'maybe-prefix' | 'prefix-token' | 'after-token' | 'body';
+type State = 'line-start' | 'hybrid-indent' | 'maybe-prefix' | 'prefix-gap' | 'prefix-token' | 'after-token' | 'body';
 
 export class ProseStreamRouter {
   private target: string | null;
@@ -42,8 +42,8 @@ export class ProseStreamRouter {
 
   constructor(
     private opts: {
-      /** 'explicit' parses `>>` prefixes; 'locus' is pure passthrough. */
-      mode: 'explicit' | 'locus';
+      /** explicit parses `>>`; hybrid parses `>>>` while retaining locus fallback. */
+      mode: 'explicit' | 'hybrid' | 'locus';
       /** Initial destination: the frozen turn locus (locus mode) or null. */
       initialTarget: string | null;
       /** Resolve a `>>spec` to a channelId, or null (unresolved/ambiguous). */
@@ -87,7 +87,12 @@ export class ProseStreamRouter {
    *  no body — dropped, matching delivery which would deliver empty body). */
   finish(): RoutedDelta[] {
     const out: RoutedDelta[] = [];
-    if (this.state === 'maybe-prefix') this.emit(this.held, out); // "" | ">" | ">>"
+    if (this.state === 'hybrid-indent') this.emit(this.held, out);
+    if (this.state === 'maybe-prefix') {
+      const full = this.opts.mode === 'hybrid' ? '>>>' : '>>';
+      const arrows = this.opts.mode === 'hybrid' ? this.held.trimStart() : this.held;
+      if (arrows !== full) this.emit(this.held, out);
+    }
     // prefix-token / after-token at EOF: prefix without body — nothing to emit.
     this.held = '';
     this.state = 'line-start';
@@ -97,7 +102,7 @@ export class ProseStreamRouter {
   private step(ch: string, out: RoutedDelta[]): void {
     switch (this.state) {
       case 'body':
-        if (ch === '\n' && this.opts.mode === 'explicit') {
+        if (ch === '\n' && this.opts.mode !== 'locus') {
           this.emit('\n', out);
           this.state = 'line-start';
         } else {
@@ -106,33 +111,62 @@ export class ProseStreamRouter {
         return;
 
       case 'line-start':
+        if (this.opts.mode === 'hybrid' && (ch === ' ' || ch === '\t')) {
+          this.state = 'hybrid-indent';
+          this.held = ch;
+          return;
+        }
         if (ch === '>') { this.state = 'maybe-prefix'; this.held = '>'; return; }
         this.state = 'body';
         this.step(ch, out);
         return;
 
-      case 'maybe-prefix':
-        if (this.held === '>' && ch === '>') { this.held = '>>'; return; }
-        if (this.held === '>>') {
-          if (ch === '\n' || ch === ' ' || ch === '\t') {
-            // `>> quoted arrow` / bare `>>`: body text, not a prefix.
-            this.emit(this.held, out);
+      case 'hybrid-indent':
+        if (ch === ' ' || ch === '\t') { this.held += ch; return; }
+        if (ch === '>') { this.held += ch; this.state = 'maybe-prefix'; return; }
+        this.emit(this.held, out);
+        this.held = '';
+        this.state = 'body';
+        this.step(ch, out);
+        return;
+
+      case 'maybe-prefix': {
+        const prefix = this.opts.mode === 'hybrid' ? '>>>' : '>>';
+        const arrows = this.opts.mode === 'hybrid' ? this.held.trimStart() : this.held;
+        if (ch === '>' && arrows.length < prefix.length) {
+          this.held += '>';
+          return;
+        }
+        if (arrows === prefix) {
+          if (this.opts.mode === 'hybrid' && (ch === ' ' || ch === '\t')) {
             this.held = '';
-            this.state = 'body';
-            this.step(ch, out);
+            this.state = 'prefix-gap';
             return;
           }
-          // real prefix begins
+          if (ch === '\n' || ch === ' ' || ch === '\t') {
+            if (this.opts.mode === 'explicit') this.emit(this.held, out);
+            this.held = '';
+            this.state = ch === '\n' ? 'line-start' : 'body';
+            if (ch !== '\n') this.step(ch, out);
+            return;
+          }
           this.state = 'prefix-token';
           this.token = ch;
           this.held = '';
           return;
         }
-        // held === '>' and ch !== '>': plain body starting with '>'
         this.emit(this.held, out);
         this.held = '';
         this.state = 'body';
         this.step(ch, out);
+        return;
+      }
+
+      case 'prefix-gap':
+        if (ch === ' ' || ch === '\t') return;
+        if (ch === '\n') { this.target = null; this.state = 'line-start'; return; }
+        this.state = 'prefix-token';
+        this.token = ch;
         return;
 
       case 'prefix-token':

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -177,8 +177,11 @@ export interface AgentConfig {
    *   (`>>#channel` / `>>@person` / `>>skip_reply`); unprefixed prose is never
    *   delivered — it bounces to a clipboard for a cheap prefixed resend.
    *   See docs/explicit-prose-routing.md.
+   * - 'hybrid': unprefixed prose keeps locus routing; `>>>destination` routes
+   *   that publication envelope through the same authorized resolver.
+   *   See docs/hybrid-prose-routing.md.
    */
-  proseRouting?: 'locus' | 'explicit';
+  proseRouting?: 'locus' | 'explicit' | 'hybrid';
 }
 
 /** The intentionally small set of agent settings that may change in-process. */

--- a/test/explicit-prose-routing.test.ts
+++ b/test/explicit-prose-routing.test.ts
@@ -30,6 +30,7 @@ import type { ContentBlock } from '@animalabs/membrane';
 class ToolboxModule implements Module {
   readonly name = 'robot';
   framework: AgentFramework | null = null;
+  calls: ToolCall[] = [];
 
   async start(_ctx: ModuleContext): Promise<void> {}
   async stop(): Promise<void> {}
@@ -39,11 +40,16 @@ class ToolboxModule implements Module {
       name: 'move',
       description: 'Move the robot',
       inputSchema: { type: 'object', properties: { dir: { type: 'string' } } },
+    }, {
+      name: 'say',
+      description: 'Publish speech into the world',
+      inputSchema: { type: 'object', properties: { text: { type: 'string' } }, required: ['text'] },
     }];
   }
 
-  async handleToolCall(_call: ToolCall): Promise<ToolResult> {
-    return { success: true, data: { ok: true } };
+  async handleToolCall(call: ToolCall): Promise<ToolResult> {
+    this.calls.push(call);
+    return { success: true, data: { ok: true, published: call.name.endsWith('--say') } };
   }
 
   async onProcess(event: ProcessEvent, _state: ProcessState): Promise<EventResponse> {
@@ -59,10 +65,12 @@ class ToolboxModule implements Module {
 }
 
 /** Registry stub: two known channels (#alpha guild, laria's DM) + capture. */
-function stubRegistry(framework: AgentFramework) {
+function stubRegistry(framework: AgentFramework, plan: Array<'delivered' | 'false' | 'throw'> = []) {
   const routed: Array<{ text: string; locus: string | null }> = [];
   const known: Record<string, { channelId: string; label: string }> = {
     '#alpha': { channelId: 'chan-alpha', label: '#alpha' },
+    '#cafe': { channelId: 'discord:g:cafe', label: '#cafe' },
+    'world:commons': { channelId: 'world:commons', label: 'world:commons' },
     'alpha': { channelId: 'chan-alpha', label: '#alpha' },
     'chan-alpha': { channelId: 'chan-alpha', label: '#alpha' },
     '@laria': { channelId: 'discord:dm:99', label: 'DM: laria' },
@@ -73,9 +81,11 @@ function stubRegistry(framework: AgentFramework) {
       known[spec] ?? { error: `no channel matches "${spec}"` },
     routeSpeech: async (_agent: string, text: string, locus?: string | null) => {
       routed.push({ text, locus: locus ?? null });
-      return { delivered: true, channelId: locus ?? '' };
+      const behavior = plan.shift() ?? 'delivered';
+      if (behavior === 'throw') throw new Error('synthetic publication failure');
+      return { delivered: behavior === 'delivered', channelId: locus ?? '' };
     },
-    resolveLocus: () => 'should-never-be-used',
+    resolveLocus: () => 'world:commons',
     getDefaultPublishChannel: () => null,
     isChannelOpen: () => true,
     getDescriptor: () => undefined,
@@ -102,7 +112,7 @@ describe('explicit prose routing', () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  async function createFramework(): Promise<AgentFramework> {
+  async function createFramework(mode: 'explicit' | 'hybrid' = 'explicit'): Promise<AgentFramework> {
     const framework = await AgentFramework.create({
       storePath: join(tempDir, 'test.chronicle'),
       membrane: membrane.asMembrane(),
@@ -110,7 +120,7 @@ describe('explicit prose routing', () => {
         name: 'assistant',
         model: 'test-model',
         systemPrompt: 'You are a test agent.',
-        proseRouting: 'explicit',
+        proseRouting: mode,
       }],
       modules: [module],
     });
@@ -302,6 +312,138 @@ describe('explicit prose routing', () => {
       { text: 'part two, just for you\nwith a second line\n>> quoted arrow stays in body', locus: 'discord:dm:99' },
     ], 'two envelopes, two destinations; quoted arrow not split');
 
+    await framework.stop();
+  });
+
+
+  it('hybrid preserves authored >>> envelope, publishes only body cross-surface, and records canonical receipt', async () => {
+    const authored = '>>>#cafe\nA message meant for the café.';
+    membrane.pushResponse(createMockResponse([{ type: 'text', text: authored }] as ContentBlock[]));
+    const framework = await createFramework('hybrid');
+    const routed = stubRegistry(framework);
+    trigger(framework);
+    await framework.runUntilIdle();
+    assert.deepEqual(routed, [{ text: 'A message meant for the café.', locus: 'discord:g:cafe' }]);
+    const cm = framework.getAgent('assistant')!.getContextManager();
+    const texts = cm.getAllMessages().flatMap(m => m.content)
+      .filter(b => b.type === 'text').map(b => (b as { text: string }).text);
+    assert.ok(texts.includes(authored), 'source/author view retains exact envelope');
+    assert.ok(texts.includes('[delivered] plain speech → discord:g:cafe'), 'canonical destination receipt enters context');
+    await framework.stop();
+  });
+
+  it('hybrid leaves unprefixed prose on the frozen locus', async () => {
+    membrane.pushResponse(createMockResponse([{ type: 'text', text: 'Ordinary field speech.' }] as ContentBlock[]));
+    const framework = await createFramework('hybrid');
+    const routed = stubRegistry(framework);
+    trigger(framework);
+    await framework.runUntilIdle();
+    assert.deepEqual(routed, [{ text: 'Ordinary field speech.', locus: 'world:commons' }]);
+    await framework.stop();
+  });
+
+  it('hybrid accepts permissive whitespace but missing targets bounce and publish nowhere', async () => {
+    membrane.pushResponse(createMockResponse([{ type: 'text', text: '  >>>   #missing\nDo not guess.' }] as ContentBlock[]));
+    const framework = await createFramework('hybrid');
+    const routed = stubRegistry(framework);
+    feedTurn(framework, 2, [{ type: 'text', text: '>>>skip_reply {{unsent}}' }] as ContentBlock[]);
+    trigger(framework);
+    await framework.runUntilIdle();
+    assert.deepEqual(routed, []);
+    const cm = framework.getAgent('assistant')!.getContextManager();
+    const texts = cm.getAllMessages().flatMap(m => m.content)
+      .filter(b => b.type === 'text').map(b => (b as { text: string }).text);
+    assert.ok(texts.some(t => t.includes('[prose-routing]') && t.includes('not delivered') && t.includes('>>>#channel {{unsent}}')));
+    await framework.stop();
+  });
+
+
+  it('hybrid keeps an explicit target sticky across tool-round segments in the same turn', async () => {
+    membrane.pushResponse(createMockResponse([
+      { type: 'text', text: '>>>#cafe first segment' },
+      { type: 'tool_use', id: 'hc1', name: 'robot--move', input: { dir: 'north' } },
+    ] as ContentBlock[], 'tool_use'));
+    membrane.pushResponse(createMockResponse([
+      { type: 'text', text: 'second segment, no repeated envelope' },
+    ] as ContentBlock[]));
+    const framework = await createFramework('hybrid');
+    const routed = stubRegistry(framework);
+    trigger(framework);
+    await framework.runUntilIdle();
+    assert.deepEqual(routed, [
+      { text: 'first segment', locus: 'discord:g:cafe' },
+      { text: 'second segment, no repeated envelope', locus: 'discord:g:cafe' },
+    ]);
+    await framework.stop();
+  });
+
+
+  it('hybrid target-only envelope establishes the sticky destination for the next tool-round segment', async () => {
+    membrane.pushResponse(createMockResponse([
+      { type: 'text', text: '>>>#cafe' },
+      { type: 'tool_use', id: 'hc2', name: 'robot--move', input: { dir: 'north' } },
+    ] as ContentBlock[], 'tool_use'));
+    membrane.pushResponse(createMockResponse([{ type: 'text', text: 'body follows' }] as ContentBlock[]));
+    const framework = await createFramework('hybrid');
+    const routed = stubRegistry(framework);
+    trigger(framework);
+    await framework.runUntilIdle();
+    assert.deepEqual(routed, [{ text: 'body follows', locus: 'discord:g:cafe' }]);
+    await framework.stop();
+  });
+
+
+  it('hybrid >>>skip_reply clears a sticky target until a fresh valid envelope', async () => {
+    membrane.pushResponse(createMockResponse([{ type: 'text', text: '>>>#cafe first' }, { type: 'tool_use', id: 'sk1', name: 'robot--move', input: { dir: 'north' } }] as ContentBlock[], 'tool_use'));
+    membrane.pushResponse(createMockResponse([{ type: 'text', text: '>>>skip_reply hidden' }, { type: 'tool_use', id: 'sk2', name: 'robot--move', input: { dir: 'north' } }] as ContentBlock[], 'tool_use'));
+    membrane.pushResponse(createMockResponse([{ type: 'text', text: 'plain text must remain suppressed' }, { type: 'tool_use', id: 'sk3', name: 'robot--move', input: { dir: 'north' } }] as ContentBlock[], 'tool_use'));
+    membrane.pushResponse(createMockResponse([{ type: 'text', text: '>>>world:commons recovered' }] as ContentBlock[]));
+    const framework = await createFramework('hybrid');
+    const routed = stubRegistry(framework);
+    trigger(framework);
+    await framework.runUntilIdle();
+    assert.deepEqual(routed, [{ text: 'first', locus: 'discord:g:cafe' }, { text: 'recovered', locus: 'world:commons' }]);
+    await framework.stop();
+  });
+
+  for (const failure of ['false', 'throw'] as const) {
+    it(`hybrid ${failure} delivery clears sticky authority, suppresses later prose, and a fresh target resumes`, async () => {
+      membrane.pushResponse(createMockResponse([{ type: 'text', text: '>>>#cafe first' }, { type: 'tool_use', id: 'fl1', name: 'robot--move', input: { dir: 'north' } }] as ContentBlock[], 'tool_use'));
+      membrane.pushResponse(createMockResponse([{ type: 'text', text: '>>>#alpha fails' }, { type: 'tool_use', id: 'fl2', name: 'robot--move', input: { dir: 'north' } }] as ContentBlock[], 'tool_use'));
+      membrane.pushResponse(createMockResponse([{ type: 'text', text: 'plain text must remain suppressed' }, { type: 'tool_use', id: 'fl3', name: 'robot--move', input: { dir: 'north' } }] as ContentBlock[], 'tool_use'));
+      membrane.pushResponse(createMockResponse([{ type: 'text', text: '>>>world:commons recovered' }] as ContentBlock[]));
+      const framework = await createFramework('hybrid');
+      const routed = stubRegistry(framework, ['delivered', failure, 'delivered']);
+      feedTurn(framework, 2, [{ type: 'text', text: '>>>skip_reply {{unsent}}' }] as ContentBlock[]);
+      trigger(framework);
+      await framework.runUntilIdle();
+      assert.equal(routed.some(r => r.text.includes('plain text must remain suppressed')), false);
+      assert.deepEqual(routed.filter(r => r.text !== 'fails'), [{ text: 'first', locus: 'discord:g:cafe' }, { text: 'recovered', locus: 'world:commons' }]);
+      const cm = framework.getAgent('assistant')!.getContextManager();
+      const texts = cm.getAllMessages().flatMap(m => m.content).filter(b => b.type === 'text').map(b => (b as { text: string }).text);
+      assert.ok(texts.some(t => t.includes('[prose-routing]') && t.includes('>>>#channel {{unsent}}')));
+      await framework.stop();
+    });
+  }
+
+
+  it('hybrid same-round successful say tool outranks a contradictory prose envelope', async () => {
+    const authored = '>>>#cafe wrong-locus duplicate';
+    membrane.pushResponse(createMockResponse([
+      { type: 'text', text: authored },
+      { type: 'tool_use', id: 'say1', name: 'robot--say', input: { text: 'Hello Sill in the world' } },
+    ] as ContentBlock[], 'tool_use'));
+    membrane.pushResponse(createMockResponse([{ type: 'text', text: 'tool completed' }] as ContentBlock[]));
+    const framework = await createFramework('hybrid');
+    const routed = stubRegistry(framework);
+    trigger(framework);
+    await framework.runUntilIdle();
+    assert.equal(module.calls.filter(c => c.name === 'say' || c.name.endsWith('--say')).length, 1);
+    assert.deepEqual(routed, []);
+    const cm = framework.getAgent('assistant')!.getContextManager();
+    const texts = cm.getAllMessages().flatMap(m => m.content).filter(b => b.type === 'text').map(b => (b as { text: string }).text);
+    assert.ok(texts.includes(authored));
+    assert.ok(texts.some(t => t.startsWith('[delivered] nothing') && t.includes('suppressed')));
     await framework.stop();
   });
 

--- a/test/prose-stream-router.test.ts
+++ b/test/prose-stream-router.test.ts
@@ -97,3 +97,53 @@ test('PROPERTY: char-by-char ≡ one-shot, across every chunk size', () => {
     }
   }
 });
+
+function hybrid(): ProseStreamRouter {
+  return new ProseStreamRouter({
+    mode: 'hybrid',
+    initialTarget: 'world:commons',
+    resolve: (spec) => RESOLVE[spec] ?? (spec === 'world:commons' ? 'world:commons' : null),
+  });
+}
+
+test('hybrid: unprefixed prose stays on the frozen locus', () => {
+  const out = run(hybrid(), 'ordinary world speech');
+  assert.equal(textFor(out, 'world:commons'), 'ordinary world speech');
+});
+
+test('hybrid: triple-arrow target switches publication and consumes the envelope', () => {
+  const out = run(hybrid(), '>>>#general cafe body');
+  assert.equal(textFor(out, 'discord:g:100'), 'cafe body');
+  assert.equal(out.every(d => !d.delta.includes('>>>')), true);
+  assert.equal(textFor(out, 'world:commons'), '');
+});
+
+test('hybrid: permissive whitespace and cross-surface canonical ids', () => {
+  const out = run(hybrid(), '  >>>   #ops spaced\n\t>>> world:commons home');
+  assert.equal(textFor(out, 'discord:g:200'), 'spaced\n');
+  assert.equal(textFor(out, 'world:commons'), 'home');
+});
+
+test('hybrid: double arrows and mid-line triple arrows remain ordinary locus prose', () => {
+  const text = '>>#ops old syntax is prose\nlook >>>#ops quoted';
+  const out = run(hybrid(), text);
+  assert.equal(textFor(out, 'world:commons'), text);
+  assert.equal(textFor(out, 'discord:g:200'), '');
+});
+
+test('hybrid: missing target suppresses that envelope; a later valid envelope resumes', () => {
+  const out = run(hybrid(), '>>>#missing nowhere\nplain remains on failed target\n>>>world:commons restored');
+  assert.equal(out.every(d => !d.delta.includes('nowhere') && !d.delta.includes('plain remains')), true);
+  assert.equal(textFor(out, 'world:commons'), 'restored');
+});
+
+test('hybrid PROPERTY: char-by-char equals one-shot', () => {
+  const text = 'locus first\n>>>#general alpha\nbeta\n>>> #ops delta\n>>>world:commons home';
+  const one = run(hybrid(), text);
+  for (const size of [1, 2, 3, 4, 7, 11]) {
+    const chunked = run(hybrid(), text, size);
+    for (const ch of ['world:commons', ...Object.values(RESOLVE)]) {
+      assert.equal(textFor(chunked, ch), textFor(one, ch));
+    }
+  }
+});


### PR DESCRIPTION
Adds resident-opt-in `proseRouting: hybrid`: unprefixed prose keeps frozen locus; `>>>destination` routes publication through the existing authorized channel registry while preserving the exact source envelope and delivery/bounce receipts. Explicit publication tools outrank contradictory envelopes. Reviewed by Mica at `c83fadb`; canonical Node 574 pass / 0 fail / 1 skip, focused delivery 16/16, stream 16/16.