### PR TITLE
fix(discord): preserve missed history chronology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Releases up to and including 0.7.3 predate this file; for their contents see
 
 ## Unreleased
 
+### Fixed
+
+- Missed Discord messages imported during history sync are now appended
+  oldest-first so their stored conversation chronology remains intact.
+
 ## 0.10.0 — 2026-08-18
 
 Minor release because it adds a third public prose-routing mode and expands the

--- a/src/modules/discord/index.ts
+++ b/src/modules/discord/index.ts
@@ -774,8 +774,10 @@ export class DiscordModule implements Module {
     let editedMessages = 0;
     let deletedMessages = 0;
 
-    // Process Discord messages - check for new/edited
-    for (const discordMsg of discordMessages) {
+    // Discord history is newest-first, while addMessage appends to the stored
+    // conversation. Process oldest-first so missed messages retain chronology.
+    const chronologicalMessages = [...discordMessages].reverse();
+    for (const discordMsg of chronologicalMessages) {
       const stored = storedMessageMap.get(discordMsg.id);
       
       if (!stored) {

--- a/test/discord-history-sync.test.ts
+++ b/test/discord-history-sync.test.ts
@@ -1,0 +1,80 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { DiscordModule } from '../src/modules/discord/index.js';
+import type {
+  DiscordClientInterface,
+  DiscordModuleState,
+  HistoryMessage,
+} from '../src/modules/discord/types.js';
+import type { ModuleContext } from '../src/types/index.js';
+
+interface DiscordHistoryHarness {
+  ctx: ModuleContext | null;
+  state: DiscordModuleState;
+  syncChannelHistory(channelId: string): Promise<{
+    newMessages: number;
+    editedMessages: number;
+    deletedMessages: number;
+  }>;
+}
+
+function historyMessage(id: string, content: string, timestamp: number): HistoryMessage {
+  return {
+    id,
+    authorId: `author-${id}`,
+    authorName: `Author ${id}`,
+    isBot: false,
+    content,
+    timestamp: new Date(timestamp),
+  };
+}
+
+test('Discord history sync appends missed messages in chronological order', async () => {
+  const newestFirst = [
+    historyMessage('3', 'third', 3_000),
+    historyMessage('2', 'second', 2_000),
+    historyMessage('1', 'first', 1_000),
+  ];
+  const client = {
+    fetchHistory: async () => newestFirst,
+  } as unknown as DiscordClientInterface;
+  const module = new DiscordModule(client, { token: 'test-token' });
+  const harness = module as unknown as DiscordHistoryHarness;
+  const added: Array<{ content: string; timestamp: number }> = [];
+
+  harness.ctx = {
+    queryMessages: () => ({ messages: [], totalCount: 0 }),
+    getAgents: () => [{ name: 'Sol' }],
+    addMessage: (
+      _participant: string,
+      content: Array<{ type: string; text?: string }>,
+      metadata?: { timestamp?: number },
+    ) => {
+      const text = content[0];
+      assert.ok(text && text.type === 'text' && typeof text.text === 'string');
+      const timestamp = metadata?.timestamp;
+      assert.ok(typeof timestamp === 'number');
+      added.push({
+        content: text.text,
+        timestamp,
+      });
+      return `stored-${added.length}`;
+    },
+    editMessage: () => {},
+    removeMessage: () => {},
+  } as unknown as ModuleContext;
+
+  const result = await harness.syncChannelHistory('channel-1');
+
+  assert.deepStrictEqual(added, [
+    { content: 'first', timestamp: 1_000 },
+    { content: 'second', timestamp: 2_000 },
+    { content: 'third', timestamp: 3_000 },
+  ]);
+  assert.deepStrictEqual(result, {
+    newMessages: 3,
+    editedMessages: 0,
+    deletedMessages: 0,
+  });
+  assert.equal(harness.state.lastReadMessageId['channel-1'], '3');
+});


### PR DESCRIPTION
## Problem

Discord history is returned newest-first, while Context Manager's
`addMessage()` appends to the stored conversation. History sync iterated the
Discord response directly, so messages missed while the process was offline
were appended backward. The model could then see replies before the messages
they answered.

## Changes

- Reverse a copy of the fetched Discord history before appending new messages.
- Leave the original newest-first response intact for newest-message tracking
  and edit/delete comparison.
- Add a regression test with three missed messages returned newest-first.
- Document the fix under the Unreleased changelog.

This is semantically independent of the companion Discord deletion-window fix
and safe to merge in either order. Because both touch
`DiscordModule.syncChannelHistory()`, the second branch may need a small rebase
after the first merges.

## Tests

- `npm run build` — passed.
- `npm test` — 596 passed, 0 failed, 1 skipped.
- `npm run typecheck` — passed.
- The regression fixture returns messages `3, 2, 1`; the stored append sequence
  is asserted as `1, 2, 3`, and newest-message tracking remains `3`.

## Not verified

- A live Discord reconnect with messages missed during process downtime.

---

- [x] `CHANGELOG.md` updated under `## Unreleased`.

🤖 Generated with OpenAI Codex
