### PR TITLE
feat(framework): puppetToolCall — admin-execute a tool AS an agent, store the pair

### DIFF
--- a/src/framework.ts
+++ b/src/framework.ts
@@ -6767,6 +6767,107 @@ export class AgentFramework {
     });
   }
 
+  /**
+   * Admin puppet: execute ONE tool call AS an agent and persist the
+   * tool_use + tool_result pair in that agent's window exactly as a
+   * model-initiated call is stored.
+   *
+   * Born from the princess exemplar surgery (2026-08-23). Her folded
+   * narrative said "I have no tools"; every past tool_use/tool_result pair
+   * had folded out of her context, so the act of calling had no in-context
+   * exemplar and she could not emit her first call despite 30 eidoverse
+   * tools riding every request. Placing one first-person pair restored the
+   * capacity. That repair required stop → store surgery → restart; this
+   * method is the live path — and the general lever for demonstrating an
+   * affordance to a model that cannot find it (older models especially).
+   *
+   * Semantics:
+   * - Refused unless the agent is idle: puppeting mid-turn would corrupt
+   *   the turn state machine and the live stream's wire ordering.
+   * - Refused for tools outside the agent's own surface (canUseTool): the
+   *   stored pair must be an act the agent could genuinely have taken.
+   * - The call executes FOR REAL through the shared dispatch (MCPL,
+   *   channel tools, utils, modules) with the agent's provenance — a
+   *   puppeted walk_to actually moves the avatar.
+   * - Storage byte-follows the ordinary path: a bare tool_use assistant
+   *   message (no fabricated thinking or text — a stored assistant turn
+   *   with unverifiable thinking is the labclaude 400 class) plus a
+   *   tool_result under the same bounded spill policy (issue #89).
+   * - Does NOT request inference; the agent sees the pair on its next
+   *   wake. Speak to the agent afterward if a wake is wanted.
+   * - Provenance is loud in traces (puppet:tool-call) and the host log,
+   *   deliberately NOT in the stored messages — metadata there would break
+   *   byte-parity with real turns. Whether to disclose to the resident is
+   *   the operator's call; the princess precedent was disclosed first.
+   */
+  async puppetToolCall(
+    agentName: string,
+    toolName: string,
+    input: Record<string, unknown>,
+  ): Promise<{ toolUseId: string; result: ToolResult }> {
+    const agent = this.agents.get(agentName);
+    if (!agent) throw new Error(`Unknown agent: ${agentName}`);
+    if (agent.state.status !== 'idle') {
+      throw new Error(
+        `puppet refused: agent ${agentName} is ${agent.state.status} (requires idle — ` +
+        `injecting a turn under an active stream corrupts wire ordering)`,
+      );
+    }
+    const onSurface = this.getToolsForAgent(agentName)
+      .some((t) => t.name === toolName && agent.canUseTool(t.name));
+    if (!onSurface) {
+      throw new Error(
+        `puppet refused: tool ${toolName} is not on ${agentName}'s surface — ` +
+        `the stored pair must be an act the agent could genuinely have taken`,
+      );
+    }
+
+    // Anthropic-shaped id so the stored pair is indistinguishable from a
+    // provider-issued call.
+    const alphabet = 'ABCDEFGHJKMNPQRSTVWXYZabcdefghjkmnpqrstvwxyz0123456789';
+    let suffix = '';
+    for (let i = 0; i < 22; i++) suffix += alphabet[Math.floor(Math.random() * alphabet.length)];
+    const toolUseId = `toolu_01${suffix}`;
+
+    const started = Date.now();
+    const result = await this.executeToolCall({
+      id: toolUseId,
+      name: toolName,
+      input,
+      callerAgentName: agentName,
+    });
+    const durationMs = Date.now() - started;
+
+    // Store the pair through the same shapes the ordinary path uses. Build
+    // the result blocks BEFORE storing the tool_use: the spill path awaits,
+    // and a message arriving during that await must land before the pair,
+    // never between tool_use and its tool_result. The two addMessage calls
+    // below are synchronous and adjacent — nothing can interleave.
+    const { blocks } = await this.buildStoredToolResultContent(
+      [{ id: toolUseId, name: toolName, input, result, durationMs }],
+      this.resolveToolResultInlineCap(agent).cap,
+    );
+    const cm = agent.getContextManager();
+    cm.addMessage(agentName, [
+      { type: 'tool_use', id: toolUseId, name: toolName, input } as ContentBlock,
+    ]);
+    cm.addMessage('user', blocks);
+
+    this.emitTrace({
+      type: 'puppet:tool-call',
+      agentName,
+      toolName,
+      toolUseId,
+      isError: !!result.isError,
+      durationMs,
+    });
+    console.log(
+      `[puppet] ${agentName}: ${toolName} → ${result.isError ? 'ERROR' : 'ok'} ` +
+      `in ${durationMs}ms (${toolUseId})`,
+    );
+    return { toolUseId, result };
+  }
+
   private async executeToolCallFrom(call: ToolCall, origin: ChannelToolOrigin): Promise<ToolResult> {
     // Client-side programmatic tool calling for promise-based callers
     // (SubagentModule ephemerals). Keyed by callerAgentName so each ephemeral

--- a/src/types/trace.ts
+++ b/src/types/trace.ts
@@ -340,6 +340,19 @@ export type TraceEvent =
       textLen: number;
     })
 
