### PR TITLE
fix(scheduler): preserve budget restart semantics in mixed batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Releases up to and including 0.7.3 predate this file; for their contents see
 
 ## Unreleased
 
+### Fixed
+
+- Mixed wake batches containing a context-budget restart now preserve the
+  restart's same-turn semantics instead of taking the restart-only turn-lock
+  exception and then starting from an older ordinary wake as a fresh turn.
+
 ## 0.10.0 — 2026-08-18
 
 Minor release because it adds a third public prose-routing mode and expands the

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -4876,8 +4876,8 @@ export class AgentFramework {
       // token; the predecessor frame's late finally no-ops via token-match.
       // This mirrors how the restart has always overwritten activeStreams
       // rather than waiting for the old stream's teardown.
-      const isBudgetRestart = requests.some((r) => r.reason === 'context_budget_restart');
-      const turnAlive = !isBudgetRestart && this.activeTurnTokens.has(agentName);
+      const budgetRestart = requests.find((r) => r.reason === 'context_budget_restart');
+      const turnAlive = !budgetRestart && this.activeTurnTokens.has(agentName);
       if (turnAlive || agent.state.status === 'inferring' || agent.state.status === 'streaming' || agent.state.status === 'waiting_for_tools') {
         // Re-queue requests, but warn if they've been pending too long
         const oldest = Math.min(...requests.map(r => r.timestamp));
@@ -4926,7 +4926,12 @@ export class AgentFramework {
       }
 
       // Start streaming inference (non-blocking — driveStream runs in background)
-      const trigger = requests[0];
+      // The request that grants the turn-alive exception must also define the
+      // downstream turn semantics. An ordinary wake can already be pending
+      // when the tool boundary appends a context-budget restart; selecting
+      // requests[0] in that mixed batch bypassed the turn lock because a
+      // restart existed, then treated the continuation as a fresh turn.
+      const trigger = budgetRestart ?? requests[0];
       // Route this turn's auto-published speech to the channel that triggered
       // it (item-3 redux). A batched wake may carry several triggering channels
       // (messages arrived in >1 channel while the agent was busy/idle):

--- a/test/busy-agent-scheduler.test.ts
+++ b/test/busy-agent-scheduler.test.ts
@@ -14,10 +14,12 @@ interface FrameworkHarness {
   activeStreams: Map<string, Promise<void>>;
   activeTurnTokens: Map<string, number>;
   staleWarnAt: Map<string, number>;
+  inferencePolicy: { shouldInfer(): boolean };
   sweepExpiredConversations(): void;
   createFrameworkState(): Record<string, never>;
   emitTrace(): void;
   handleProcessEvent(event: unknown): Promise<void>;
+  startAgentStream(agent: unknown, trigger?: { reason: string; channelId?: string }): Promise<void>;
   processNextEvent(): Promise<void>;
   processInferenceRequests(): Promise<void>;
 }
@@ -39,6 +41,8 @@ function busyAgentHarness(): FrameworkHarness {
   framework.createFrameworkState = () => ({});
   framework.emitTrace = () => {};
   framework.handleProcessEvent = async () => {};
+  framework.inferencePolicy = { shouldInfer: () => true };
+  framework.startAgentStream = async () => {};
   return framework;
 }
 
@@ -88,4 +92,39 @@ test('stale busy-agent diagnostics are throttled with the warning', async () => 
 
   assert.equal(traceCount, 1, 'the stale trace shares the once-per-minute warning throttle');
   assert.equal(framework.pendingRequests.length, 1, 'diagnostics do not consume the deferred wake');
+});
+
+test('a budget restart defines turn semantics when batched behind an ordinary wake', async () => {
+  const framework = busyAgentHarness();
+  const now = Date.now();
+  framework.pendingRequests = [
+    {
+      agentName: 'Sol',
+      reason: 'mcpl:channel-incoming',
+      source: 'discord',
+      timestamp: now - 1,
+    },
+    {
+      agentName: 'Sol',
+      reason: 'context_budget_restart',
+      source: 'framework',
+      timestamp: now,
+    },
+  ];
+  framework.agents = new Map([['Sol', { state: { status: 'idle' } }]]);
+  framework.activeTurnTokens.set('Sol', 1);
+
+  let selectedTrigger: { reason: string; channelId?: string } | undefined;
+  framework.startAgentStream = async (_agent, trigger) => {
+    selectedTrigger = trigger;
+  };
+
+  await framework.processInferenceRequests();
+
+  assert.equal(
+    selectedTrigger?.reason,
+    'context_budget_restart',
+    'the request that bypasses the turn-alive lock must preserve continuation semantics',
+  );
+  assert.equal(framework.pendingRequests.length, 0, 'the mixed wake batch is consumed once');
 });


### PR DESCRIPTION
## Problem

When an ordinary inference wake was already pending and a `context_budget_restart` request joined the same batch, the scheduler detected the restart and used it to bypass the active-turn lock, but then selected the batch's first request as the downstream trigger.

If the ordinary wake came first, the continuation was therefore treated as a fresh turn. Fresh-turn handling could flush deferred messages, reset the active reply channel, and clear other turn-scoped routing state even though the context-budget restart was continuing the same logical turn.

## Changes

- Select the context-budget restart as the trigger whenever one is present in a mixed wake batch.
- Use that same selected request for both the active-turn exception and downstream turn semantics.
- Add a regression test covering an ordinary wake queued immediately before a budget restart.
- Document the fix under the Unreleased changelog.

## Tests

- `npm run build` — passed.
- `node --test --test-force-exit dist/test/busy-agent-scheduler.test.js` — 4 passed, 0 failed.
- `npm test` — 596 passed, 0 failed, 1 skipped.
- `npx tsc --noEmit` — passed.
- Regression discriminator with the old scheduler logic — 3 passed, 1 failed; the new test observed `mcpl:channel-incoming` where `context_budget_restart` was required.

## Not verified

- A live provider session reaching its physical context limit while an unrelated wake is simultaneously pending.

🤖 Generated with OpenAI Codex
