### PR TITLE
integrate: approved queue and Discord history integrity fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Releases up to and including 0.7.3 predate this file; for their contents see
 
 ### Fixed
 
+- Discord downtime history is written to Context Manager in chronological order while newest-message tracking retains Discord order.
+
 - Rapid external messages now retain arrival order while remaining prioritized
   ahead of queued internal framework events.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Releases up to and including 0.7.3 predate this file; for their contents see
 
 ### Fixed
 
+- Rapid external messages now retain arrival order while remaining prioritized
+  ahead of queued internal framework events.
+
 - Mixed wake batches containing a context-budget restart now preserve the
   restart's same-turn semantics instead of taking the restart-only turn-lock
   exception and then starting from an older ordinary wake as a fresh turn.

--- a/src/modules/discord/index.ts
+++ b/src/modules/discord/index.ts
@@ -754,7 +754,7 @@ export class DiscordModule implements Module {
     });
 
     // Build a map of stored message external IDs -> internal data
-    const storedMessageMap = new Map<string, { internalId: string; content: string }>();
+    const storedMessageMap = new Map<string, { internalId: string; content: string; sourceTimestamp?: number }>();
     for (const msg of storedMessages) {
       const external = msg.metadata?.external as { id?: string } | undefined;
       if (external?.id) {
@@ -766,6 +766,9 @@ export class DiscordModule implements Module {
         storedMessageMap.set(external.id, {
           internalId: msg.id,
           content: textContent,
+          sourceTimestamp: typeof msg.metadata?.timestamp === 'number'
+            ? msg.metadata.timestamp
+            : undefined,
         });
       }
     }
@@ -812,10 +815,23 @@ export class DiscordModule implements Module {
       }
     }
 