+  // Admin puppet: an operator executed a tool AS an agent and stored the
+  // tool_use + tool_result pair in that agent's window (Framework.
+  // puppetToolCall). Provenance lives HERE and in the host log — the stored
+  // messages deliberately byte-match a model-initiated call.
+  | (TraceEventBase & {
+      type: 'puppet:tool-call';
+      agentName: string;
+      toolName: string;
+      toolUseId: string;
+      isError: boolean;
+      durationMs: number;
+    })
+
   // MCPL server connection lifecycle (spawn / handshake / reconnect health).
   // Previously these outcomes were visible only on the host process's own
   // stderr, so a server that lost the boot handshake race just went missing.

--- a/test/puppet-tool-call.test.ts
+++ b/test/puppet-tool-call.test.ts
@@ -1,0 +1,138 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AgentFramework } from '../src/framework.js';
+
+/**
+ * Framework.puppetToolCall — admin puppet: execute one tool AS an agent and
+ * persist the tool_use + tool_result pair byte-shaped like a model-initiated
+ * call. Born from the princess exemplar surgery (2026-08-23).
+ */
+
+type Stored = { participant: string; content: Array<Record<string, unknown>> };
+
+function puppetHarness(opts?: {
+  status?: string;
+  surface?: string[];
+  result?: { success: boolean; data?: unknown; error?: string; isError?: boolean };
+}) {
+  const stored: Stored[] = [];
+  const traces: Array<Record<string, unknown>> = [];
+  const executed: Array<Record<string, unknown>> = [];
+  const status = opts?.status ?? 'idle';
+  const surface = opts?.surface ?? ['mcpl--eido--look'];
+  // Real MCPL results are MCP content arrays — the helper renders them plain.
+  const result = opts?.result ?? {
+    success: true,
+    data: [{ type: 'text', text: 'You are "p" in world "w".' }],
+    isError: false,
+  };
+
+  const agent = {
+    name: 'princess',
+    state: { status },
+    canUseTool: (name: string) => surface.includes(name),
+    getContextManager: () => ({
+      addMessage: (participant: string, content: Array<Record<string, unknown>>) => {
+        stored.push({ participant, content });
+        return `msg-${stored.length}`;
+      },
+    }),
+  };
+
+  const framework = Object.create(AgentFramework.prototype) as AgentFramework;
+  (framework as unknown as { agents: Map<string, unknown> }).agents =
+    new Map([['princess', agent]]);
+  (framework as unknown as Record<string, unknown>).getToolsForAgent =
+    () => surface.map((name) => ({ name }));
+  (framework as unknown as Record<string, unknown>).executeToolCall =
+    async (call: Record<string, unknown>) => {
+      executed.push(call);
+      return result;
+    };
+  (framework as unknown as Record<string, unknown>).resolveToolResultInlineCap =
+    () => ({ cap: undefined });
+  (framework as unknown as Record<string, unknown>).emitTrace =
+    (e: Record<string, unknown>) => { traces.push(e); };
+
+  return { framework, stored, traces, executed };
+}
+
+test('puppetToolCall executes with agent provenance and stores the pair', async () => {
+  const { framework, stored, traces, executed } = puppetHarness();
+  const quiet = console.log;
+  console.log = () => {};
+  try {
+    const { toolUseId, result } = await framework.puppetToolCall(
+      'princess', 'mcpl--eido--look', {},
+    );
+
+    assert.match(toolUseId, /^toolu_01[A-Za-z0-9]{22}$/, 'anthropic-shaped id');
+    assert.equal(result.success, true);
+    assert.equal(executed.length, 1);
+    assert.equal(executed[0].callerAgentName, 'princess', 'executes AS the agent');
+    assert.equal(executed[0].id, toolUseId, 'wire call carries the stored id');
+
+    assert.equal(stored.length, 2, 'exactly the pair, nothing else');
+    const [use, res] = stored;
+    assert.equal(use.participant, 'princess', 'tool_use is the agent turn');
+    assert.equal(use.content.length, 1, 'bare tool_use — no fabricated text/thinking');
+    assert.equal(use.content[0].type, 'tool_use');
+    assert.equal(use.content[0].id, toolUseId);
+    assert.equal(res.participant, 'user', 'tool_result rides a user message');
+    assert.equal(res.content[0].type, 'tool_result');
+    assert.equal(res.content[0].toolUseId, toolUseId, 'result pairs with the call');
+    assert.equal(res.content[0].toolName, 'mcpl--eido--look');
+    assert.equal(res.content[0].isError, false);
+    assert.match(String(res.content[0].content), /You are "p"/, 'real result text stored');
+
+    assert.equal(traces.length, 1);
+    assert.equal(traces[0].type, 'puppet:tool-call');
+    assert.equal(traces[0].agentName, 'princess');
+  } finally {
+    console.log = quiet;
+  }
+});
+
+test('puppetToolCall refuses a non-idle agent', async () => {
+  const { framework, stored } = puppetHarness({ status: 'streaming' });
+  await assert.rejects(
+    () => framework.puppetToolCall('princess', 'mcpl--eido--look', {}),
+    /requires idle/,
+  );
+  assert.equal(stored.length, 0, 'nothing stored on refusal');
+});
+
+test('puppetToolCall refuses a tool off the agent surface', async () => {
+  const { framework, stored, executed } = puppetHarness();
+  await assert.rejects(
+    () => framework.puppetToolCall('princess', 'mcpl--other--nuke', {}),
+    /not on princess's surface/,
+  );
+  assert.equal(executed.length, 0, 'never executed');
+  assert.equal(stored.length, 0, 'nothing stored');
+});
+
+test('puppetToolCall refuses an unknown agent', async () => {
+  const { framework } = puppetHarness();
+  await assert.rejects(
+    () => framework.puppetToolCall('ghost', 'mcpl--eido--look', {}),
+    /Unknown agent/,
+  );
+});
+
+test('puppetToolCall stores an error result as isError, still paired', async () => {
+  const { framework, stored } = puppetHarness({
+    result: { success: false, error: 'MCPL server unreachable', isError: true },
+  });
+  const quiet = console.log;
+  console.log = () => {};
+  try {
+    const { result } = await framework.puppetToolCall('princess', 'mcpl--eido--look', {});
+    assert.equal(result.isError, true);
+    assert.equal(stored.length, 2, 'error results are stored too — same as a real turn');
+    assert.equal(stored[1].content[0].isError, true);
+    assert.match(String(stored[1].content[0].content), /unreachable/);
+  } finally {
+    console.log = quiet;
+  }
+});


