### PR TITLE
fix(queue): preserve external message arrival order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Releases up to and including 0.7.3 predate this file; for their contents see
 
 ## Unreleased
 
+### Fixed
+
+- Rapid external messages now retain arrival order while remaining prioritized
+  ahead of queued internal framework events.
+
 ## 0.10.0 — 2026-08-18
 
 Minor release because it adds a third public prose-routing mode and expands the

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -22,8 +22,14 @@ export class ProcessQueueImpl implements ProcessQueue {
     if (waiter) {
       waiter(event);
     } else if (event.type === 'external-message') {
-      // User input jumps to front so it's processed before queued internal events
-      this.queue.unshift(event);
+      // User input stays ahead of queued internal work, but joins the end of
+      // the external-message lane so rapid messages retain arrival order.
+      const firstInternal = this.queue.findIndex((queued) => queued.type !== 'external-message');
+      if (firstInternal === -1) {
+        this.queue.push(event);
+      } else {
+        this.queue.splice(firstInternal, 0, event);
+      }
     } else {
       this.queue.push(event);
     }

--- a/test/framework.test.ts
+++ b/test/framework.test.ts
@@ -305,6 +305,42 @@ describe('ProcessQueueImpl', () => {
     assert.strictEqual(queue.isEmpty, true);
   });
 
+  it('prioritizes external messages without reversing their arrival order', () => {
+    const queue = new ProcessQueueImpl();
+    const firstMessage: ProcessEvent = {
+      type: 'external-message',
+      source: 'test',
+      content: 'first',
+      metadata: {},
+    };
+    const secondMessage: ProcessEvent = {
+      type: 'external-message',
+      source: 'test',
+      content: 'second',
+      metadata: {},
+    };
+    const firstInternal: ProcessEvent = {
+      type: 'timer-fired',
+      timerId: 'first-internal',
+      reason: 'test',
+    };
+    const secondInternal: ProcessEvent = {
+      type: 'timer-fired',
+      timerId: 'second-internal',
+      reason: 'test',
+    };
+
+    queue.push(firstInternal);
+    queue.push(firstMessage);
+    queue.push(secondMessage);
+    queue.push(secondInternal);
+
+    assert.deepStrictEqual(queue.tryPop(), firstMessage);
+    assert.deepStrictEqual(queue.tryPop(), secondMessage);
+    assert.deepStrictEqual(queue.tryPop(), firstInternal);
+    assert.deepStrictEqual(queue.tryPop(), secondInternal);
+  });
+
   it('should return null when queue is empty', () => {
     const queue = new ProcessQueueImpl();
     assert.strictEqual(queue.tryPop(), null);


### PR DESCRIPTION
## Problem

`ProcessQueueImpl.push()` used `unshift()` for every external message so user
input would jump ahead of queued internal work. When two external messages
arrived before the queue drained, each new message also jumped ahead of the
previous external message. A rapid sequence such as “first”, then “second” was
therefore processed as “second”, then “first”.

## Changes

- Keep external messages in a FIFO priority lane ahead of internal events.
- Insert a new external message after already queued external messages and
  before the first internal event.
- Add a regression test covering two external messages interleaved with two
  internal events.
- Document the fix under the Unreleased changelog.

This is independent of the companion scheduler and Discord fixes and is safe to
merge in any order.

## Tests

- `npm run build` — passed.
- `npm test` — 596 passed, 0 failed, 1 skipped.
- `npm run typecheck` — passed.
- Regression discriminator: the old `unshift()` behavior deterministically
  returns the second external message before the first; the new test requires
  `first message`, `second message`, `first internal`, `second internal`.

## Not verified

- A live Discord or other MCPL source delivering multiple messages during a
  running inference turn.

---

- [x] `CHANGELOG.md` updated under `## Unreleased`.

🤖 Generated with OpenAI Codex
