### PR TITLE
test: cover channel_publish fence (home-default + foreign-reject)

### DIFF
--- a/test/conversation-routing.test.ts
+++ b/test/conversation-routing.test.ts
@@ -284,4 +284,60 @@ describe('Conversation routing', () => {
 
     await framework.stop();
   });
+
+  it('fork channel_publish: omitted channelId defaults to home; foreign publish is rejected', async () => {
+    membrane.pushResponse(createMockResponse([{ type: 'text', text: 'hi' }]));
+    const framework = await makeFramework();
+    framework.pushEvent(incomingEvent({ channelId: 'slack:C7', text: 'bot, help', mentioned: true }));
+    await framework.runUntilIdle();
+    const forkName = 'conversation-slack-C7-g1';
+    assert.ok(framework.getAgent(forkName), 'fork should exist');
+
+    // tool:started is emitted AFTER the fence with the (possibly rewritten)
+    // input, so home-defaulting is observable there; a fence rejection emits
+    // tool:failed and never reaches tool:started.
+    const started: Array<{ tool: string; input?: { channelId?: string } }> = [];
+    const failures: Array<{ callId: string; error: string }> = [];
+    framework.onTrace((e: TraceEvent) => {
+      if (e.type === 'tool:started') started.push(e as unknown as (typeof started)[number]);
+      if (e.type === 'tool:failed') failures.push(e as unknown as (typeof failures)[number]);
+    });
+
+    const fw = framework as unknown as {
+      dispatchChannelToolCall(agentName: string, call: { id: string; name: string; input: Record<string, unknown> }): void;
+      channelRegistry: {
+        handleChannelToolCall(name: string, input: unknown, origin?: unknown): Promise<{ success: boolean }>;
+        stopAll(): void;
+      } | null;
+    };
+
+    // This harness runs no MCPL servers, so the framework never builds a real
+    // ChannelRegistry (the public dispatch path guards on it before routing
+    // channel_* tools). Stub the downstream boundary — the unit under test is
+    // the fence ABOVE it, and a home-defaulted publish must get past the fence
+    // to be observable at tool:started.
+    fw.channelRegistry = { handleChannelToolCall: async () => ({ success: true }), stopAll: () => {} };
+
+    // (a) omitted channelId → rewritten to the home channel, passes the fence
+    fw.dispatchChannelToolCall(forkName, { id: 'p1', name: 'channel_publish', input: { content: 'hello home' } });
+    const homePublish = started.find((t) => t.tool === 'channel_publish');
+    assert.ok(homePublish, 'home-defaulted publish should pass the fence and reach tool:started');
+    assert.equal(homePublish!.input?.channelId, 'slack:C7', 'omitted channelId is rewritten to the home channel');
+    assert.ok(
+      !failures.some((f) => f.callId === 'p1'),
+      'home-defaulted publish must not be rejected by the fence',
+    );
+
+    // (b) foreign channelId → rejected by the fence, never starts
+    fw.dispatchChannelToolCall(forkName, { id: 'p2', name: 'channel_publish', input: { channelId: 'slack:C8', content: 'sneaky' } });
+    const rejection = failures.find((f) => f.callId === 'p2');
+    assert.ok(rejection, 'foreign publish should be rejected');
+    assert.ok(rejection!.error.includes('publishing to slack:C8 is not allowed'), 'rejection names the foreign channel');
+    assert.equal(
+      started.filter((t) => t.tool === 'channel_publish').length, 1,
+      'foreign publish never reaches tool:started',
+    );
+
+    await framework.stop();
+  });
 });


### PR DESCRIPTION
## Problem

The channel fence in `dispatchChannelToolCall` is tested only for `channel_open` and foreign `channel_close`. The action conversation forks actually perform — **`channel_publish`** — has no coverage on either side of the fence: home-defaulting (omitted `channelId` → injected home) and foreign-publish rejection are both untested.

Fixes #45.

## Changes

One new case in `test/conversation-routing.test.ts`, same harness and style as the existing fence test:

- **(a) home-defaulting**: a `channel_publish` with no `channelId` passes the fence and reaches `tool:started` with `channelId` rewritten to the fork's home channel (`tool:started` is emitted after the rewrite, so the injected input is directly observable there), and is not rejected.
- **(b) foreign-reject**: a `channel_publish` with a foreign `channelId` emits `tool:failed` with the fence's "publishing to … is not allowed" error and never reaches `tool:started`.

The harness runs no MCPL servers, so the framework never builds a real `ChannelRegistry` — which is fine for the public dispatch path (it guards `channel_*` routing on the registry existing, `framework.ts` `dispatchToolCall`), but the home-defaulted publish gets past the fence and would NPE on the null registry. The test stubs that downstream boundary (`handleChannelToolCall` + `stopAll` no-ops), since the unit under test is the fence above it.

Test-only, no `src/` changes, no changelog entry per the test-only rule.

## Tests

- `npm test` on ubuntu (Node 24): **603 pass / 0 fail** (baseline on `main`: 602 / 0; the +1 is this PR's).
- Both asserts verified to fail on a broken fence, independently: removing the home-default rewrite fails "(a) omitted channelId is rewritten to the home channel"; removing the foreign-reject branch fails "(b) foreign publish should be rejected".
- `npx tsc --noEmit`: clean.

## Out of scope

The issue also notes the existing fence test reaches through `as unknown as { dispatchChannelToolCall }` and validates the guard in isolation rather than a fork's real tool call being routed through it. This PR keeps that pattern (consistent with the file); routing a real synthesized tool call end-to-end would need an MCPL-backed harness — happy to look at that separately if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)