### PR TITLE
fix(discord): bound deletion checks to fetched history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Releases up to and including 0.7.3 predate this file; for their contents see
 
 ## Unreleased
 
+### Fixed
+
+- Discord history sync no longer mistakes stored messages older than its
+  configured scrollback window for deleted messages and removes them.
+
 ## 0.10.0 — 2026-08-18
 
 Minor release because it adds a third public prose-routing mode and expands the

--- a/src/modules/discord/index.ts
+++ b/src/modules/discord/index.ts
@@ -733,10 +733,10 @@ export class DiscordModule implements Module {
     }
 
     const scrollback = this.config.historyScrollback ?? 50;
-    
+
     // Fetch recent history from Discord
     const discordMessages = await this.client.fetchHistory(channelId, { limit: scrollback });
-    
+
     // Build a map of Discord message ID -> content for comparison
     const discordMessageMap = new Map<string, { content: string; authorName: string; timestamp: Date }>();
     for (const msg of discordMessages) {
@@ -754,7 +754,11 @@ export class DiscordModule implements Module {
     });
 
     // Build a map of stored message external IDs -> internal data
-    const storedMessageMap = new Map<string, { internalId: string; content: string }>();
+    const storedMessageMap = new Map<string, {
+      internalId: string;
+      content: string;
+      sourceTimestamp?: number;
+    }>();
     for (const msg of storedMessages) {
       const external = msg.metadata?.external as { id?: string } | undefined;
       if (external?.id) {
@@ -766,6 +770,9 @@ export class DiscordModule implements Module {
         storedMessageMap.set(external.id, {
           internalId: msg.id,
           content: textContent,
+          sourceTimestamp: typeof msg.metadata?.timestamp === 'number'
+            ? msg.metadata.timestamp
+            : undefined,
         });
       }
     }
@@ -784,7 +791,7 @@ export class DiscordModule implements Module {
         // This ensures continuity of conversation history
         const isBotMessage = discordMsg.authorId === this.state.botUserId;
         const agentName = this.ctx.getAgents()[0]?.name;
-        const participantName = isBotMessage 
+        const participantName = isBotMessage
           ? (agentName ?? discordMsg.authorName)
           : discordMsg.authorName;
         
@@ -810,12 +817,22 @@ export class DiscordModule implements Module {
       }
     }
 
-    // Check for deletes - messages we have that Discord doesn't
-    // Only consider messages within the scrollback window (recent ones)
+    // Check for deletes only inside the history we actually fetched. When the
+    // response reaches the configured limit, older stored messages are outside
+    // the comparison window and their absence does not mean Discord deleted
+    // them. A short response covers the channel's complete available history.
+    const fetchedCompleteHistory = discordMessages.length < scrollback;
+    const oldestFetchedTimestamp = discordMessages.length > 0
+      ? Math.min(...discordMessages.map((msg) => msg.timestamp.getTime()))
+      : undefined;
     for (const [externalId, stored] of storedMessageMap) {
-      if (!discordMessageMap.has(externalId)) {
+      const isInsideFetchedWindow = fetchedCompleteHistory || (
+        stored.sourceTimestamp !== undefined &&
+        oldestFetchedTimestamp !== undefined &&
+        stored.sourceTimestamp >= oldestFetchedTimestamp
+      );
+      if (isInsideFetchedWindow && !discordMessageMap.has(externalId)) {
         // Message exists in our store but not in Discord - it was deleted
-        // Note: This only catches deletes within the scrollback window
         this.ctx.removeMessage(stored.internalId);
         deletedMessages++;
       }

--- a/src/modules/discord/index.ts
+++ b/src/modules/discord/index.ts
@@ -829,7 +829,10 @@ export class DiscordModule implements Module {
       const isInsideFetchedWindow = fetchedCompleteHistory || (
         stored.sourceTimestamp !== undefined &&
         oldestFetchedTimestamp !== undefined &&
-        stored.sourceTimestamp >= oldestFetchedTimestamp
+        // Discord timestamps are millisecond-precise, so an older message just
+        // beyond the page can tie the oldest fetched timestamp. Preserve ties
+        // rather than guessing that an unseen boundary message was deleted.
+        stored.sourceTimestamp > oldestFetchedTimestamp
       );
       if (isInsideFetchedWindow && !discordMessageMap.has(externalId)) {
         // Message exists in our store but not in Discord - it was deleted

--- a/test/discord-history-delete-window.test.ts
+++ b/test/discord-history-delete-window.test.ts
@@ -91,6 +91,24 @@ test('history sync preserves stored messages older than a full scrollback window
   assert.equal(result.deletedMessages, 1);
 });
 
+test('history sync preserves an unfetched message tied with the oldest fetched timestamp', async () => {
+  const { harness, removed } = historyHarness(
+    [historyMessage('3', 3_000), historyMessage('2', 2_000)],
+    [
+      storedMessage('stored-boundary-unseen', '1', 2_000),
+      storedMessage('stored-recent-deleted', 'deleted', 2_500),
+      storedMessage('stored-2', '2', 2_000),
+      storedMessage('stored-3', '3', 3_000),
+    ],
+    2,
+  );
+
+  const result = await harness.syncChannelHistory('channel-1');
+
+  assert.deepStrictEqual(removed, ['stored-recent-deleted']);
+  assert.equal(result.deletedMessages, 1);
+});
+
 test('history sync still detects older deletions when the fetch covers the whole channel', async () => {
   const { harness, removed } = historyHarness(
     [historyMessage('2', 2_000)],

--- a/test/discord-history-delete-window.test.ts
+++ b/test/discord-history-delete-window.test.ts
@@ -1,0 +1,108 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { DiscordModule } from '../src/modules/discord/index.js';
+import type {
+  DiscordClientInterface,
+  DiscordModuleState,
+  HistoryMessage,
+} from '../src/modules/discord/types.js';
+import type { ModuleContext } from '../src/types/index.js';
+
+interface DiscordHistoryHarness {
+  ctx: ModuleContext | null;
+  state: DiscordModuleState;
+  syncChannelHistory(channelId: string): Promise<{
+    newMessages: number;
+    editedMessages: number;
+    deletedMessages: number;
+  }>;
+}
+
+function historyMessage(id: string, timestamp: number): HistoryMessage {
+  return {
+    id,
+    authorId: `author-${id}`,
+    authorName: `Author ${id}`,
+    isBot: false,
+    content: `message ${id}`,
+    timestamp: new Date(timestamp),
+  };
+}
+
+function storedMessage(internalId: string, externalId: string, timestamp: number) {
+  return {
+    id: internalId,
+    sequence: 1,
+    participant: `Author ${externalId}`,
+    content: [{ type: 'text' as const, text: `message ${externalId}` }],
+    metadata: {
+      external: { source: 'discord', id: externalId },
+      channelId: 'channel-1',
+      timestamp,
+    },
+    timestamp: new Date(timestamp),
+  };
+}
+
+function historyHarness(
+  discordMessages: HistoryMessage[],
+  storedMessages: ReturnType<typeof storedMessage>[],
+  historyScrollback: number,
+): { harness: DiscordHistoryHarness; removed: string[] } {
+  const client = {
+    fetchHistory: async () => discordMessages,
+  } as unknown as DiscordClientInterface;
+  const module = new DiscordModule(client, {
+    token: 'test-token',
+    historyScrollback,
+  });
+  const harness = module as unknown as DiscordHistoryHarness;
+  const removed: string[] = [];
+
+  harness.ctx = {
+    queryMessages: () => ({
+      messages: storedMessages,
+      totalCount: storedMessages.length,
+    }),
+    getAgents: () => [{ name: 'Sol' }],
+    addMessage: () => 'unexpected-add',
+    editMessage: () => {},
+    removeMessage: (id: string) => removed.push(id),
+  } as unknown as ModuleContext;
+
+  return { harness, removed };
+}
+
+test('history sync preserves stored messages older than a full scrollback window', async () => {
+  const { harness, removed } = historyHarness(
+    [historyMessage('3', 3_000), historyMessage('2', 2_000)],
+    [
+      storedMessage('stored-old', '1', 1_000),
+      storedMessage('stored-recent-deleted', 'deleted', 2_500),
+      storedMessage('stored-2', '2', 2_000),
+      storedMessage('stored-3', '3', 3_000),
+    ],
+    2,
+  );
+
+  const result = await harness.syncChannelHistory('channel-1');
+
+  assert.deepStrictEqual(removed, ['stored-recent-deleted']);
+  assert.equal(result.deletedMessages, 1);
+});
+
+test('history sync still detects older deletions when the fetch covers the whole channel', async () => {
+  const { harness, removed } = historyHarness(
+    [historyMessage('2', 2_000)],
+    [
+      storedMessage('stored-deleted', '1', 1_000),
+      storedMessage('stored-2', '2', 2_000),
+    ],
+    3,
+  );
+
+  const result = await harness.syncChannelHistory('channel-1');
+
+  assert.deepStrictEqual(removed, ['stored-deleted']);
+  assert.equal(result.deletedMessages, 1);
+});


### PR DESCRIPTION
## Problem

Discord history sync queried every stored message for a channel but fetched only
the configured recent scrollback window from Discord. It treated any stored
message absent from that bounded response as deleted. Once a channel contained
more messages than the scrollback limit, valid older history could therefore be
removed from Context Manager on sync.

## Changes

- Retain each stored Discord message's source timestamp during comparison.
- When a fetch reaches the scrollback limit, check deletion only for stored
  messages at or newer than the oldest fetched timestamp.
- When Discord returns fewer messages than the limit, continue treating the
  response as complete channel history so genuine older deletions are detected.
- Preserve messages without a usable source timestamp when the response is
  window-limited rather than guessing that they were deleted.
- Conservatively preserve timestamp ties at the oldest fetched boundary,
  because Discord can contain multiple messages in the same millisecond.
- Add regressions for a full bounded window, a tied boundary, and complete short
  history.
- Document the fix under the Unreleased changelog.

This is semantically independent of the companion Discord chronology fix and
safe to merge in either order. Because both touch
`DiscordModule.syncChannelHistory()`, the second branch may need a small rebase
after the first merges.

## Tests

- `npm run build` — passed.
- Focused deletion-window suite — 3 passed, 0 failed.
- `npm test` — 598 passed, 0 failed, 1 skipped.
- `npm run typecheck` — passed.
- Regression discriminator: with the old comparison, both the valid old message
  and a recent deleted message are removed; the fixed comparison removes only
  the recent deleted message.
- Review discriminator: an unfetched message tied with the oldest fetched
  timestamp is preserved while a genuinely newer deleted message is removed.

## Not verified

- Live Discord history pagination on a channel larger than the configured
  scrollback.
- Deletion detection for legacy stored Discord messages that lack source
  timestamps; the fix deliberately preserves them when the fetch is bounded.

---

- [x] `CHANGELOG.md` updated under `## Unreleased`.

🤖 Generated with OpenAI Codex