### PR DESCRIPTION
## What

`Framework.puppetToolCall(agentName, toolName, input)`: an admin lever that executes one tool call through the shared dispatch (`executeToolCall`: MCPL routing, channel tools, utils, modules) with the agent's provenance, then persists the `tool_use` + `tool_result` pair in that agent's window byte-shaped like a model-initiated call.

## Why

Born from the princess exemplar surgery (2026-08-23). Her folded narrative said *"I have no tools"*; every past tool_use/tool_result pair had folded out of her context, so the act of calling had no in-context exemplar and she could not emit her first call — despite 30 eidoverse tools riding every request. Placing ONE first-person pair restored the capacity. That repair required stop → chronicle surgery → restart; this is the live path, and the general lever for demonstrating an affordance a model cannot find on its own (older models especially).

## Semantics

- **Idle-guarded** — puppeting mid-turn would corrupt the turn state machine and wire ordering.
- **Surface-guarded** — refused for tools outside `getToolsForAgent` + `canUseTool`; the stored pair must be an act the agent could genuinely have taken.
- **Real execution** — a puppeted `walk_to` actually moves the avatar; checkpoints/provenance attribute to the agent.
- **Byte-parity storage** — bare tool_use (anthropic-shaped id, no fabricated thinking/text — the labclaude thinking-only 400 class), tool_result through the same bounded spill policy (#89). Result blocks are built *before* the tool_use is stored so nothing can interleave inside the pair.
- **No wake** — the agent sees the pair on its next activation; speak to it if a reaction is wanted.
- **Loud provenance** — new `puppet:tool-call` trace + host log line, deliberately NOT in the stored messages. Disclosure to the resident is the operator's call; the precedent was disclosed first.

## Tests

5 new tests (happy path incl. wire id/provenance/pair shape, non-idle refusal, off-surface refusal, unknown agent, error-result storage). Full-suite failure count identical to an environment-matched baseline run of main in the same worktree (this suite's totals vary run-to-run; failure counts compared).

Companion host PR: anima-research/connectome-host `feat/puppet-command` (adds `/puppet` + fixes headless IPC dropping `asyncWork` results).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XiTi13astLRVF95UcnzMJ1