### PR TITLE
fix(workspace): mount containment checks use POSIX separators — every in-mount path rejected as traversal on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ Releases up to and including 0.7.3 predate this file; for their contents see
 
 ### Fixed
 
+- **Workspace mounts are usable on native Windows.** The mount containment
+  checks (the `parsePath` traversal guard and sync's `safePath`) appended a
+  POSIX `'/'` to the mount root before prefix-matching, but `resolve()` emits
+  backslash-separated paths on Windows — so every legitimate in-mount path
+  was rejected: read/write threw "Path traversal detected" and `syncFromFs`
+  reported every real file as outside its mount (`ls` was unaffected, making
+  a populated mount look empty). Containment now compares with the platform
+  separator; the sync walker and the watcher additionally normalize relative
+  paths to the `'/'`-separated logical form used everywhere else. No
+  behavior change on POSIX.
+
 - Discord downtime history is written to Context Manager in chronological order while newest-message tracking retains Discord order.
 
 - Rapid external messages now retain arrival order while remaining prioritized

--- a/src/modules/workspace/index.ts
+++ b/src/modules/workspace/index.ts
@@ -1134,10 +1134,12 @@ export class WorkspaceModule implements Module {
       throw new Error(`Unknown mount: "${mountName}". Available: ${[...this.mounts.keys()].join(', ')}`);
     }
 
-    // Path traversal guard (CWE-22): ensure resolved path stays within mount
+    // Path traversal guard (CWE-22): ensure resolved path stays within mount.
+    // Containment must compare with the PLATFORM separator (isContainedPath):
+    // resolve() emits backslashes on Windows, so a '/'-suffixed root never
+    // prefix-matches there and every in-mount path was rejected as traversal.
     const resolved = resolve(mount.config.path, relativePath);
-    const mountRoot = mount.config.path.endsWith('/') ? mount.config.path : mount.config.path + '/';
-    if (resolved !== mount.config.path && !resolved.startsWith(mountRoot)) {
+    if (!isContainedPath(mount.config.path, resolved)) {
       throw new Error(`Path traversal detected: "${path}" resolves outside mount "${mountName}"`);
     }
 

--- a/src/modules/workspace/sync.ts
+++ b/src/modules/workspace/sync.ts
@@ -8,7 +8,7 @@
 
 import { createHash } from 'node:crypto';
 import { readFile, writeFile, mkdir, readdir, stat, access } from 'node:fs/promises';
-import { join, dirname, relative, resolve } from 'node:path';
+import { join, dirname, relative, resolve, sep } from 'node:path';
 import type { JsStore, JsTreeEntry } from '@animalabs/chronicle';
 import type { MountState } from './types.js';
 
@@ -19,8 +19,11 @@ export const DEFAULT_MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
  * Returns the absolute path, or null if the path is outside the mount.
  */
 function safePath(mountPath: string, relativePath: string): string | null {
+  // Compare with the PLATFORM separator: resolve() emits backslashes on
+  // Windows, so a '/'-suffixed root never prefix-matches there and every
+  // in-mount path was reported as outside the mount.
   const resolved = resolve(mountPath, relativePath);
-  const root = mountPath.endsWith('/') ? mountPath : mountPath + '/';
+  const root = mountPath.endsWith(sep) ? mountPath : mountPath + sep;
   if (resolved !== mountPath && !resolved.startsWith(root)) {
     return null;
   }
@@ -299,7 +302,10 @@ async function walkDirectory(
       if (results.length >= maxFiles) break;
 
       const fullPath = join(dir, entry.name);
-      const relativePath = relative(basePath, fullPath);
+      // Logical workspace paths are '/'-separated everywhere (mount-prefixed
+      // paths, chronicle tree paths); node's relative() emits backslashes on
+      // Windows, so normalize. No-op on POSIX (sep === '/').
+      const relativePath = relative(basePath, fullPath).split(sep).join('/');
 
       // Check ignore patterns (simple glob matching)
       if (shouldIgnore(relativePath, entry.name, ignorePatterns)) continue;

--- a/src/modules/workspace/watcher.ts
+++ b/src/modules/workspace/watcher.ts
@@ -7,7 +7,7 @@
 
 import { watch, type FSWatcher } from 'chokidar';
 import { mkdirSync, statSync } from 'node:fs';
-import { basename } from 'node:path';
+import { basename, sep } from 'node:path';
 import { type MountConfig } from './types.js';
 
 export type FsOp = 'created' | 'modified' | 'deleted';
@@ -363,20 +363,23 @@ export class MountWatcher {
   }
 
   private toRelative(absolutePath: string): string | null {
-    const base = this.config.path.endsWith('/')
+    // Chokidar hands back platform-separated absolute paths; compare with
+    // the platform separator and normalize the result to the '/'-separated
+    // logical form the rest of the workspace uses. No-op on POSIX.
+    const base = this.config.path.endsWith(sep)
       ? this.config.path
-      : this.config.path + '/';
+      : this.config.path + sep;
     if (absolutePath.startsWith(base)) {
-      return absolutePath.slice(base.length);
+      return absolutePath.slice(base.length).split(sep).join('/');
     }
     return null;
   }
 
   private isRootPath(absolutePath: string): boolean {
-    const root = this.config.path.endsWith('/')
+    const root = this.config.path.endsWith(sep)
       ? this.config.path.slice(0, -1)
       : this.config.path;
-    const candidate = absolutePath.endsWith('/')
+    const candidate = absolutePath.endsWith(sep)
       ? absolutePath.slice(0, -1)
       : absolutePath;
     return candidate === root;

--- a/test/workspace-path-containment.test.ts
+++ b/test/workspace-path-containment.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Mount containment on Windows (path-separator regression).
+ *
+ * The mount boundary checks (parsePath traversal guard, sync's safePath)
+ * appended a POSIX '/' to the mount root before prefix-matching, but
+ * node's resolve() emits backslash-separated paths on Windows — so the
+ * prefix never matched and EVERY legitimate in-mount path was rejected:
+ * read/write threw "Path traversal detected" and syncFromFs reported every
+ * real file as outside its mount. ls was unaffected (tree listing takes a
+ * different path), which made a populated mount look empty-but-haunted.
+ *
+ * These tests drive the public tool surface over a real tmpdir mount, so
+ * they exercise the platform's actual separators: on Windows they fail
+ * against the unfixed guards; on POSIX the fix is a no-op and they pin
+ * the behavior either way. The traversal rejection itself is asserted
+ * too — the fix must not widen the boundary.
+ */
+
+import test, { type TestContext } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { JsStore } from '@animalabs/chronicle';
+import { WorkspaceModule } from '../src/modules/workspace/index.js';
+import type { ToolResult } from '../src/types/events.js';
+
+function makeWorkspace(t: TestContext) {
+  const root = mkdtempSync(join(tmpdir(), 'af-path-containment-'));
+  const mountDir = join(root, 'mount');
+  mkdirSync(mountDir, { recursive: true });
+  const store = JsStore.openOrCreate({ path: join(root, 'workspace.chronicle') });
+  const workspace = new WorkspaceModule({
+    mounts: [{ name: 'work', path: mountDir, mode: 'read-write', watch: 'never' }],
+  });
+  workspace.initStore(store);
+  t.after(() => {
+    store.close();
+    rmSync(root, { recursive: true, force: true });
+  });
+  return { mountDir, workspace };
+}
+
+function call(workspace: WorkspaceModule, name: string, input: Record<string, unknown>): Promise<ToolResult> {
+  return workspace.handleToolCall({ id: `call-${name}`, name, input });
+}
+
+function resultText(result: ToolResult): string {
+  return typeof result.data === 'string' ? result.data : JSON.stringify(result.data ?? '');
+}
+
+test('sync + read reach a real file inside the mount', async (t) => {
+  const { mountDir, workspace } = makeWorkspace(t);
+  writeFileSync(join(mountDir, 'hello.txt'), 'hola desde el mount\n');
+
+  const sync = await call(workspace, 'sync', { mount: 'work' });
+  assert.equal(sync.success, true, `sync should succeed: ${sync.error ?? ''}`);
+  assert.ok(
+    !resultText(sync).includes('outside'),
+    'sync must not report an in-mount file as outside the mount',
+  );
+
+  const read = await call(workspace, 'read', { path: 'work/hello.txt' });
+  assert.equal(read.success, true, `read should succeed: ${read.error ?? ''}`);
+  assert.ok(resultText(read).includes('hola desde el mount'), 'read returns the file content');
+});
+
+test('write lands inside the mount', async (t) => {
+  const { workspace } = makeWorkspace(t);
+  const write = await call(workspace, 'write', { path: 'work/out.txt', content: 'producto' });
+  assert.equal(write.success, true, `write should succeed: ${write.error ?? ''}`);
+
+  const read = await call(workspace, 'read', { path: 'work/out.txt' });
+  assert.equal(read.success, true);
+  assert.ok(resultText(read).includes('producto'));
+});
+
+test('nested files sync and read under /-separated logical paths', async (t) => {
+  const { mountDir, workspace } = makeWorkspace(t);
+  mkdirSync(join(mountDir, 'sub', 'deep'), { recursive: true });
+  writeFileSync(join(mountDir, 'sub', 'deep', 'nested.txt'), 'anidado\n');
+
+  const sync = await call(workspace, 'sync', { mount: 'work' });
+  assert.equal(sync.success, true, `sync should succeed: ${sync.error ?? ''}`);
+
+  // Logical workspace paths are '/'-separated everywhere — the walker must
+  // not leak platform separators into tree paths (relative() emits
+  // backslashes on Windows).
+  const ls = await call(workspace, 'ls', { path: 'work', recursive: true });
+  assert.equal(ls.success, true);
+  const listing = resultText(ls);
+  assert.ok(listing.includes('sub/deep/nested.txt'), `listing should use '/' paths, got: ${listing.slice(0, 300)}`);
+  assert.ok(!listing.includes('sub\\deep'), 'listing must not contain backslash-separated paths');
+
+  const read = await call(workspace, 'read', { path: 'work/sub/deep/nested.txt' });
+  assert.equal(read.success, true, `nested read should succeed: ${read.error ?? ''}`);
+  assert.ok(resultText(read).includes('anidado'));
+});
+
+test('traversal outside the mount is still rejected', async (t) => {
+  const { workspace } = makeWorkspace(t);
+
+  const read = await call(workspace, 'read', { path: 'work/../escape.txt' });
+  assert.equal(read.success, false, 'escaping read must be rejected');
+  assert.match(read.error ?? '', /traversal/i);
+
+  const write = await call(workspace, 'write', { path: 'work/../../evil.txt', content: 'nope' });
+  assert.equal(write.success, false, 'escaping write must be rejected');
+  assert.match(write.error ?? '', /traversal/i);
+});


### PR DESCRIPTION
## Problem

The workspace mount containment checks append a POSIX `'/'` to the mount root before prefix-matching, but node's `resolve()` emits backslash-separated paths on Windows — the prefix never matches, so **every legitimate in-mount path is rejected**: `read`/`write` throw `Path traversal detected` and `syncFromFs` reports every real file as outside its mount. `ls` takes a different code path and still lists the tree, which makes a populated mount look mounted-but-unreadable.

Found running connectome-host on native Windows: a file sitting in the `input` mount was visible to `ls` but unreadable and unsyncable. Same Windows-portability family as connectome-host #87.

## Changes

- `index.ts` `parsePath`: the traversal guard now uses the **existing sep-aware `isContainedPath` helper** (defined ~1000 lines above in the same file — the guard predates it or never adopted it).
- `sync.ts` `safePath`: same duplicated guard, same fix (platform `sep`).
- `sync.ts` walker: `relative()` emits backslashes on Windows; normalize to the `'/'`-separated logical form used by mount-prefixed and chronicle tree paths everywhere else. No-op on POSIX.
- `watcher.ts` `toRelative`/`isRootPath`: platform-sep comparison, `'/'`-normalized output (chokidar hands back platform-separated absolute paths).
- Changelog entry under `## Unreleased → ### Fixed`, same commit.

No behavior change on POSIX (`sep === '/'` makes every change literal-identical to the old code paths).

## Tests

- New `test/workspace-path-containment.test.ts` drives the public tool surface (`sync`/`read`/`write`/`ls`) over a real tmpdir mount, so it exercises the platform's actual separators: in-mount read/write/sync succeed, nested files keep `'/'` logical paths (no backslash leakage), and **escaping paths are still rejected** — the fix must not widen the boundary.
- On native Windows against unfixed `main`: **3 of 4 fail** (in-mount read, write, nested sync); the traversal-rejection test passes on both, pinning that the boundary didn't move.
- `npm test` on ubuntu (Node 24): **606 pass / 0 fail** (baseline on `main`: 602 / 0; the +4 are this PR's).
- On native Windows with the fix: the 4 new tests pass, and the original repro (connectome-host, real recipe, `workspace--read` on a file in the `input` mount) now succeeds end-to-end.
- `npx tsc --noEmit`: clean.

## Not verified

- CI runs ubuntu/macos only, where this change is a designed no-op — the Windows evidence above is from a native Windows 11 box (Node 24 / bun 1.4).
- The watcher fix follows the same pattern but was exercised only by inspection plus the existing watcher suite; the repro host runs mounts with `watch: 'never'`.

## Out of scope

Other Windows-portability gaps in the suite itself (pre-existing test failures/hangs on native Windows unrelated to workspace) — same vein as connectome-host #87, worth a separate sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)