### PR TITLE
feat(workspace): readFileFromDisk — filesystem-enforced mount containment for peer reads

### DIFF
--- a/changelog.d/129-workspace-read-file-from-disk.added.md
+++ b/changelog.d/129-workspace-read-file-from-disk.added.md
@@ -1,0 +1,14 @@
+- **`WorkspaceModule.readFileFromDisk(mountPath, { maxBytes })`** — a
+  workspace-owned filesystem read for peer modules that enforces the mount
+  boundary on disk, not just on the path string (#129). Honors the mount's
+  `followSymlinks` policy (default: refuse), requires the canonical target to
+  stay beneath the canonical mount root when symlinks are allowed (so an
+  intermediate symlinked directory or a sibling-prefix root cannot escape), and
+  performs a bounded prefix read when `maxBytes` is set, reporting `truncated`
+  alongside the full `size`, `mtimeMs` and canonical `realPath`. Refusals throw
+  the exported `WorkspaceReadError` with a `code` distinguishing unknown mount,
+  lexical traversal, unavailable mount, missing file, directory, policy-denied
+  symlink, outside-mount target and file-changed-during-read.
+  `resolveAbsolutePath()` is now documented as lexical-only and deprecated for
+  direct reads; `read_image` shares the same containment core with its error
+  wording unchanged.

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -8,7 +8,8 @@ export type { ApiEvent } from './api/index.js';
 export { HealthModule } from './health/index.js';
 export type { HealthModuleConfig } from './health/index.js';
 
-export { WorkspaceModule } from './workspace/index.js';
+export { WorkspaceModule, WorkspaceReadError } from './workspace/index.js';
+export type { WorkspaceReadErrorCode, WorkspaceReadStage, WorkspaceDiskReadResult, ReadFileFromDiskOptions } from './workspace/index.js';
 export type {
   WorkspaceConfig,
   MountConfig,

--- a/src/modules/workspace/index.ts
+++ b/src/modules/workspace/index.ts
@@ -6,6 +6,7 @@
  */
 
 import { constants as fsConstants } from 'node:fs';
+import type { Stats } from 'node:fs';
 import { open, readFile, stat, access, writeFile, unlink, mkdir, lstat, realpath } from 'node:fs/promises';
 import { join, resolve, relative, dirname, sep } from 'node:path';
 import type { JsStore } from '@animalabs/chronicle';
@@ -76,6 +77,82 @@ class WorkspaceImageReadError extends Error {
     super(message);
     this.name = 'WorkspaceImageReadError';
   }
+}
+
+/**
+ * Why a workspace-owned filesystem read was refused. Distinguishes the cases a
+ * peer needs to react to differently: a path that never resolved inside the
+ * mount (`unknown_mount`, `traversal`), a mount whose root is gone
+ * (`mount_unavailable`), an ordinary missing file (`not_found`), a directory
+ * (`directory`), a symlink refused by the mount's `followSymlinks` policy
+ * (`symlink`), a symlink whose canonical target lands outside the canonical
+ * mount root (`escape`), and a file swapped underneath the read (`changed`).
+ */
+export type WorkspaceReadErrorCode =
+  | 'unknown_mount'
+  | 'traversal'
+  | 'mount_unavailable'
+  | 'not_found'
+  | 'directory'
+  | 'symlink'
+  | 'escape'
+  | 'changed';
+
+/** Where in the open sequence a `WorkspaceReadError` originated (diagnostics). */
+export type WorkspaceReadStage =
+  | 'parse'
+  | 'lstat'
+  | 'realpath_root'
+  | 'open'
+  | 'fstat'
+  | 'post_lstat'
+  | 'realpath'
+  | 'stat'
+  | 'read';
+
+/**
+ * Thrown by `WorkspaceModule.readFileFromDisk()`. Messages carry the
+ * mount-prefixed path only — never absolute filesystem paths — so they can be
+ * surfaced to the agent or logged without leaking host layout.
+ */
+export class WorkspaceReadError extends Error {
+  constructor(
+    readonly code: WorkspaceReadErrorCode,
+    message: string,
+    readonly stage: WorkspaceReadStage,
+    /** Underlying errno code (e.g. 'ENOENT', 'ELOOP') when a syscall failed. */
+    readonly errno?: string,
+  ) {
+    super(message);
+    this.name = 'WorkspaceReadError';
+  }
+}
+
+/** Successful `readFileFromDisk()` result. */
+export interface WorkspaceDiskReadResult {
+  /** File bytes — the whole file, or its first `maxBytes` when `truncated`. */
+  bytes: Buffer;
+  /** Full on-disk size in bytes, regardless of truncation. */
+  size: number;
+  /** True when `maxBytes` was set and the file was larger; `bytes` is a prefix. */
+  truncated: boolean;
+  /** mtime of the file actually read (for change-detection caches). */
+  mtimeMs: number;
+  /** Canonical (realpath) location of the file read — inside the canonical mount root by construction. */
+  realPath: string;
+  /** Mount the path resolved into. */
+  mount: string;
+}
+
+export interface ReadFileFromDiskOptions {
+  /** Read at most this many bytes (a bounded prefix read — the rest of the file is never loaded). */
+  maxBytes?: number;
+}
+
+function errnoOf(err: unknown): string | undefined {
+  return typeof err === 'object' && err !== null && 'code' in err && typeof (err as { code?: unknown }).code === 'string'
+    ? (err as { code: string }).code
+    : undefined;
 }
 
 const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
@@ -994,8 +1071,17 @@ export class WorkspaceModule implements Module {
   /**
    * Resolve a mount-prefixed path (e.g. "tickets/2026-04-22-foo.md") to its
    * absolute filesystem path. Returns null if the mount is unknown or the
-   * resolved path escapes the mount root (path-traversal guard). Public API
-   * for peer modules that need to read workspace files directly.
+   * resolved path escapes the mount root.
+   *
+   * **Lexical containment only.** The guard reasons about `..` segments in the
+   * path string; it knows nothing about what is on disk. A symlink inside the
+   * mount that targets an outside file passes this check, and a caller that
+   * then does `fs.readFile(path)` reads the outside content. Use the returned
+   * path for resolution-only purposes (write targets, nonexistent paths,
+   * display); for reading file content, use {@link readFileFromDisk}, which
+   * enforces the mount's `followSymlinks` policy and canonical containment.
+   *
+   * @deprecated for direct filesystem reads — call `readFileFromDisk()`.
    */
   resolveAbsolutePath(mountPrefixedPath: string): string | null {
     try {
@@ -1189,82 +1275,107 @@ export class WorkspaceModule implements Module {
     return this.validateImageBytes(blob, mountPrefixedPath, maxSize);
   }
 
-  private async readImageFromFilesystem(
+  /**
+   * Open a mount-relative file for reading with the mount boundary enforced on
+   * the *filesystem*, not just the path string:
+   *
+   * 1. `lstat` the lexical path — refuse directories; refuse a final-component
+   *    symlink when the mount does not `followSymlinks`.
+   * 2. Open with `O_NOFOLLOW` where the platform has it (POSIX) so the refusal
+   *    holds against a symlink swapped in between lstat and open; where it
+   *    doesn't (Windows), re-`lstat` after opening instead.
+   * 3. `realpath` both the mount root and the opened path and require canonical
+   *    containment — this is what catches an *intermediate* symlinked
+   *    directory escaping the mount, and a followed symlink whose target lands
+   *    outside, on every platform (junctions included).
+   * 4. Confirm the descriptor and the canonical path are the same inode.
+   *
+   * `inspect` runs right after the descriptor is stat'd and before the
+   * containment work, so callers can impose size policy in the same order the
+   * image reader always has. The returned handle is the caller's to close.
+   */
+  private async openContainedFile(
     mount: MountState,
     relativePath: string,
     mountPrefixedPath: string,
-    maxSize: number,
-  ): Promise<{ bytes: Buffer; mimeType: SupportedImageMimeType }> {
+    inspect?: (fileStat: Stats) => void,
+  ): Promise<{ handle: Awaited<ReturnType<typeof open>>; fileStat: Stats; realFilePath: string }> {
     const lexicalPath = resolve(mount.config.path, relativePath);
-    const useNoFollow = !mount.config.followSymlinks && typeof fsConstants.O_NOFOLLOW === 'number';
+    const follow = mount.config.followSymlinks === true;
+    const useNoFollow = !follow && typeof fsConstants.O_NOFOLLOW === 'number';
 
     let fileInfo: Awaited<ReturnType<typeof lstat>>;
     try {
       fileInfo = await lstat(lexicalPath);
     } catch (err) {
-      if (isErrnoCode(err, 'ENOENT')) {
-        throw new WorkspaceImageReadError('not_found', `File not found: ${mountPrefixedPath}`);
+      const code = errnoOf(err);
+      if (code === 'ENOENT' || code === 'ENOTDIR') {
+        throw new WorkspaceReadError('not_found', `File not found: ${mountPrefixedPath}`, 'lstat', code);
       }
-      throw new WorkspaceImageReadError('not_found', `Unable to read image file: ${mountPrefixedPath}`);
+      throw new WorkspaceReadError('not_found', `Unable to read file: ${mountPrefixedPath}`, 'lstat', code);
     }
-
     if (fileInfo.isDirectory()) {
-      throw new WorkspaceImageReadError('directory', `Path is a directory: ${mountPrefixedPath}`);
+      throw new WorkspaceReadError('directory', `Path is a directory: ${mountPrefixedPath}`, 'lstat');
     }
-    if (fileInfo.isSymbolicLink() && !mount.config.followSymlinks) {
-      throw new WorkspaceImageReadError('symlink', `Symlinks are not allowed: ${mountPrefixedPath}`);
+    if (fileInfo.isSymbolicLink() && !follow) {
+      throw new WorkspaceReadError('symlink', `Symlinks are not allowed: ${mountPrefixedPath}`, 'lstat');
     }
 
     let realMountRoot: string;
     try {
       realMountRoot = await realpath(mount.config.path);
-    } catch {
-      throw new WorkspaceImageReadError('mount_unavailable', `Mount unavailable: ${mount.config.name}`);
+    } catch (err) {
+      throw new WorkspaceReadError('mount_unavailable', `Mount unavailable: ${mount.config.name}`, 'realpath_root', errnoOf(err));
     }
 
-    let handle: Awaited<ReturnType<typeof open>> | null = null;
+    let handle: Awaited<ReturnType<typeof open>>;
     try {
       handle = await open(lexicalPath, fsConstants.O_RDONLY | (useNoFollow ? fsConstants.O_NOFOLLOW : 0));
     } catch (err) {
-      if (isErrnoCode(err, 'ENOENT')) {
-        throw new WorkspaceImageReadError('not_found', `File not found: ${mountPrefixedPath}`);
+      const code = errnoOf(err);
+      if (code === 'ENOENT' || code === 'ENOTDIR') {
+        throw new WorkspaceReadError('not_found', `File not found: ${mountPrefixedPath}`, 'open', code);
       }
-      if (!mount.config.followSymlinks && isErrnoCode(err, 'ELOOP')) {
-        throw new WorkspaceImageReadError('symlink', `Symlinks are not allowed: ${mountPrefixedPath}`);
+      if (!follow && code === 'ELOOP') {
+        throw new WorkspaceReadError('symlink', `Symlinks are not allowed: ${mountPrefixedPath}`, 'open', code);
       }
-      throw new WorkspaceImageReadError('not_found', `Unable to read image file: ${mountPrefixedPath}`);
+      throw new WorkspaceReadError('not_found', `Unable to read file: ${mountPrefixedPath}`, 'open', code);
     }
 
     try {
-      const fileStat = await handle.stat();
-      if (fileStat.isDirectory()) {
-        throw new WorkspaceImageReadError('directory', `Path is a directory: ${mountPrefixedPath}`);
-      }
-      if (!fileStat.isFile()) {
-        throw new WorkspaceImageReadError('not_found', `File not found: ${mountPrefixedPath}`);
-      }
-      if (fileStat.size === 0) {
-        throw new WorkspaceImageReadError('empty', `Image file is empty: ${mountPrefixedPath}`);
-      }
-      if (fileStat.size > maxSize) {
-        throw new WorkspaceImageReadError(
-          'too_large',
-          `Image file exceeds max size (${maxSize} bytes): ${mountPrefixedPath}`,
+      let fileStat: Stats;
+      try {
+        fileStat = await handle.stat();
+      } catch (err) {
+        const code = errnoOf(err);
+        throw new WorkspaceReadError(
+          'not_found',
+          code === 'ENOENT' ? `File not found: ${mountPrefixedPath}` : `Unable to read file: ${mountPrefixedPath}`,
+          'fstat',
+          code,
         );
       }
+      if (fileStat.isDirectory()) {
+        throw new WorkspaceReadError('directory', `Path is a directory: ${mountPrefixedPath}`, 'fstat');
+      }
+      if (!fileStat.isFile()) {
+        throw new WorkspaceReadError('not_found', `File not found: ${mountPrefixedPath}`, 'fstat');
+      }
+      inspect?.(fileStat);
 
-      if (!mount.config.followSymlinks && !useNoFollow) {
+      if (!follow && !useNoFollow) {
         let postOpenInfo: Awaited<ReturnType<typeof lstat>>;
         try {
           postOpenInfo = await lstat(lexicalPath);
         } catch (err) {
-          if (isErrnoCode(err, 'ENOENT')) {
-            throw new WorkspaceImageReadError('changed', `Image file changed during read: ${mountPrefixedPath}`);
+          const code = errnoOf(err);
+          if (code === 'ENOENT') {
+            throw new WorkspaceReadError('changed', `File changed during read: ${mountPrefixedPath}`, 'post_lstat', code);
           }
-          throw new WorkspaceImageReadError('not_found', `Unable to read image file: ${mountPrefixedPath}`);
+          throw new WorkspaceReadError('not_found', `Unable to read file: ${mountPrefixedPath}`, 'post_lstat', code);
         }
         if (postOpenInfo.isSymbolicLink()) {
-          throw new WorkspaceImageReadError('symlink', `Symlinks are not allowed: ${mountPrefixedPath}`);
+          throw new WorkspaceReadError('symlink', `Symlinks are not allowed: ${mountPrefixedPath}`, 'post_lstat');
         }
       }
 
@@ -1272,29 +1383,162 @@ export class WorkspaceModule implements Module {
       try {
         realFilePath = await realpath(lexicalPath);
       } catch (err) {
-        if (isErrnoCode(err, 'ENOENT')) {
-          throw new WorkspaceImageReadError('changed', `Image file changed during read: ${mountPrefixedPath}`);
+        const code = errnoOf(err);
+        if (code === 'ENOENT') {
+          throw new WorkspaceReadError('changed', `File changed during read: ${mountPrefixedPath}`, 'realpath', code);
         }
-        throw new WorkspaceImageReadError('not_found', `Unable to resolve image file: ${mountPrefixedPath}`);
+        throw new WorkspaceReadError('not_found', `Unable to resolve file: ${mountPrefixedPath}`, 'realpath', code);
       }
 
       if (!isContainedPath(realMountRoot, realFilePath)) {
-        throw new WorkspaceImageReadError('escape', `Symlink escape detected: ${mountPrefixedPath}`);
+        throw new WorkspaceReadError('escape', `Symlink escape detected: ${mountPrefixedPath}`, 'realpath');
       }
 
-      let pathStat: Awaited<ReturnType<typeof stat>>;
+      let pathStat: Stats;
       try {
         pathStat = await stat(realFilePath);
       } catch (err) {
-        if (isErrnoCode(err, 'ENOENT')) {
-          throw new WorkspaceImageReadError('changed', `Image file changed during read: ${mountPrefixedPath}`);
+        const code = errnoOf(err);
+        if (code === 'ENOENT') {
+          throw new WorkspaceReadError('changed', `File changed during read: ${mountPrefixedPath}`, 'stat', code);
         }
-        throw new WorkspaceImageReadError('not_found', `Unable to stat image file: ${mountPrefixedPath}`);
+        throw new WorkspaceReadError('not_found', `Unable to stat file: ${mountPrefixedPath}`, 'stat', code);
       }
       if (pathStat.dev !== fileStat.dev || pathStat.ino !== fileStat.ino) {
-        throw new WorkspaceImageReadError('changed', `Image file changed during read: ${mountPrefixedPath}`);
+        throw new WorkspaceReadError('changed', `File changed during read: ${mountPrefixedPath}`, 'stat');
       }
 
+      return { handle, fileStat, realFilePath };
+    } catch (err) {
+      await handle.close();
+      throw err;
+    }
+  }
+
+  /**
+   * Read a workspace file from disk with the mount boundary enforced on the
+   * filesystem (see {@link openContainedFile}). Public API for peer modules
+   * that read mounted files outside the Chronicle tree — the safe replacement
+   * for `resolveAbsolutePath()` + `fs.readFile()`, whose lexical-only guard let
+   * an in-mount symlink smuggle outside content into context (agent-framework
+   * #129, found via connectome-host #101).
+   *
+   * - Honors the mount's `followSymlinks` policy (default: refuse).
+   * - With symlinks allowed, the canonical target must stay beneath the
+   *   canonical mount root; a sibling-prefix root (`/mount-other`) does not count.
+   * - `maxBytes` performs a bounded prefix read: at most `maxBytes` bytes are
+   *   ever loaded, and `truncated` reports that the file was larger.
+   *
+   * Throws {@link WorkspaceReadError} with a `code` distinguishing unknown
+   * mount, lexical traversal, unavailable mount, missing file, directory,
+   * policy-denied symlink, outside-mount target, and file-changed-during-read.
+   */
+  async readFileFromDisk(
+    mountPrefixedPath: string,
+    options: ReadFileFromDiskOptions = {},
+  ): Promise<WorkspaceDiskReadResult> {
+    if (options.maxBytes !== undefined && !(Number.isInteger(options.maxBytes) && options.maxBytes >= 0)) {
+      throw new RangeError('readFileFromDisk: maxBytes must be a non-negative integer');
+    }
+    let mount: MountState;
+    let relativePath: string;
+    try {
+      ({ mount, relativePath } = this.parsePath(mountPrefixedPath));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const code: WorkspaceReadErrorCode = message.startsWith('Unknown mount') ? 'unknown_mount' : 'traversal';
+      throw new WorkspaceReadError(code, message, 'parse');
+    }
+    if (!relativePath) {
+      throw new WorkspaceReadError('directory', `Path is a directory: ${mountPrefixedPath}`, 'parse');
+    }
+
+    const { handle, fileStat, realFilePath } = await this.openContainedFile(mount, relativePath, mountPrefixedPath);
+    try {
+      const size = fileStat.size;
+      const cap = options.maxBytes;
+      let bytes: Buffer;
+      let truncated = false;
+      if (cap !== undefined && size > cap) {
+        truncated = true;
+        bytes = Buffer.alloc(cap);
+        let offset = 0;
+        while (offset < cap) {
+          const { bytesRead } = await handle.read(bytes, offset, cap - offset, offset);
+          if (bytesRead === 0) break;
+          offset += bytesRead;
+        }
+        if (offset < cap) bytes = bytes.subarray(0, offset);
+      } else {
+        bytes = await handle.readFile();
+      }
+      return { bytes, size, truncated, mtimeMs: fileStat.mtimeMs, realPath: realFilePath, mount: mount.config.name };
+    } catch (err) {
+      if (err instanceof WorkspaceReadError) throw err;
+      throw new WorkspaceReadError('not_found', `Unable to read file: ${mountPrefixedPath}`, 'read', errnoOf(err));
+    } finally {
+      await handle.close();
+    }
+  }
+
+  /** Map a core read refusal onto the image reader's historical error vocabulary and wording. */
+  private imageErrorFromRead(err: WorkspaceReadError, mount: MountState, mountPrefixedPath: string): WorkspaceImageReadError {
+    const p = mountPrefixedPath;
+    switch (err.code) {
+      case 'mount_unavailable':
+        return new WorkspaceImageReadError('mount_unavailable', `Mount unavailable: ${mount.config.name}`);
+      case 'directory':
+        return new WorkspaceImageReadError('directory', `Path is a directory: ${p}`);
+      case 'symlink':
+        return new WorkspaceImageReadError('symlink', `Symlinks are not allowed: ${p}`);
+      case 'escape':
+        return new WorkspaceImageReadError('escape', `Symlink escape detected: ${p}`);
+      case 'changed':
+        return new WorkspaceImageReadError('changed', `Image file changed during read: ${p}`);
+      case 'not_found':
+      default:
+        if (err.message.startsWith('File not found')) {
+          return new WorkspaceImageReadError('not_found', `File not found: ${p}`);
+        }
+        if (err.stage === 'realpath') {
+          return new WorkspaceImageReadError('not_found', `Unable to resolve image file: ${p}`);
+        }
+        if (err.stage === 'stat') {
+          return new WorkspaceImageReadError('not_found', `Unable to stat image file: ${p}`);
+        }
+        return new WorkspaceImageReadError('not_found', `Unable to read image file: ${p}`);
+    }
+  }
+
+  private async readImageFromFilesystem(
+    mount: MountState,
+    relativePath: string,
+    mountPrefixedPath: string,
+    maxSize: number,
+  ): Promise<{ bytes: Buffer; mimeType: SupportedImageMimeType }> {
+    let opened: Awaited<ReturnType<WorkspaceModule['openContainedFile']>>;
+    try {
+      opened = await this.openContainedFile(mount, relativePath, mountPrefixedPath, (fileStat) => {
+        if (fileStat.size === 0) {
+          throw new WorkspaceImageReadError('empty', `Image file is empty: ${mountPrefixedPath}`);
+        }
+        if (fileStat.size > maxSize) {
+          throw new WorkspaceImageReadError(
+            'too_large',
+            `Image file exceeds max size (${maxSize} bytes): ${mountPrefixedPath}`,
+          );
+        }
+      });
+    } catch (err) {
+      if (err instanceof WorkspaceImageReadError) throw err;
+      if (err instanceof WorkspaceReadError) throw this.imageErrorFromRead(err, mount, mountPrefixedPath);
+      if (isErrnoCode(err, 'ENOENT')) {
+        throw new WorkspaceImageReadError('not_found', `File not found: ${mountPrefixedPath}`);
+      }
+      throw new WorkspaceImageReadError('not_found', `Unable to read image file: ${mountPrefixedPath}`);
+    }
+    const { handle } = opened;
+    try {
       const bytes = await handle.readFile();
       return this.validateImageBytes(bytes, mountPrefixedPath, maxSize);
     } catch (err) {
@@ -1304,7 +1548,7 @@ export class WorkspaceModule implements Module {
       }
       throw new WorkspaceImageReadError('not_found', `Unable to read image file: ${mountPrefixedPath}`);
     } finally {
-      await handle?.close();
+      await handle.close();
     }
   }
 

--- a/test/workspace-read-file-from-disk.test.ts
+++ b/test/workspace-read-file-from-disk.test.ts
@@ -1,0 +1,192 @@
+/**
+ * WorkspaceModule.readFileFromDisk — filesystem-enforced mount containment
+ * for peer modules (issue #129).
+ *
+ * `resolveAbsolutePath()` is lexical: an in-mount symlink targeting an outside
+ * file passes it, and a peer that then `fs.readFile`s the returned path reads
+ * the outside content (connectome-host #101 pulled such a file into a
+ * system-position injection). `readFileFromDisk()` is the workspace-owned read
+ * that enforces the mount's `followSymlinks` policy and canonical containment,
+ * so peers stop reimplementing the boundary.
+ *
+ * Symlink cases create real symlinks; on Windows that needs a privilege the
+ * test runner may not have (EPERM), in which case those cases are skipped —
+ * the non-symlink cases still run everywhere.
+ */
+
+import test, { type TestContext } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { JsStore } from '@animalabs/chronicle';
+import { WorkspaceModule, WorkspaceReadError } from '../src/modules/workspace/index.js';
+
+function setup(t: TestContext, options?: { followSymlinks?: boolean }) {
+  const root = mkdtempSync(join(tmpdir(), 'af-read-from-disk-'));
+  const mountDir = join(root, 'mount');
+  mkdirSync(mountDir, { recursive: true });
+  const store = JsStore.openOrCreate({ path: join(root, 'workspace.chronicle') });
+  const workspace = new WorkspaceModule({
+    mounts: [{ name: 'work', path: mountDir, mode: 'read-write', watch: 'never', followSymlinks: options?.followSymlinks }],
+  });
+  workspace.initStore(store);
+  t.after(() => {
+    store.close();
+    rmSync(root, { recursive: true, force: true });
+  });
+  return { root, mountDir, workspace };
+}
+
+/** Create a symlink, or skip the test when the platform refuses (Windows without the privilege). */
+function symlinkOrSkip(t: TestContext, target: string, linkPath: string, type?: 'file' | 'dir' | 'junction'): boolean {
+  try {
+    symlinkSync(target, linkPath, type);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'EPERM' || code === 'EACCES') {
+      t.skip(`symlink creation not permitted on this platform (${code})`);
+      return false;
+    }
+    throw err;
+  }
+}
+
+async function expectRefusal(promise: Promise<unknown>, code: WorkspaceReadError['code']): Promise<WorkspaceReadError> {
+  try {
+    await promise;
+  } catch (err) {
+    assert.ok(err instanceof WorkspaceReadError, `expected WorkspaceReadError, got ${String(err)}`);
+    assert.equal(err.code, code, `expected code ${code}, got ${err.code} (${err.message})`);
+    return err;
+  }
+  assert.fail(`expected a WorkspaceReadError(${code}) but the read succeeded`);
+}
+
+test('a regular in-mount file can be read, with size and mtime reported', async (t) => {
+  const { mountDir, workspace } = setup(t);
+  writeFileSync(join(mountDir, 'AGENTS.md'), '# instructions\n');
+
+  const result = await workspace.readFileFromDisk('work/AGENTS.md');
+  assert.equal(result.bytes.toString('utf8'), '# instructions\n');
+  assert.equal(result.size, Buffer.byteLength('# instructions\n'));
+  assert.equal(result.truncated, false);
+  assert.equal(result.mount, 'work');
+  assert.ok(result.mtimeMs > 0);
+  assert.ok(result.realPath.endsWith('AGENTS.md'));
+});
+
+test('nested paths read and reject lexical traversal / unknown mounts by code', async (t) => {
+  const { mountDir, workspace } = setup(t);
+  mkdirSync(join(mountDir, 'sub'), { recursive: true });
+  writeFileSync(join(mountDir, 'sub', 'deep.txt'), 'deep');
+
+  assert.equal((await workspace.readFileFromDisk('work/sub/deep.txt')).bytes.toString(), 'deep');
+
+  const traversal = await expectRefusal(workspace.readFileFromDisk('work/../outside.txt'), 'traversal');
+  assert.match(traversal.message, /traversal/i);
+  await expectRefusal(workspace.readFileFromDisk('nope/file.txt'), 'unknown_mount');
+});
+
+test('missing files and directories are distinguished', async (t) => {
+  const { mountDir, workspace } = setup(t);
+  mkdirSync(join(mountDir, 'dir'));
+
+  await expectRefusal(workspace.readFileFromDisk('work/missing.txt'), 'not_found');
+  await expectRefusal(workspace.readFileFromDisk('work/dir'), 'directory');
+  await expectRefusal(workspace.readFileFromDisk('work'), 'directory');
+});
+
+test('a final-component symlink to an outside file is rejected under the default no-follow policy', async (t) => {
+  const { root, mountDir, workspace } = setup(t);
+  const outside = join(root, 'outside');
+  mkdirSync(outside);
+  writeFileSync(join(outside, 'secret.txt'), 'SECRET');
+  if (!symlinkOrSkip(t, join(outside, 'secret.txt'), join(mountDir, 'AGENTS.md'), 'file')) return;
+
+  // The lexical resolver is happy — that is exactly the gap.
+  assert.ok(workspace.resolveAbsolutePath('work/AGENTS.md'));
+
+  const err = await expectRefusal(workspace.readFileFromDisk('work/AGENTS.md'), 'symlink');
+  assert.ok(!err.message.includes(root), 'refusal must not leak absolute paths');
+});
+
+test('an intermediate symlinked directory escaping the mount is rejected under no-follow', async (t) => {
+  const { root, mountDir, workspace } = setup(t);
+  const outside = join(root, 'outside');
+  mkdirSync(outside);
+  writeFileSync(join(outside, 'secret.txt'), 'SECRET');
+  if (!symlinkOrSkip(t, outside, join(mountDir, 'linkdir'), 'dir')) return;
+
+  // Final component is a regular file; only the directory hop is a symlink.
+  const err = await expectRefusal(workspace.readFileFromDisk('work/linkdir/secret.txt'), 'escape');
+  assert.ok(!err.message.includes(root));
+});
+
+test('with followSymlinks, an in-mount target is followed but an outside target is still an escape', async (t) => {
+  const { root, mountDir, workspace } = setup(t, { followSymlinks: true });
+  writeFileSync(join(mountDir, 'real.txt'), 'inside');
+  const outside = join(root, 'outside');
+  mkdirSync(outside);
+  writeFileSync(join(outside, 'secret.txt'), 'SECRET');
+  if (!symlinkOrSkip(t, join(mountDir, 'real.txt'), join(mountDir, 'alias.txt'), 'file')) return;
+  if (!symlinkOrSkip(t, join(outside, 'secret.txt'), join(mountDir, 'leak.txt'), 'file')) return;
+
+  const followed = await workspace.readFileFromDisk('work/alias.txt');
+  assert.equal(followed.bytes.toString(), 'inside');
+  assert.ok(followed.realPath.endsWith('real.txt'), 'realPath reports the canonical target');
+
+  await expectRefusal(workspace.readFileFromDisk('work/leak.txt'), 'escape');
+});
+
+test('with followSymlinks, an in-mount symlink is followed only because policy allows it', async (t) => {
+  const strict = setup(t);
+  writeFileSync(join(strict.mountDir, 'real.txt'), 'inside');
+  if (!symlinkOrSkip(t, join(strict.mountDir, 'real.txt'), join(strict.mountDir, 'alias.txt'), 'file')) return;
+  // Same layout, default policy: the in-mount symlink is refused as a symlink,
+  // not followed — containment would have passed, policy says no.
+  await expectRefusal(strict.workspace.readFileFromDisk('work/alias.txt'), 'symlink');
+});
+
+test('a sibling-prefix directory is not beneath the mount', async (t) => {
+  const { root, mountDir, workspace } = setup(t, { followSymlinks: true });
+  const sibling = join(root, 'mount-other');
+  mkdirSync(sibling);
+  writeFileSync(join(sibling, 'x.txt'), 'sibling');
+  if (!symlinkOrSkip(t, join(sibling, 'x.txt'), join(mountDir, 'x.txt'), 'file')) return;
+
+  // `/mount-other/x.txt` starts with `/mount` as a string prefix — a naive
+  // startsWith(root) check would accept it.
+  await expectRefusal(workspace.readFileFromDisk('work/x.txt'), 'escape');
+});
+
+test('maxBytes performs a bounded prefix read and reports truncation', async (t) => {
+  const { mountDir, workspace } = setup(t);
+  const content = 'x'.repeat(10_000);
+  writeFileSync(join(mountDir, 'big.txt'), content);
+
+  const capped = await workspace.readFileFromDisk('work/big.txt', { maxBytes: 1024 });
+  assert.equal(capped.truncated, true);
+  assert.equal(capped.bytes.length, 1024);
+  assert.equal(capped.size, 10_000, 'size reports the full on-disk length');
+  assert.equal(capped.bytes.toString(), 'x'.repeat(1024));
+
+  const whole = await workspace.readFileFromDisk('work/big.txt', { maxBytes: 20_000 });
+  assert.equal(whole.truncated, false);
+  assert.equal(whole.bytes.length, 10_000);
+
+  await assert.rejects(workspace.readFileFromDisk('work/big.txt', { maxBytes: -1 }), RangeError);
+});
+
+test('read_image keeps its historical error wording after sharing the containment core', async (t) => {
+  // The image reader was the original owner of this algorithm; its messages
+  // are pinned by workspace-read-image.test.ts. Spot-check the two codes the
+  // shared core maps most delicately (not_found variants and directory).
+  const { mountDir, workspace } = setup(t);
+  mkdirSync(join(mountDir, 'folder'));
+  const dir = await workspace.handleToolCall({ id: 'c1', name: 'read_image', input: { path: 'work/folder' } });
+  assert.equal(dir.error, 'Path is a directory: work/folder');
+  const missing = await workspace.handleToolCall({ id: 'c2', name: 'read_image', input: { path: 'work/nope.png' } });
+  assert.equal(missing.error, 'File not found: work/nope.png');
+});


### PR DESCRIPTION
## Problem

`WorkspaceModule.resolveAbsolutePath()` validates lexical `..` containment and hands peers an absolute path; a peer that then `fs.readFile()`s it follows filesystem symlinks, so an in-mount path can resolve to content outside the declared mount — connectome-host #101 pulled a mounted `instructions/AGENTS.md -> /outside/secret.txt` into a system-position injection. The mount and symlink policy belongs to the workspace boundary; every peer should not have to rebuild it.

Fixes #129.

## Changes

- **`readFileFromDisk(mountPath, { maxBytes? })`** — workspace-owned read for peer modules. Enforces the mount's `followSymlinks` policy (default: refuse) with `O_NOFOLLOW` where the platform has it and a post-open `lstat` where it doesn't; realpaths both mount root and opened file and requires **canonical containment** (catches intermediate symlinked directories, followed symlinks landing outside, and sibling-prefix roots like `/mount-other`); confirms descriptor and canonical path share an inode. `maxBytes` is a **bounded prefix read** — the rest of the file is never loaded — returning `truncated` alongside full `size`, `mtimeMs` and canonical `realPath` (the cache key #101's module wants).
- **`WorkspaceReadError`** (exported, plus the result/option types) with `code ∈ unknown_mount | traversal | mount_unavailable | not_found | directory | symlink | escape | changed` and a `stage` for diagnostics. Messages carry mount-prefixed paths only — no host layout leaks.
- **Shared core, not a second copy**: the algorithm is the one `read_image` already ran. It is extracted into `openContainedFile()`; `read_image` now runs on it and maps refusals back onto its historical codes **and exact wording** (pinned by `workspace-read-image.test.ts`, 13/13 unchanged). Size policy runs at the same point in the sequence as before via an `inspect` hook.
- `resolveAbsolutePath()` documented as **lexical-only** and `@deprecated` for direct reads (still works; resolution-only uses — write targets, nonexistent paths — are unchanged).
- Changelog fragment `changelog.d/129-workspace-read-file-from-disk.added.md`.

## Tests

New `test/workspace-read-file-from-disk.test.ts` covers the issue's acceptance list: regular in-mount read; final-component `mount/file -> outside` rejected under default no-follow (`symlink`); intermediate symlinked-directory escape rejected (`escape`); with `followSymlinks`, an in-mount target follows and reports its canonical `realPath` while an outside target is still `escape`; the same in-mount symlink is refused under default policy (policy, not containment, decides); sibling-prefix root rejected; `maxBytes` truncation with full `size`; missing/directory/traversal/unknown-mount distinguished by code; `read_image` wording spot-check.

- ubuntu (Node 24), clean `dist`: **653 pass / 0 fail** (base `98c34c5`: 643 / 0; +10 are this PR's). New suite 10/10 with **real symlinks**; `workspace-read-image` 13/13.
- native Windows 11: 5/5 non-symlink cases pass; the 5 symlink cases **skip with an explicit reason** (`symlinkSync` → EPERM without the privilege) rather than fail, per "covered where the platform permits it". `read_image` 12/13 on Windows — the 1 failure is the pre-existing `symlinkSync`-without-guard test, identical on unmodified `main` (verified).
- `npx tsc --noEmit`: clean.

## Not verified

- Windows **junction** semantics were not exercised by a test (no junction case in the suite); by construction they resolve through `realpath` into the same containment check, but that is inspection, not evidence.
- No live host boot — unit tests drive `WorkspaceModule` over a tmpdir.

## Companion / follow-up

Once released, connectome-host's `InstructionsModule` (#101) can drop its local realpath defense for `readFileFromDisk` — happy to send that PR. Safe to land this alone; nothing depends on it yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
