### PR TITLE
feat: tool-only disabled prose routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Releases up to and including 0.7.3 predate this file; for their contents see
 
 ## Unreleased
 
+### Added
+
+- `proseRouting: "disabled"` keeps all generated plain prose private and permits external publication only through explicit tools, preventing ambient locus capture from publishing continuity output.
+
 ### Fixed
 
 - Discord downtime history is written to Context Manager in chronological order while newest-message tracking retains Discord order.

--- a/docs/disabled-prose-routing.md
+++ b/docs/disabled-prose-routing.md
@@ -1,0 +1,17 @@
+# Disabled prose routing
+
+`proseRouting: "disabled"` is a fail-closed publication mode for residents who
+want every external utterance to be an explicit tool action.
+
+- Generated plain prose is never sent to a channel, even with a `>>` prefix.
+- Ambient traffic and channel opens cannot establish a publication locus.
+- Outgoing prose streaming and typing indicators are disabled.
+- Explicit publish tools (Discord/Portal sends, Eidoverse `say`, etc.) are unchanged.
+- Authored prose remains in Chronicle. At turn end, a private `[delivered] nothing`
+  receipt records how many prose segments were suppressed.
+- The mode injects no model-visible primer.
+- Sleep announcements remain private unless the resident sends one explicitly.
+
+This mode contains the continuity-summary locus leak tracked as Connectome Host #96.
+It differs from `explicit`: explicit mode permits `>>destination` prose envelopes;
+`disabled` permits publication only through tools.

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -67,7 +67,7 @@ export class Agent {
   /** Refusal auto-rewind policy (see AgentConfig.refusalHandling). */
   readonly refusalHandling: AgentConfig['refusalHandling'];
   /** Prose delivery mode (see AgentConfig.proseRouting). Default 'locus'. */
-  readonly proseRouting: 'locus' | 'explicit' | 'hybrid';
+  readonly proseRouting: 'locus' | 'explicit' | 'hybrid' | 'disabled';
   /** Prompt-cache TTL forwarded to the provider (see AgentConfig.cacheTtl). */
   readonly cacheTtl: NonNullable<AgentConfig['cacheTtl']>;
   /** Emit prompt-cache markers on requests (see AgentConfig.promptCaching). */

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -228,7 +228,7 @@ const isAddressedMessage = (
 // envelopes can never disagree on what is a prefix.
 
 /** One-time primer appended when an agent's proseRouting mode changes. */
-function proseModePrimer(mode: 'explicit' | 'hybrid' | 'locus'): string {
+function proseModePrimer(mode: 'explicit' | 'hybrid' | 'locus' | 'disabled'): string {
   if (mode === 'locus') {
     return '[prose-routing] Mode change: your plain text auto-routes to the ' +
       'conversational locus again. `>>` destination prefixes are no longer needed.';
@@ -3993,7 +3993,7 @@ export class AgentFramework {
           // updates lastAnnouncedLocus so the next turn's announce-on-change
           // diffs against what the agent was actually last told.
           if (
-            agent.proseRouting !== 'explicit' &&
+            (agent.proseRouting === 'locus' || agent.proseRouting === 'hybrid') &&
             !shouldEndTurn && !overBudget && currentState.stream
           ) {
             // Two signals qualify an injection to move the pin (n=6 + n=7):
@@ -5013,7 +5013,9 @@ export class AgentFramework {
     }
     const suppressedNote =
       suppressed > 0
-        ? `${suppressed} plain-speech segment(s) suppressed (explicit send in the same round — resend with a send tool if it was meant to be heard)`
+        ? agent.proseRouting === 'disabled'
+          ? `${suppressed} plain-speech segment(s) suppressed (proseRouting=disabled — publish only with an explicit send tool)`
+          : `${suppressed} plain-speech segment(s) suppressed (explicit send in the same round — resend with a send tool if it was meant to be heard)`
         : '';
     const text =
       shown.length > 0
@@ -5383,6 +5385,13 @@ export class AgentFramework {
       console.error('maybePrimeProseMode: state read/write failed:', err);
       return;
     }
+    // Disabled mode is intentionally silent: no model-visible routing prose.
+    // The resident publishes only through explicit tools. This contains
+    // continuity-summary locus leaks (Host #96).
+    if (mode === 'disabled') {
+      console.error(`[prose] ${agent.name}: disabled mode recorded (no primer injected)`);
+      return;
+    }
     try {
       const id = agent.getContextManager().addMessage(
         'user',
@@ -5525,10 +5534,10 @@ export class AgentFramework {
       this.turnProseSuppressed.delete(agent.name);
       this.proseHybridSuppressed.delete(agent.name);
       if (agent.proseRouting === 'hybrid') this.proseTargetPins.delete(agent.name);
-      if (agent.proseRouting === 'explicit') {
-        // Explicit prose routing: there is no locus. The model names every
-        // destination in-band (`>>` prefixes); the only turn state is the
-        // sticky target, reset for each fresh turn. No freeze, no announce.
+      if (agent.proseRouting === 'explicit' || agent.proseRouting === 'disabled') {
+        // Explicit and disabled prose routing have no inferred locus.
+        // Explicit mode uses a turn-scoped `>>` target; disabled mode has no
+        // prose target at all. Neither mode freezes or announces a locus.
         this.proseTargetPins.delete(agent.name);
         this.proseContinuations.delete(agent.name);
         this.midTurnInputSignals.delete(agent.name);
@@ -5759,9 +5768,11 @@ export class AgentFramework {
     //     sent here", which is true regardless of where the reply goes.
     //     Heartbeat/no-trigger explicit turns show no indicator.
     const typingChannel =
-      agent.proseRouting === 'explicit'
-        ? trigger?.channelId ?? null
-        : resolveTurnLocus();
+      agent.proseRouting === 'disabled'
+        ? null
+        : agent.proseRouting === 'explicit'
+          ? trigger?.channelId ?? null
+          : resolveTurnLocus();
     if (typingChannel) this.channelRegistry!.startTyping(typingChannel);
 
     // MCPL Spec 14.3 outgoing streaming: route text deltas to their
@@ -5791,7 +5802,7 @@ export class AgentFramework {
       turnIndex: 0,
       phase: 'started',
     });
-    const proseStream = this.channelRegistry
+    const proseStream = this.channelRegistry && agent.proseRouting !== 'disabled'
       ? new ProseStreamRouter({
           mode: agent.proseRouting === 'explicit' ? 'explicit' : agent.proseRouting === 'hybrid' ? 'hybrid' : 'locus',
           initialTarget: typingChannel,
@@ -5983,7 +5994,12 @@ export class AgentFramework {
                 liveProseRouting = true;
                 const roundSegments = splitProseSegments(assistantBlocks);
                 if (roundSegments.length > 0) {
-                  if (agent.proseRouting === 'hybrid') {
+                  if (agent.proseRouting === 'disabled') {
+                    console.error(
+                      `[routing] ${agent.name}: mid-turn prose NOT routed (proseRouting=disabled)`,
+                    );
+                    this.recordProseSuppression(agent.name, roundSegments.length);
+                  } else if (agent.proseRouting === 'hybrid') {
                     if (turnSilenced) {
                       this.recordProseSuppression(agent.name, roundSegments.length);
                     } else if (!hasSameRoundPrivateThink) {
@@ -6324,7 +6340,10 @@ export class AgentFramework {
                 .join('\n')
                 .trim();
               if (speechText) {
-                if (agent.proseRouting === 'hybrid') {
+                if (agent.proseRouting === 'disabled') {
+                  console.error(`[routing] ${agent.name}: text-only prose NOT routed (proseRouting=disabled)`);
+                  this.recordProseSuppression(agent.name, 1);
+                } else if (agent.proseRouting === 'hybrid') {
                   const locus = resolveTurnLocus();
                   console.error(`[prose] ${agent.name}: text-only turn -> hybrid prose gateway`);
                   try {
@@ -6391,7 +6410,14 @@ export class AgentFramework {
               // the chain may still be flushing earlier rounds' posts.
               await turnSpeechChain;
 
-              if (agent.proseRouting === 'hybrid') {
+              if (agent.proseRouting === 'disabled') {
+                if (segments.length > 0) {
+                  console.error(
+                    `[routing] ${agent.name}: tool-call trailing prose NOT routed (proseRouting=disabled)`,
+                  );
+                  this.recordProseSuppression(agent.name, segments.length);
+                }
+              } else if (agent.proseRouting === 'hybrid') {
                 if (silenced && segments.length > 0) {
                   this.recordProseSuppression(agent.name, segments.length);
                 } else if (segments.length > 0) {
@@ -10080,7 +10106,7 @@ export class AgentFramework {
           if (opened) {
             this.activeTriggerChannels.set(agentName, opened);
             const openerAgent = this.agents.get(agentName);
-            if (openerAgent && openerAgent.proseRouting !== 'explicit') {
+            if (openerAgent && (openerAgent.proseRouting === 'locus' || openerAgent.proseRouting === 'hybrid')) {
               this.turnLocusPins.set(agentName, opened);
               this.lastAnnouncedLocus.set(agentName, opened);
               result = {
@@ -10298,7 +10324,9 @@ export class AgentFramework {
     if (announce && this.channelRegistry) {
       const text = input.message ?? `💤 Going quiet for ${human}. I'll still see messages, but won't respond until I wake.`;
       const agent = this.agents.get(agentName);
-      if (agent?.proseRouting === 'explicit') {
+      if (agent?.proseRouting === 'disabled') {
+        console.error(`[sleep] ${agentName}: proseRouting=disabled — sleep announcement not posted`);
+      } else if (agent?.proseRouting === 'explicit') {
         // Explicit mode: announce to the turn's sticky prose target if the
         // model has set one; otherwise stay quiet — never guess a channel.
         const target = this.proseTargetPins.get(agentName);

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -180,8 +180,10 @@ export interface AgentConfig {
    * - 'hybrid': unprefixed prose keeps locus routing; `>>>destination` routes
    *   that publication envelope through the same authorized resolver.
    *   See docs/hybrid-prose-routing.md.
+   * - 'disabled': generated prose is never published. Only explicit tools may
+   *   send externally; prose remains in Chronicle with a private suppression receipt.
    */
-  proseRouting?: 'locus' | 'explicit' | 'hybrid';
+  proseRouting?: 'locus' | 'explicit' | 'hybrid' | 'disabled';
 }
 
 /** The intentionally small set of agent settings that may change in-process. */

--- a/test/explicit-prose-routing.test.ts
+++ b/test/explicit-prose-routing.test.ts
@@ -112,7 +112,7 @@ describe('explicit prose routing', () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  async function createFramework(mode: 'explicit' | 'hybrid' = 'explicit'): Promise<AgentFramework> {
+  async function createFramework(mode: 'explicit' | 'hybrid' | 'disabled' = 'explicit'): Promise<AgentFramework> {
     const framework = await AgentFramework.create({
       storePath: join(tempDir, 'test.chronicle'),
       membrane: membrane.asMembrane(),
@@ -444,6 +444,58 @@ describe('explicit prose routing', () => {
     const texts = cm.getAllMessages().flatMap(m => m.content).filter(b => b.type === 'text').map(b => (b as { text: string }).text);
     assert.ok(texts.includes(authored));
     assert.ok(texts.some(t => t.startsWith('[delivered] nothing') && t.includes('suppressed')));
+    await framework.stop();
+  });
+
+
+  it('disabled mode suppresses text-only prose without a bounce, primer, or channel delivery', async () => {
+    const authored = 'Internal continuity summary that must never publish.';
+    membrane.pushResponse(createMockResponse([{ type: 'text', text: authored }] as ContentBlock[]));
+    const framework = await createFramework('disabled');
+    const routed = stubRegistry(framework);
+    const sources: string[] = [];
+    framework.onTrace((e) => {
+      const ev = e as { type: string; source?: string };
+      if (ev.type === 'message:added' && ev.source) sources.push(ev.source);
+    });
+
+    trigger(framework);
+    await framework.runUntilIdle();
+
+    assert.deepEqual(routed, [], 'disabled prose never reaches a channel');
+    assert.equal(sources.includes('prose-bounce'), false, 'disabled prose does not bounce');
+    assert.equal(sources.includes('prose-routing-primer'), false, 'disabled mode injects no model-visible primer');
+    const texts = framework.getAgent('assistant')!.getContextManager().getAllMessages()
+      .flatMap(m => m.content).filter(b => b.type === 'text').map(b => (b as { text: string }).text);
+    assert.ok(texts.includes(authored), 'authored prose remains in Chronicle');
+    assert.ok(texts.some(t => t.includes('[delivered] nothing') && t.includes('proseRouting=disabled')),
+      'private suppression receipt explains the unsent prose');
+
+    await framework.stop();
+  });
+
+  it('disabled mode ignores destination prefixes but explicit publish tools still execute', async () => {
+    membrane.pushResponse(createMockResponse([
+      { type: 'text', text: '>>#alpha this prefix must not bypass disabled mode' },
+      { type: 'tool_use', id: 'd1', name: 'robot--say', input: { text: 'published explicitly' } },
+    ] as ContentBlock[], 'tool_use'));
+    membrane.pushResponse(createMockResponse([
+      { type: 'text', text: 'trailing prose must also remain private' },
+    ] as ContentBlock[]));
+    const framework = await createFramework('disabled');
+    const routed = stubRegistry(framework);
+
+    trigger(framework);
+    await framework.runUntilIdle();
+
+    assert.deepEqual(routed, [], 'neither prefixed nor trailing prose routed');
+    assert.equal(module.calls.length, 1, 'explicit tool call executed');
+    assert.equal(module.calls[0]!.name, 'say');
+    const texts = framework.getAgent('assistant')!.getContextManager().getAllMessages()
+      .flatMap(m => m.content).filter(b => b.type === 'text').map(b => (b as { text: string }).text);
+    assert.ok(texts.some(t => t.includes('[delivered] nothing') && t.includes('2 plain-speech segment(s) suppressed')),
+      'one receipt accounts for mid-turn and trailing prose');
+
     await framework.stop();
   });
 


### PR DESCRIPTION
## Summary
- add `proseRouting: "disabled"`
- suppress text-only, mid-turn, trailing, streaming, typing, channel-open locus, and sleep-announcement prose
- preserve authored prose plus a private suppression receipt
- leave explicit publish tools unchanged

## Evidence
- focused routing/integration matrix: 85/85
- disabled discriminators: branch 2/2; copied to base 0/2
- prose stream router: 16/16
- typecheck/build/diff-check clean
- broad source suite: 583 pass; standing unrelated runtime/harness failures remain