-    // Check for deletes - messages we have that Discord doesn't
-    // Only consider messages within the scrollback window (recent ones)
+    // Check for deletes only inside the history we actually fetched. A short
+    // response covers complete available history; a full page has an older
+    // boundary whose tied millisecond must be preserved.
+    const fetchedCompleteHistory = discordMessages.length < scrollback;
+    const oldestFetchedTimestamp = discordMessages.length > 0
+      ? Math.min(...discordMessages.map((msg) => msg.timestamp.getTime()))
+      : undefined;
     for (const [externalId, stored] of storedMessageMap) {
-      if (!discordMessageMap.has(externalId)) {
+      const isInsideFetchedWindow = fetchedCompleteHistory || (
+        stored.sourceTimestamp !== undefined &&
+        oldestFetchedTimestamp !== undefined &&
+        // Discord timestamps are millisecond-precise, so an older message just
+        // beyond the page can tie the oldest fetched timestamp. Preserve ties
+        // rather than guessing that an unseen boundary message was deleted.
+        stored.sourceTimestamp > oldestFetchedTimestamp
+      );
+      if (isInsideFetchedWindow && !discordMessageMap.has(externalId)) {
         // Message exists in our store but not in Discord - it was deleted
         // Note: This only catches deletes within the scrollback window
         this.ctx.removeMessage(stored.internalId);

--- a/src/modules/discord/index.ts
+++ b/src/modules/discord/index.ts
@@ -774,8 +774,10 @@ export class DiscordModule implements Module {
     let editedMessages = 0;
     let deletedMessages = 0;
 
-    // Process Discord messages - check for new/edited
-    for (const discordMsg of discordMessages) {
+    // Discord history is newest-first, while addMessage appends to the stored
+    // conversation. Process oldest-first so missed messages retain chronology.
+    const chronologicalMessages = [...discordMessages].reverse();
+    for (const discordMsg of chronologicalMessages) {
       const stored = storedMessageMap.get(discordMsg.id);
       
       if (!stored) {

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -22,8 +22,14 @@ export class ProcessQueueImpl implements ProcessQueue {
     if (waiter) {
       waiter(event);
     } else if (event.type === 'external-message') {
-      // User input jumps to front so it's processed before queued internal events
-      this.queue.unshift(event);
+      // User input stays ahead of queued internal work, but joins the end of
+      // the external-message lane so rapid messages retain arrival order.
+      const firstInternal = this.queue.findIndex((queued) => queued.type !== 'external-message');
+      if (firstInternal === -1) {
+        this.queue.push(event);
+      } else {
+        this.queue.splice(firstInternal, 0, event);
+      }
     } else {
       this.queue.push(event);
     }

--- a/test/discord-history-delete-window.test.ts
+++ b/test/discord-history-delete-window.test.ts
@@ -1,0 +1,126 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { DiscordModule } from '../src/modules/discord/index.js';
+import type {
+  DiscordClientInterface,
+  DiscordModuleState,
+  HistoryMessage,
+} from '../src/modules/discord/types.js';
+import type { ModuleContext } from '../src/types/index.js';
+
+interface DiscordHistoryHarness {
+  ctx: ModuleContext | null;
+  state: DiscordModuleState;
+  syncChannelHistory(channelId: string): Promise<{
+    newMessages: number;
+    editedMessages: number;
+    deletedMessages: number;
+  }>;
+}
+
+function historyMessage(id: string, timestamp: number): HistoryMessage {
+  return {
+    id,
+    authorId: `author-${id}`,
+    authorName: `Author ${id}`,
+    isBot: false,
+    content: `message ${id}`,
+    timestamp: new Date(timestamp),
+  };
+}
+
+function storedMessage(internalId: string, externalId: string, timestamp: number) {
+  return {
+    id: internalId,
+    sequence: 1,
+    participant: `Author ${externalId}`,
+    content: [{ type: 'text' as const, text: `message ${externalId}` }],
+    metadata: {
+      external: { source: 'discord', id: externalId },
+      channelId: 'channel-1',
+      timestamp,
+    },
+    timestamp: new Date(timestamp),
+  };
+}
+
+function historyHarness(
+  discordMessages: HistoryMessage[],
+  storedMessages: ReturnType<typeof storedMessage>[],
+  historyScrollback: number,
+): { harness: DiscordHistoryHarness; removed: string[] } {
+  const client = {
+    fetchHistory: async () => discordMessages,
+  } as unknown as DiscordClientInterface;
+  const module = new DiscordModule(client, {
+    token: 'test-token',
+    historyScrollback,
+  });
+  const harness = module as unknown as DiscordHistoryHarness;
+  const removed: string[] = [];
+
+  harness.ctx = {
+    queryMessages: () => ({
+      messages: storedMessages,
+      totalCount: storedMessages.length,
+    }),
+    getAgents: () => [{ name: 'Sol' }],
+    addMessage: () => 'unexpected-add',
+    editMessage: () => {},
+    removeMessage: (id: string) => removed.push(id),
+  } as unknown as ModuleContext;
+
+  return { harness, removed };
+}
+
+test('history sync preserves stored messages older than a full scrollback window', async () => {
+  const { harness, removed } = historyHarness(
+    [historyMessage('3', 3_000), historyMessage('2', 2_000)],
+    [
+      storedMessage('stored-old', '1', 1_000),
+      storedMessage('stored-recent-deleted', 'deleted', 2_500),
+      storedMessage('stored-2', '2', 2_000),
+      storedMessage('stored-3', '3', 3_000),
+    ],
+    2,
+  );
+
+  const result = await harness.syncChannelHistory('channel-1');
+
+  assert.deepStrictEqual(removed, ['stored-recent-deleted']);
+  assert.equal(result.deletedMessages, 1);
+});
+
+test('history sync preserves an unfetched message tied with the oldest fetched timestamp', async () => {
+  const { harness, removed } = historyHarness(
+    [historyMessage('3', 3_000), historyMessage('2', 2_000)],
+    [
+      storedMessage('stored-boundary-unseen', '1', 2_000),
+      storedMessage('stored-recent-deleted', 'deleted', 2_500),
+      storedMessage('stored-2', '2', 2_000),
+      storedMessage('stored-3', '3', 3_000),
+    ],
+    2,
+  );
+
+  const result = await harness.syncChannelHistory('channel-1');
+
+  assert.deepStrictEqual(removed, ['stored-recent-deleted']);
+  assert.equal(result.deletedMessages, 1);
+});
+
+test('history sync still detects older deletions when the fetch covers the whole channel', async () => {
+  const { harness, removed } = historyHarness(
+    [historyMessage('2', 2_000)],
+    [
+      storedMessage('stored-deleted', '1', 1_000),
+      storedMessage('stored-2', '2', 2_000),
+    ],
+    3,
+  );
+
+  const result = await harness.syncChannelHistory('channel-1');
+
+  assert.deepStrictEqual(removed, ['stored-deleted']);
+  assert.equal(result.deletedMessages, 1);
+});

--- a/test/discord-history-sync.test.ts
+++ b/test/discord-history-sync.test.ts
@@ -1,0 +1,80 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { DiscordModule } from '../src/modules/discord/index.js';
+import type {
+  DiscordClientInterface,
+  DiscordModuleState,
+  HistoryMessage,
+} from '../src/modules/discord/types.js';
+import type { ModuleContext } from '../src/types/index.js';
+
+interface DiscordHistoryHarness {
+  ctx: ModuleContext | null;
+  state: DiscordModuleState;
+  syncChannelHistory(channelId: string): Promise<{
+    newMessages: number;
+    editedMessages: number;
+    deletedMessages: number;
+  }>;
+}
+
+function historyMessage(id: string, content: string, timestamp: number): HistoryMessage {
+  return {
+    id,
+    authorId: `author-${id}`,
+    authorName: `Author ${id}`,
+    isBot: false,
+    content,
+    timestamp: new Date(timestamp),
+  };
+}
+
+test('Discord history sync appends missed messages in chronological order', async () => {
+  const newestFirst = [
+    historyMessage('3', 'third', 3_000),
+    historyMessage('2', 'second', 2_000),
+    historyMessage('1', 'first', 1_000),
+  ];
+  const client = {
+    fetchHistory: async () => newestFirst,
+  } as unknown as DiscordClientInterface;
+  const module = new DiscordModule(client, { token: 'test-token' });
+  const harness = module as unknown as DiscordHistoryHarness;
+  const added: Array<{ content: string; timestamp: number }> = [];
+
+  harness.ctx = {
+    queryMessages: () => ({ messages: [], totalCount: 0 }),
+    getAgents: () => [{ name: 'Sol' }],
+    addMessage: (
+      _participant: string,
+      content: Array<{ type: string; text?: string }>,
+      metadata?: { timestamp?: number },
+    ) => {
+      const text = content[0];
+      assert.ok(text && text.type === 'text' && typeof text.text === 'string');
+      const timestamp = metadata?.timestamp;
+      assert.ok(typeof timestamp === 'number');
+      added.push({
+        content: text.text,
+        timestamp,
+      });
+      return `stored-${added.length}`;
+    },
+    editMessage: () => {},
+    removeMessage: () => {},
+  } as unknown as ModuleContext;
+
+  const result = await harness.syncChannelHistory('channel-1');
+
+  assert.deepStrictEqual(added, [
+    { content: 'first', timestamp: 1_000 },
+    { content: 'second', timestamp: 2_000 },
+    { content: 'third', timestamp: 3_000 },
+  ]);
+  assert.deepStrictEqual(result, {
+    newMessages: 3,
+    editedMessages: 0,
+    deletedMessages: 0,
+  });
+  assert.equal(harness.state.lastReadMessageId['channel-1'], '3');
+});

--- a/test/framework.test.ts
+++ b/test/framework.test.ts
@@ -305,6 +305,42 @@ describe('ProcessQueueImpl', () => {
     assert.strictEqual(queue.isEmpty, true);
   });
 
+  it('prioritizes external messages without reversing their arrival order', () => {
+    const queue = new ProcessQueueImpl();
+    const firstMessage: ProcessEvent = {
+      type: 'external-message',
+      source: 'test',
+      content: 'first',
+      metadata: {},
+    };
+    const secondMessage: ProcessEvent = {
+      type: 'external-message',
+      source: 'test',
+      content: 'second',
+      metadata: {},
+    };
+    const firstInternal: ProcessEvent = {
+      type: 'timer-fired',
+      timerId: 'first-internal',
+      reason: 'test',
+    };
+    const secondInternal: ProcessEvent = {
+      type: 'timer-fired',
+      timerId: 'second-internal',
+      reason: 'test',
+    };
+
+    queue.push(firstInternal);
+    queue.push(firstMessage);
+    queue.push(secondMessage);
+    queue.push(secondInternal);
+
+    assert.deepStrictEqual(queue.tryPop(), firstMessage);
+    assert.deepStrictEqual(queue.tryPop(), secondMessage);
+    assert.deepStrictEqual(queue.tryPop(), firstInternal);
+    assert.deepStrictEqual(queue.tryPop(), secondInternal);
+  });
+
   it('should return null when queue is empty', () => {
     const queue = new ProcessQueueImpl();
     assert.strictEqual(queue.tryPop(), null);


### PR DESCRIPTION
Integrates approved #118, #119, and #120 after #117 changed main. Preserves external FIFO priority, chronological downtime ingestion, and conservative bounded-history deletion at same-millisecond page boundaries. Independent integrated receipts: build/typecheck clean; focused framework/history suites 26/26; diff-check clean. Supersedes the three approved but now-conflicting source PRs without changing their feature contracts.