### PR TITLE
fix(provider): defer org acceleration retries into fresh primary compile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Releases up to and including 0.7.3 predate this file; for their contents see
 
 ### Fixed
 
+- Anthropic organization-acceleration 429s now enter a per-residence provider cooldown instead of immediate same-window retries: later arrivals are retained for one fresh compile after the quiet window, local Context Manager maintenance waits behind the primary lane, and capacity errors never enter the poisoned-history breaker (AF #114 bounded first slice).
+
 - Discord downtime history is written to Context Manager in chronological order while newest-message tracking retains Discord order.
 
 - Rapid external messages now retain arrival order while remaining prioritized

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -475,6 +475,53 @@ const DEFAULT_MAINTENANCE_INTERVAL_MS = 5000;
 /** Bound one pass so a large backlog yields to inference and other agents. */
 const MAINTENANCE_TICKS_PER_PASS = 8;
 
+/** Local per-residence provider admission (AF #114 bounded first slice). */
+interface LocalProviderGate {
+  primaryDepth: number;
+  primaryPending: boolean;
+  auxiliaryInFlight: number;
+  auxiliaryWaiters: Array<() => void>;
+  idleWaiters: Array<() => void>;
+  deferredAuxiliary: number;
+}
+interface ProviderAccelerationCooldown {
+  startedAt: number;
+  until: number;
+  timer: ReturnType<typeof setTimeout>;
+  heldRequests: InferenceRequest[];
+  reason: string;
+  failures: number;
+}
+interface ProviderAccelerationRecovery {
+  startedAt: number;
+  releasedAt?: number;
+  failures: number;
+  heldRequests: number;
+  reason: string;
+}
+interface ProviderAccelerationReceipt {
+  startedAt: number;
+  releasedAt: number;
+  completedAt: number;
+  cooldownMs: number;
+  waitedMs: number;
+  failures: number;
+  heldRequests: number;
+  messageCount: number;
+  toolCount: number;
+  stopReason: string;
+}
+const PROVIDER_ACCELERATION_DEFAULT_COOLDOWN_MS = 65_000;
+const PROVIDER_ACCELERATION_MAX_COOLDOWN_MS = 10 * 60_000;
+const PROVIDER_ACCELERATION_JITTER_MS = 5_000;
+function isOrganizationAccelerationRateLimit(error: Error): error is MembraneError {
+  if (!(error instanceof MembraneError) || error.type !== 'rate_limit') return false;
+  return (
+    /organization(?:'s)?[^\n]{0,120}maximum(?:\s+usage)?\s+increase\s+rate/i.test(error.message) ||
+    /organization(?:'s)?[^\n]{0,120}acceleration(?:\s+limit)?/i.test(error.message)
+  );
+}
+
 /**
  * Extract fields the EventGate cares about from a ProcessEvent. The set of
  * event variants that carry `content`/`mount`/`paths`/`metadata` is open-ended
@@ -623,6 +670,13 @@ export class AgentFramework {
   private maintenanceRunId = 0;
   private currentMaintenanceRun: ContextMaintenanceRun | null = null;
   private maintenanceHistory: ContextMaintenanceRun[] = [];
+  private providerGates: Map<string, LocalProviderGate> = new Map();
+  private providerAccelerationCooldowns: Map<string, ProviderAccelerationCooldown> = new Map();
+  private providerAccelerationRecoveries: Map<string, ProviderAccelerationRecovery> = new Map();
+  private providerAccelerationLastRecovery: Map<string, ProviderAccelerationReceipt> = new Map();
+  private providerAccelerationDefaultCooldownMs = PROVIDER_ACCELERATION_DEFAULT_COOLDOWN_MS;
+  private providerAccelerationJitterMs = PROVIDER_ACCELERATION_JITTER_MS;
+  private providerAdmissionClosed = false;
   /** Last time we reported stale (busy-requeued) inference requests, per agent. */
   private staleWarnAt = new Map<string, number>();
   /** Per-agent last inference activity (epoch ms), for /healthz + doctor tooling. */
@@ -1197,6 +1251,7 @@ export class AgentFramework {
     }
 
     this.running = true;
+    this.providerAdmissionClosed = false;
     this.loopPromise = this.runLoop();
 
     // Start periodic sync timer (if enabled)
@@ -1226,6 +1281,7 @@ export class AgentFramework {
    */
   async stop(): Promise<void> {
     this.running = false;
+    this.providerAdmissionClosed = true;
     this.queue.close();
 
     // Kill running code_execution scripts before cancelling streams: a
@@ -1246,6 +1302,9 @@ export class AgentFramework {
       record.runner.dispose();
     }
     this.backgroundScripts.clear();
+
+    // A stopped host must never hang behind its own cooldown.
+    this.cancelProviderAdmission();
 
     // Cancel all active streams
     for (const agent of this.agents.values()) {
@@ -1312,6 +1371,138 @@ export class AgentFramework {
    * schemas are absent. Passes never overlap; each agent gets a bounded drain
    * so maintenance cannot monopolize the framework event loop.
    */
+  private providerGate(agentName: string): LocalProviderGate {
+    let gate = this.providerGates.get(agentName);
+    if (!gate) {
+      gate = { primaryDepth: 0, primaryPending: false, auxiliaryInFlight: 0,
+        auxiliaryWaiters: [], idleWaiters: [], deferredAuxiliary: 0 };
+      this.providerGates.set(agentName, gate);
+    }
+    return gate;
+  }
+  private providerGateBlocked(agentName: string): boolean {
+    const gate = this.providerGates.get(agentName);
+    return (gate?.primaryDepth ?? 0) > 0 || (gate?.primaryPending ?? false) ||
+      this.providerAccelerationCooldowns.has(agentName);
+  }
+  private acquirePrimaryProviderGate(agentName: string): void {
+    const gate = this.providerGate(agentName); gate.primaryPending = false; gate.primaryDepth++;
+  }
+  private releasePrimaryProviderGate(agentName: string): void {
+    const gate = this.providerGate(agentName); gate.primaryDepth = Math.max(0, gate.primaryDepth - 1);
+    this.flushAuxiliaryAdmission(agentName);
+  }
+  private flushAuxiliaryAdmission(agentName: string): void {
+    const gate = this.providerGate(agentName);
+    if (gate.primaryDepth > 0 || gate.primaryPending || this.providerAccelerationCooldowns.has(agentName)) return;
+    for (const resolve of gate.auxiliaryWaiters.splice(0)) resolve();
+  }
+  private async waitForAuxiliaryIdle(agentName: string): Promise<void> {
+    const gate = this.providerGate(agentName);
+    if (gate.auxiliaryInFlight === 0) return;
+    await new Promise<void>((resolve) => gate.idleWaiters.push(resolve));
+  }
+  private async withAuxiliaryAdmission<T>(agentName: string, run: () => Promise<T>): Promise<T> {
+    const gate = this.providerGate(agentName);
+    if (this.providerGateBlocked(agentName)) {
+      gate.deferredAuxiliary++;
+      try {
+        await new Promise<void>((resolve) => gate.auxiliaryWaiters.push(resolve));
+      } finally {
+        gate.deferredAuxiliary = Math.max(0, gate.deferredAuxiliary - 1);
+      }
+    }
+    if (this.providerAdmissionClosed) {
+      throw new Error(`Provider admission closed while stopping (${agentName})`);
+    }
+    gate.auxiliaryInFlight++;
+    try { return await run(); }
+    finally {
+      gate.auxiliaryInFlight = Math.max(0, gate.auxiliaryInFlight - 1);
+      if (gate.auxiliaryInFlight === 0) for (const resolve of gate.idleWaiters.splice(0)) resolve();
+    }
+  }
+  private auxiliaryMembraneFor(agentName: string): Membrane {
+    const target = this.membrane as unknown as Record<PropertyKey, unknown>;
+    return new Proxy(target, { get: (obj, prop, receiver) => {
+      const value = Reflect.get(obj, prop, receiver);
+      if (prop === 'complete' && typeof value === 'function') {
+        return (...args: unknown[]) => this.withAuxiliaryAdmission(
+          agentName, () => Reflect.apply(value, this.membrane, args) as Promise<unknown>);
+      }
+      return typeof value === 'function' ? value.bind(this.membrane) : value;
+    }}) as unknown as Membrane;
+  }
+  private accelerationCooldownMs(agentName: string, error: MembraneError): number {
+    const base = error.retryAfterMs ?? this.providerAccelerationDefaultCooldownMs;
+    let hash = 0; for (const ch of agentName) hash = ((hash * 31) + ch.charCodeAt(0)) >>> 0;
+    const jitter = this.providerAccelerationJitterMs > 0 ? hash % (this.providerAccelerationJitterMs + 1) : 0;
+    return Math.min(PROVIDER_ACCELERATION_MAX_COOLDOWN_MS, Math.max(1_000, base) + jitter);
+  }
+  private sameInferenceRequest(a: InferenceRequest, b: InferenceRequest): boolean {
+    return a.agentName === b.agentName && a.reason === b.reason && a.source === b.source &&
+      a.timestamp === b.timestamp && a.channelId === b.channelId;
+  }
+  private holdProviderAcceleration(agent: Agent, error: Error, trigger?: InferenceRequest): boolean {
+    if (this.ephemeralRuns.has(agent.name) || this.conversationAgentHomes.has(agent.name) || !isOrganizationAccelerationRateLimit(error)) return false;
+    const now = Date.now(); const delayMs = this.accelerationCooldownMs(agent.name, error);
+    const existing = this.providerAccelerationCooldowns.get(agent.name);
+    const held = existing?.heldRequests ?? [];
+    if (trigger && !held.some((r) => this.sameInferenceRequest(r, trigger))) held.push(trigger);
+    if (existing) clearTimeout(existing.timer);
+    const timer = setTimeout(() => this.releaseProviderAccelerationCooldown(agent.name), delayMs); timer.unref?.();
+    this.providerAccelerationCooldowns.set(agent.name, { startedAt: existing?.startedAt ?? now,
+      until: now + delayMs, timer, heldRequests: held, reason: error.message,
+      failures: (existing?.failures ?? 0) + 1 });
+    const gate = this.providerGate(agent.name); gate.primaryPending = true;
+    this.providerAccelerationRecoveries.set(agent.name, { startedAt: existing?.startedAt ?? now,
+      failures: (existing?.failures ?? 0) + 1, heldRequests: held.length, reason: error.message });
+    console.error(`[provider-cooldown] agent=${agent.name} organization acceleration 429 — ` +
+      `holding primary/auxiliary for ${delayMs}ms; ${held.length} request(s) retained`);
+    return true;
+  }
+  private releaseProviderAccelerationCooldown(agentName: string): void {
+    const cooldown = this.providerAccelerationCooldowns.get(agentName); if (!cooldown) return;
+    clearTimeout(cooldown.timer); this.providerAccelerationCooldowns.delete(agentName);
+    const recovery = this.providerAccelerationRecoveries.get(agentName);
+    if (recovery) { recovery.releasedAt = Date.now(); recovery.heldRequests = cooldown.heldRequests.length; }
+    const requests = cooldown.heldRequests.length > 0 ? cooldown.heldRequests : [{ agentName,
+      reason: 'provider-acceleration-retry', source: 'framework', timestamp: Date.now() } satisfies InferenceRequest];
+    this.pendingRequests.push(...requests);
+    console.error(`[provider-cooldown] agent=${agentName} released after ${Date.now() - cooldown.startedAt}ms — ` +
+      `fresh compile queued with ${requests.length} retained request(s)`);
+  }
+  private recordProviderAccelerationRecovery(agent: Agent, request: NormalizedRequest | undefined, stopReason: string): void {
+    const recovery = this.providerAccelerationRecoveries.get(agent.name); if (!recovery?.releasedAt) return;
+    this.providerAccelerationRecoveries.delete(agent.name);
+    const completedAt = Date.now();
+    const receipt: ProviderAccelerationReceipt = {
+      startedAt: recovery.startedAt,
+      releasedAt: recovery.releasedAt,
+      completedAt,
+      cooldownMs: recovery.releasedAt - recovery.startedAt,
+      waitedMs: completedAt - recovery.startedAt,
+      failures: recovery.failures,
+      heldRequests: recovery.heldRequests,
+      messageCount: request?.messages.length ?? 0,
+      toolCount: request?.tools?.length ?? 0,
+      stopReason,
+    };
+    this.providerAccelerationLastRecovery.set(agent.name, receipt);
+    // Operational receipt only: provider admission must never author resident memory.
+    console.error(`[provider-cooldown] recovered ${JSON.stringify({ agent: agent.name, ...receipt })}`);
+  }
+  private cancelProviderAdmission(): void {
+    for (const cooldown of this.providerAccelerationCooldowns.values()) clearTimeout(cooldown.timer);
+    this.providerAccelerationCooldowns.clear(); this.providerAccelerationRecoveries.clear();
+    for (const gate of this.providerGates.values()) {
+      gate.primaryDepth = 0; gate.primaryPending = false;
+      for (const resolve of gate.auxiliaryWaiters.splice(0)) resolve();
+      for (const resolve of gate.idleWaiters.splice(0)) resolve();
+    }
+    this.providerGates.clear();
+  }
+
   private startQueuedMaintenance(): void {
     if (this.maintenancePass || !this.running) return;
     const pass = this.runQueuedMaintenance().catch((error) => {
@@ -1338,6 +1529,7 @@ export class AgentFramework {
       const cm = agent.getContextManager();
       const tools = this.getToolsForAgent(agent.name).filter((tool) => agent.canUseTool(tool.name));
       cm.setToolDefinitions(tools);
+      if (this.providerGateBlocked(agent.name)) return [];
       if (cm.isReady()) return [];
       const pending = cm.getPendingWork()?.description;
       const progress = this.contextProgress(cm);
@@ -3738,7 +3930,9 @@ export class AgentFramework {
       store: this.store,
       namespace: `agents/${config.name}`,
       strategy: config.strategy ?? new PassthroughStrategy(),
-      membrane: this.membrane,
+      // Context Manager complete() calls are auxiliary work; the primary
+      // streaming agent keeps the original Membrane.
+      membrane: this.auxiliaryMembraneFor(config.name),
       debugLogContext: !!process.env.DEBUG_CONTEXT,
     });
 
@@ -4462,6 +4656,9 @@ export class AgentFramework {
       isolate: true,
       // Strategy instances are stateful — never share the template's.
       strategy: router.strategyFactory?.() ?? new PassthroughStrategy(),
+      // Dynamic conversation forks retain the established provider policy in
+      // this bounded first slice. Provider cooldown ownership belongs to the
+      // persistent resident only; generation-unique forks must not leak gates.
       membrane: this.membrane,
       debugLogContext: !!process.env.DEBUG_CONTEXT,
     });
@@ -4845,7 +5042,8 @@ export class AgentFramework {
     this.pendingRequests = [];
 
     // Check each agent
-    for (const [agentName, requests] of requestsByAgent) {
+    for (const [agentName, groupedRequests] of requestsByAgent) {
+      let requests = groupedRequests;
       const agent = this.agents.get(agentName);
       if (!agent) {
         // Agent not found — request is orphaned. Emit warning and drop.
@@ -4859,6 +5057,28 @@ export class AgentFramework {
         });
         console.error(`[inference-dropped] agent=${agentName} reason=agent_not_found requests=${requests.length}`);
         continue;
+      }
+
+      const providerCooldown = this.providerAccelerationCooldowns?.get(agentName);
+      if (providerCooldown) {
+        if (now < providerCooldown.until) {
+          for (const req of requests) {
+            if (!providerCooldown.heldRequests.some((r) => this.sameInferenceRequest(r, req))) {
+              providerCooldown.heldRequests.push(req);
+            }
+          }
+          const recovery = this.providerAccelerationRecoveries.get(agentName);
+          if (recovery) recovery.heldRequests = providerCooldown.heldRequests.length;
+          // The timer owns release. Do not hot-poll these requests.
+          continue;
+        }
+        // Timers can deliver late under load. Release synchronously and merge
+        // the held causes into this one current compile.
+        clearTimeout(providerCooldown.timer);
+        this.providerAccelerationCooldowns.delete(agentName);
+        const recovery = this.providerAccelerationRecoveries.get(agentName);
+        if (recovery) recovery.releasedAt = now;
+        requests = [...providerCooldown.heldRequests, ...requests];
       }
 
       // Skip if agent is busy (inferring, streaming, or waiting for tools) —
@@ -4878,7 +5098,12 @@ export class AgentFramework {
       // rather than waiting for the old stream's teardown.
       const budgetRestart = requests.find((r) => r.reason === 'context_budget_restart');
       const turnAlive = !budgetRestart && this.activeTurnTokens.has(agentName);
-      if (turnAlive || agent.state.status === 'inferring' || agent.state.status === 'streaming' || agent.state.status === 'waiting_for_tools') {
+      const providerGate = this.providerGates?.get(agentName);
+      // A primary can own provider admission while yielding to an already in-flight
+      // auxiliary call. Keep this agent's later wakes queued, but do not block the
+      // framework event loop or other residents while that auxiliary call settles.
+      const providerPrimaryWaiting = (providerGate?.primaryDepth ?? 0) > 0 && !this.activeTurnTokens.has(agentName);
+      if (providerPrimaryWaiting || turnAlive || agent.state.status === 'inferring' || agent.state.status === 'streaming' || agent.state.status === 'waiting_for_tools') {
         // Re-queue requests, but warn if they've been pending too long
         const oldest = Math.min(...requests.map(r => r.timestamp));
         if (
@@ -4922,6 +5147,12 @@ export class AgentFramework {
           `[inference-dropped] agent=${agentName} reason=policy-skip ` +
           `requests=${requests.length} triggers=${requests.map((r) => r.reason).join(',')}`,
         );
+        const gate = this.providerGates.get(agentName);
+        if (gate?.primaryPending && this.providerAccelerationRecoveries.has(agentName)) {
+          gate.primaryPending = false;
+          this.providerAccelerationRecoveries.delete(agentName);
+          this.flushAuxiliaryAdmission(agentName);
+        }
         continue;
       }
 
@@ -5405,7 +5636,38 @@ export class AgentFramework {
     }
   }
 
-  private async startAgentStream(agent: Agent, trigger?: InferenceRequest, attempt = 0): Promise<void> {
+  private async startAgentStream(
+    agent: Agent,
+    trigger?: InferenceRequest,
+    attempt = 0,
+    providerGateAlreadyHeld = false,
+  ): Promise<void> {
+    const ownsProviderGate =
+      !this.ephemeralRuns.has(agent.name) && !this.conversationAgentHomes.has(agent.name);
+    if (ownsProviderGate && !providerGateAlreadyHeld) {
+      this.acquirePrimaryProviderGate(agent.name);
+      const gate = this.providerGate(agent.name);
+      if (gate.auxiliaryInFlight > 0) {
+        // Do not await inside processInferenceRequests: one slow auxiliary call for
+        // this resident must not block events or other residents. Admission stays
+        // owned and the continuation receives it after the in-flight call settles.
+        void this.waitForAuxiliaryIdle(agent.name).then(async () => {
+          if (this.providerAdmissionClosed) {
+            this.releasePrimaryProviderGate(agent.name);
+            return;
+          }
+          await this.startAgentStream(agent, trigger, attempt, true);
+        }).catch((error) => {
+          this.releasePrimaryProviderGate(agent.name);
+          console.error(`[provider-cooldown] failed to resume primary for ${agent.name}:`, error);
+        });
+        return;
+      }
+      if (this.providerAdmissionClosed) {
+        this.releasePrimaryProviderGate(agent.name);
+        return;
+      }
+    }
     // Mark the turn alive before ANYTHING awaits (hooks, compile, stream
     // setup): from here until this turn's teardown, cross-turn writers defer
     // (addMessage guard) instead of appending — nothing may enter the window
@@ -5426,11 +5688,12 @@ export class AgentFramework {
     this.activeTurnTokens.set(agent.name, turnToken);
     let tokenHandedOff = false;
     try {
-      tokenHandedOff = await this.beginAgentTurn(agent, trigger, attempt, turnToken);
+      tokenHandedOff = await this.beginAgentTurn(agent, trigger, attempt, turnToken, ownsProviderGate);
     } finally {
       if (!tokenHandedOff && this.activeTurnTokens.get(agent.name) === turnToken) {
         this.activeTurnTokens.delete(agent.name);
       }
+      if (!tokenHandedOff && ownsProviderGate) this.releasePrimaryProviderGate(agent.name);
     }
   }
 
@@ -5444,6 +5707,7 @@ export class AgentFramework {
     trigger: InferenceRequest | undefined,
     attempt: number,
     turnToken: number,
+    ownsProviderGate: boolean,
   ): Promise<boolean> {
     // Flush messages deferred during the PREVIOUS turn — before the
     // checkpoint, the locus announcement, and the compile — so a turn started
@@ -5631,6 +5895,7 @@ export class AgentFramework {
         trigger,
         attempt,
         compiledRequest,
+        ownsProviderGate,
       );
       this.activeStreams.set(agent.name, handle);
       // Handoff: driveStream captured the token in its synchronous prefix;
@@ -5649,6 +5914,13 @@ export class AgentFramework {
         stack: err.stack,
       });
       agent.reset();
+
+      if (ownsProviderGate && this.holdProviderAcceleration(agent, err, trigger)) {
+        // Capacity scheduling is not poisoned history. The cooldown timer owns
+        // one later fresh compile; no immediate retry or exhaustion marker.
+        this.eventGate?.onInferenceEnded(agent.name);
+        return false;
+      }
 
       const action = this.errorPolicy.onInferenceError(err, agent.name, attempt);
       if (action.retry) {
@@ -5703,7 +5975,8 @@ export class AgentFramework {
     requestSnapshot: InferenceToolSnapshot,
     trigger?: InferenceRequest,
     attempt = 0,
-    compiledRequest?: NormalizedRequest
+    compiledRequest?: NormalizedRequest,
+    ownsProviderGate = false,
   ): Promise<void> {
     const startTime = Date.now();
     const requestId = `${agent.name}-${startTime}-${Math.random().toString(36).slice(2, 8)}`;
@@ -6114,6 +6387,10 @@ export class AgentFramework {
             } else {
               agent.addAssistantResponse(terminalContent);
             }
+
+            // Bind the cooldown receipt to this fresh, successful request —
+            // never to the frozen request that received the 429.
+            this.recordProviderAccelerationRecovery(agent, compiledRequest, response.stopReason);
 
             // §10.5: context/afterInference is removed in 0.5.0 — no
             // content leaves the host here. Turn boundaries are announced
@@ -6531,6 +6808,12 @@ export class AgentFramework {
             this.abortAgentScript(agent.name, 'stream error');
             agent.reset();
 
+            if (ownsProviderGate && this.holdProviderAcceleration(agent, err, trigger)) {
+              lifecyclePhase = 'failed';
+              this.eventGate?.onInferenceEnded(agent.name);
+              break;
+            }
+
             const action = this.errorPolicy.onInferenceError(err, agent.name, attempt);
             if (action.retry) {
               await new Promise((resolve) => setTimeout(resolve, action.delayMs));
@@ -6670,10 +6953,19 @@ export class AgentFramework {
         }
       }
     } catch (error) {
-      // Stream itself threw (unexpected) — no retry path here, so also emit
-      // inference:exhausted so ephemeral agent promises can settle.
+      // Stream itself threw. Organization acceleration is deferred from a
+      // fresh compile; every other throw keeps the ordinary exhausted path.
       const err = error instanceof Error ? error : new Error(String(error));
       const durationMs = Date.now() - startTime;
+      if (ownsProviderGate && this.holdProviderAcceleration(agent, err, trigger)) {
+        this.emitTrace({ type: 'inference:failed', agentName: agent.name, error: err.message, stack: err.stack });
+        this.logInference({ timestamp: startTime, agentName: agent.name, requestId, success: false,
+          error: `Provider acceleration cooldown: ${err.message}`,
+          request: compiledRequest ?? { note: 'streaming request rate-limited' }, durationMs });
+        this.abortAgentScript(agent.name, 'provider acceleration cooldown');
+        lifecyclePhase = 'failed'; agent.reset(); this.eventGate?.onInferenceEnded(agent.name);
+        return;
+      }
       this.emitTrace({
         type: 'inference:failed',
         agentName: agent.name,
@@ -6728,6 +7020,7 @@ export class AgentFramework {
       // wedge). onInferenceEnded is idempotent, so a redundant call is safe.
       this.eventGate?.onInferenceEnded(agent.name);
       this.lastInferenceAt.set(agent.name, { ...this.lastInferenceAt.get(agent.name), endedAt: Date.now() });
+      if (ownsProviderGate) this.releasePrimaryProviderGate(agent.name);
 
       // Stop the typing indicator on every exit path (complete, error,
       // exhausted, abort) so it never sticks after the turn ends.
@@ -8056,6 +8349,19 @@ export class AgentFramework {
         name,
         status: agent.state.status,
         consecutiveInferenceFailures: this.consecutiveInferenceFailures.get(name) ?? 0,
+        providerAdmission: (() => {
+          const gate = this.providerGates?.get(name);
+          const cooldown = this.providerAccelerationCooldowns?.get(name);
+          return {
+            primaryActive: (gate?.primaryDepth ?? 0) > 0,
+            primaryPending: gate?.primaryPending ?? false,
+            auxiliaryInFlight: gate?.auxiliaryInFlight ?? 0,
+            auxiliaryDeferred: gate?.deferredAuxiliary ?? 0,
+            cooldownUntil: cooldown?.until ?? null,
+            heldRequests: cooldown?.heldRequests.length ?? 0,
+            lastRecovery: this.providerAccelerationLastRecovery?.get(name) ?? null,
+          };
+        })(),
         lastInference: this.lastInferenceAt.get(name) ?? null,
         refusalStats: this.refusalStats.get(name) ?? null,
       })),

--- a/test/provider-acceleration-cooldown.test.ts
+++ b/test/provider-acceleration-cooldown.test.ts
@@ -1,0 +1,315 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { MembraneError } from '@animalabs/membrane';
+import type { ContentBlock, NormalizedRequest, StreamEvent, YieldingStream } from '@animalabs/membrane';
+import type { EventResponse, Module, ModuleContext, ProcessEvent, ProcessState, ToolCall, ToolDefinition, ToolResult } from '../src/index.js';
+import { AgentFramework } from '../src/index.js';
+import { MockMembrane, MockYieldingStream, createMockResponse } from './helpers/mock-membrane.js';
+
+class InputModule implements Module {
+  readonly name = 'input';
+  private ctx: ModuleContext | null = null;
+  async start(ctx: ModuleContext): Promise<void> { this.ctx = ctx; }
+  async stop(): Promise<void> { this.ctx = null; }
+  getTools(): ToolDefinition[] { return []; }
+  async handleToolCall(_call: ToolCall): Promise<ToolResult> { return { success: false, isError: true, error: 'none' }; }
+  async onProcess(event: ProcessEvent, _state: ProcessState): Promise<EventResponse> {
+    if (event.type !== 'external-message') return {};
+    return { addMessages: [{ participant: 'User', content: [{ type: 'text', text: String(event.content) }] }], requestInference: true };
+  }
+}
+
+class ErrorStream implements YieldingStream {
+  isWaitingForTools = false;
+  pendingToolCallIds: string[] = [];
+  toolDepth = 0;
+  isCancelled = false;
+  constructor(private readonly error: Error) {}
+  provideToolResults(): void { throw new Error('not waiting'); }
+  cancel(): void { this.isCancelled = true; }
+  async *[Symbol.asyncIterator](): AsyncIterator<StreamEvent> {
+    yield { type: 'error', error: this.error } as StreamEvent;
+  }
+}
+
+class AccelerationThenSuccessMembrane extends MockMembrane {
+  private n = 0;
+  override streamYielding(request: NormalizedRequest): YieldingStream {
+    this.calls.push(request);
+    this.n++;
+    if (this.n === 1) {
+      return new ErrorStream(new MembraneError({
+        type: 'rate_limit', retryable: true, httpStatus: 429,
+        message: "This request would exceed your organization's maximum usage increase rate for input tokens per minute",
+        rawError: { status: 429 }, rawRequest: request,
+      }));
+    }
+    return new MockYieldingStream([createMockResponse([{ type: 'text', text: 'recovered' }])]);
+  }
+}
+
+
+class GenericRateLimitThenSuccessMembrane extends MockMembrane {
+  private n = 0;
+  override streamYielding(request: NormalizedRequest): YieldingStream {
+    this.calls.push(request); this.n++;
+    if (this.n === 1) return new ErrorStream(new MembraneError({
+      type: 'rate_limit', retryable: true, httpStatus: 429,
+      message: "This request would exceed your organization's rate limit for input tokens per minute; retry after 1", retryAfterMs: 1,
+      rawError: { status: 429 }, rawRequest: request,
+    }));
+    return new MockYieldingStream([createMockResponse([{ type: 'text', text: 'ordinary retry' }])]);
+  }
+}
+
+class AlwaysSuccessMembrane extends MockMembrane {
+  override streamYielding(request: NormalizedRequest): YieldingStream {
+    this.calls.push(request);
+    return new MockYieldingStream([createMockResponse([{ type: 'text', text: 'ok' }])]);
+  }
+}
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+function textOf(request: NormalizedRequest): string {
+  return request.messages.flatMap((m) => m.content)
+    .filter((b): b is ContentBlock & { type: 'text'; text: string } => b.type === 'text')
+    .map((b) => b.text).join('\n');
+}
+
+test('organization acceleration 429 defers one fresh compile, includes arrivals, and avoids failure breaker', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'af-provider-cooldown-'));
+  const membrane = new AccelerationThenSuccessMembrane();
+  const framework = await AgentFramework.create({
+    storePath: join(dir, 'store.chronicle'), membrane: membrane.asMembrane(),
+    agents: [{ name: 'resident', model: 'test-model', systemPrompt: 'system' }],
+    modules: [new InputModule()], syncIntervalMs: 0, maintenanceIntervalMs: 0,
+  });
+  const internal = framework as unknown as {
+    providerAccelerationDefaultCooldownMs: number;
+    providerAccelerationJitterMs: number;
+    consecutiveInferenceFailures: Map<string, number>;
+    providerAccelerationCooldowns: Map<string, { heldRequests: unknown[] }>;
+    providerAccelerationLastRecovery: Map<string, {
+      waitedMs: number; cooldownMs: number; heldRequests: number; messageCount: number; stopReason: string;
+    }>;
+  };
+  internal.providerAccelerationDefaultCooldownMs = 1_000;
+  internal.providerAccelerationJitterMs = 0;
+  try {
+    framework.pushEvent({ type: 'external-message', source: 'test', content: 'first', metadata: {} });
+    await framework.runUntilIdle();
+    assert.equal(membrane.calls.length, 1, 'no immediate same-window retry');
+    assert.equal(internal.consecutiveInferenceFailures.get('resident') ?? 0, 0, 'capacity does not enter hard-down streak');
+    assert.equal(internal.providerAccelerationCooldowns.size, 1);
+
+    framework.pushEvent({ type: 'external-message', source: 'test', content: 'arrived during cooldown', metadata: {} });
+    await framework.runUntilIdle();
+    assert.equal(membrane.calls.length, 1, 'new arrival is held, not separately inferred');
+    assert.equal(internal.providerAccelerationCooldowns.get('resident')?.heldRequests.length, 2);
+
+    await sleep(1_100);
+    await framework.runUntilIdle();
+    assert.equal(membrane.calls.length, 2, 'one deferred primary attempt');
+    assert.match(textOf(membrane.calls[1]!), /first/);
+    assert.match(textOf(membrane.calls[1]!), /arrived during cooldown/);
+
+    const messages = framework.getAgent('resident')!.getContextManager().queryMessages({}).messages;
+    const failed = messages.filter((m) => (m.metadata as { kind?: string } | undefined)?.kind === 'inference-failed');
+    const authoredReceipt = messages.filter((m) => (m.metadata as { kind?: string } | undefined)?.kind === 'provider-acceleration-recovered');
+    assert.equal(failed.length, 0, 'no poisoned-history/failure marker');
+    assert.equal(authoredReceipt.length, 0, 'provider admission never authors resident memory');
+    const recovery = internal.providerAccelerationLastRecovery.get('resident');
+    assert.ok(recovery, 'operational recovery receipt is exposed outside Chronicle');
+    assert.ok(recovery.waitedMs >= recovery.cooldownMs);
+    assert.equal(recovery.heldRequests, 2);
+    assert.ok(recovery.messageCount > 0);
+    assert.equal(recovery.stopReason, 'end_turn');
+  } finally {
+    await framework.stop();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('dynamic conversation forks are excluded from provider cooldown ownership', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'af-provider-conversation-'));
+  const membrane = new AccelerationThenSuccessMembrane();
+  const framework = await AgentFramework.create({
+    storePath: join(dir, 'store.chronicle'), membrane: membrane.asMembrane(),
+    agents: [{ name: 'resident', model: 'test-model', systemPrompt: 'system' }],
+    modules: [], syncIntervalMs: 0, maintenanceIntervalMs: 0,
+  });
+  const internal = framework as unknown as {
+    conversationAgentHomes: Map<string, string>;
+    providerAccelerationCooldowns: Map<string, unknown>;
+    providerGates: Map<string, unknown>;
+    holdProviderAcceleration(agent: unknown, error: Error, trigger?: unknown): boolean;
+  };
+  internal.conversationAgentHomes.set('resident', 'world:test');
+  try {
+    const error = new MembraneError({
+      type: 'rate_limit', retryable: true, httpStatus: 429,
+      message: "This request would exceed your organization's maximum usage increase rate for input tokens per minute",
+      rawError: { status: 429 },
+    });
+    const held = internal.holdProviderAcceleration(framework.getAgent('resident')!, error, {
+      agentName: 'resident', reason: 'conversation', source: 'test', timestamp: Date.now(),
+    });
+    assert.equal(held, false, 'conversation fork retains its existing provider policy');
+    assert.equal(internal.providerAccelerationCooldowns.size, 0);
+    assert.equal(internal.providerGates.size, 0, 'generation-unique conversation name allocates no provider gate');
+  } finally {
+    await framework.stop();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('a resident waiting behind auxiliary work does not block another resident', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'af-provider-cross-agent-'));
+  const membrane = new AlwaysSuccessMembrane();
+  const framework = await AgentFramework.create({
+    storePath: join(dir, 'store.chronicle'), membrane: membrane.asMembrane(),
+    agents: [
+      { name: 'resident', model: 'test-model', systemPrompt: 'system' },
+      { name: 'other', model: 'test-model', systemPrompt: 'system' },
+    ],
+    modules: [], syncIntervalMs: 0, maintenanceIntervalMs: 0,
+  });
+  const internal = framework as unknown as {
+    withAuxiliaryAdmission<T>(name: string, run: () => Promise<T>): Promise<T>;
+    startAgentStream(agent: unknown): Promise<void>;
+  };
+  let finish!: () => void;
+  const auxiliary = internal.withAuxiliaryAdmission('resident', () => new Promise<void>((resolve) => {
+    finish = resolve;
+  }));
+  try {
+    await internal.startAgentStream(framework.getAgent('resident')!);
+    await internal.startAgentStream(framework.getAgent('other')!);
+    await sleep(20);
+    assert.equal(membrane.calls.length, 1, 'the other resident reaches the provider while the first waits');
+    finish();
+    await auxiliary;
+    await sleep(20);
+    assert.equal(membrane.calls.length, 2, 'the waiting resident resumes after auxiliary settlement');
+  } finally {
+    finish();
+    await auxiliary;
+    await framework.stop();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('shutdown aborts a primary waiting behind in-flight auxiliary work', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'af-provider-stop-aux-'));
+  const membrane = new MockMembrane();
+  const framework = await AgentFramework.create({
+    storePath: join(dir, 'store.chronicle'), membrane: membrane.asMembrane(),
+    agents: [{ name: 'resident', model: 'test-model', systemPrompt: 'system' }],
+    modules: [new InputModule()], syncIntervalMs: 0, maintenanceIntervalMs: 0,
+  });
+  const internal = framework as unknown as {
+    withAuxiliaryAdmission<T>(name: string, run: () => Promise<T>): Promise<T>;
+  };
+  let finish!: () => void;
+  const auxiliary = internal.withAuxiliaryAdmission('resident', () => new Promise<void>((resolve) => {
+    finish = resolve;
+  }));
+  let stopped = false;
+  try {
+    framework.pushEvent({ type: 'external-message', source: 'test', content: 'first', metadata: {} });
+    const draining = framework.runUntilIdle();
+    await sleep(20);
+    assert.equal(membrane.calls.length, 0, 'primary waits behind the admitted auxiliary');
+    await Promise.race([
+      framework.stop().then(() => { stopped = true; }),
+      sleep(250).then(() => { throw new Error('shutdown left the primary waiting behind auxiliary work'); }),
+    ]);
+    await draining;
+    assert.equal(membrane.calls.length, 0, 'shutdown does not start a late primary against the closed store');
+  } finally {
+    finish();
+    await auxiliary;
+    if (!stopped) await framework.stop();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('ordinary 429 keeps the existing retry policy instead of entering acceleration cooldown', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'af-provider-generic-'));
+  const membrane = new GenericRateLimitThenSuccessMembrane();
+  const framework = await AgentFramework.create({
+    storePath: join(dir, 'store.chronicle'), membrane: membrane.asMembrane(),
+    agents: [{ name: 'resident', model: 'test-model', systemPrompt: 'system' }],
+    modules: [new InputModule()], syncIntervalMs: 0, maintenanceIntervalMs: 0,
+  });
+  try {
+    framework.pushEvent({ type: 'external-message', source: 'test', content: 'ordinary', metadata: {} });
+    await framework.runUntilIdle();
+    assert.equal(membrane.calls.length, 2);
+    const internal = framework as unknown as { providerAccelerationCooldowns: Map<string, unknown> };
+    assert.equal(internal.providerAccelerationCooldowns.size, 0);
+  } finally { await framework.stop(); rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('local provider gate settles in-flight auxiliary work and parks later auxiliary admission', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'af-provider-gate-'));
+  const membrane = new MockMembrane();
+  const framework = await AgentFramework.create({
+    storePath: join(dir, 'store.chronicle'), membrane: membrane.asMembrane(),
+    agents: [{ name: 'resident', model: 'test-model', systemPrompt: 'system' }], modules: [],
+    syncIntervalMs: 0, maintenanceIntervalMs: 0,
+  });
+  const internal = framework as unknown as {
+    acquirePrimaryProviderGate(name: string): void;
+    releasePrimaryProviderGate(name: string): void;
+    waitForAuxiliaryIdle(name: string): Promise<void>;
+    withAuxiliaryAdmission<T>(name: string, run: () => Promise<T>): Promise<T>;
+    providerGates: Map<string, { deferredAuxiliary: number }>;
+  };
+  try {
+    let finish!: () => void;
+    const inFlight = internal.withAuxiliaryAdmission('resident', () => new Promise<number>((resolve) => {
+      finish = () => resolve(3);
+    }));
+    internal.acquirePrimaryProviderGate('resident');
+    let primaryReady = false;
+    const wait = internal.waitForAuxiliaryIdle('resident').then(() => { primaryReady = true; });
+    let laterRan = false;
+    const later = internal.withAuxiliaryAdmission('resident', async () => { laterRan = true; return 7; });
+    await sleep(10);
+    assert.equal(primaryReady, false, 'primary observes the already in-flight auxiliary');
+    assert.equal(laterRan, false, 'new auxiliary is parked');
+    finish();
+    assert.equal(await inFlight, 3);
+    await wait;
+    assert.equal(primaryReady, true);
+    assert.equal(laterRan, false, 'parked auxiliary still waits for primary settlement');
+    internal.releasePrimaryProviderGate('resident');
+    assert.equal(await later, 7);
+    assert.equal(internal.providerGates.get('resident')?.deferredAuxiliary, 0, 'completed wait no longer reports backlog');
+
+    // The real Context Manager door is the wrapped auxiliary Membrane, not
+    // merely the helper tested above.
+    internal.acquirePrimaryProviderGate('resident');
+    const cm = framework.getAgent('resident')!.getContextManager() as unknown as {
+      membrane: { complete(request: NormalizedRequest): Promise<unknown> };
+    };
+    const request = {
+      messages: [], tools: [], config: { model: 'test-model', maxTokens: 16 },
+    } as unknown as NormalizedRequest;
+    const before = membrane.calls.length;
+    const throughCm = cm.membrane.complete(request);
+    await sleep(10);
+    assert.equal(membrane.calls.length, before, 'Context Manager provider call is parked');
+    internal.releasePrimaryProviderGate('resident');
+    await throughCm;
+    assert.equal(membrane.calls.length, before + 1, 'Context Manager call resumes once');
+  } finally {
+    await framework.stop();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add a per-residence/process primary-vs-Context-Manager admission gate
- treat Anthropic organization-acceleration 429s as capacity scheduling, not poisoned history
- hold arrivals during cooldown and issue one fresh compile from current Chronicle state
- pause new local maintenance while primary is pending/active, let in-flight auxiliary settle, and resume after settlement
- expose counts-only provider admission state and append a durable post-recovery receipt

Bounded first slice for #114. Deliberately no org-wide/cross-process coordinator.

## Receipts
- focused provider cooldown/gate: 3/3
- neighboring maintenance/ephemeral/exhaustion/overbudget: 27/27
- typecheck/build/diff-check green
- current main with the new discriminator copied forward: 0/3; founding no-immediate-retry assertion observes 2 calls instead of 1

