### PR TITLE
fix(routing): world say/whisper silence adjacent prose in every mode

### DIFF
--- a/changelog.d/world-say-silences-prose.fixed.md
+++ b/changelog.d/world-say-silences-prose.fixed.md
@@ -1,0 +1,9 @@
+- **World `say` / `whisper` now silence adjacent auto-routed prose in every
+  prose-routing mode**, not only `hybrid`. In `locus` mode a round of ordinary
+  text plus an explicit Eidoverse `say` published twice — the say text, then the
+  adjacent prose auto-routed to the same world locus (Cairn, 2026-09-01, world
+  seq 15146/15147 byte-for-byte). An explicit world utterance is the resident's
+  chosen public speech for that round and is treated exactly like a channel
+  send: sticky silencing from that round on, suppression visible in the
+  `[delivered]` receipt. Discord send/reply/DM, `skip_reply`, `think()` privacy,
+  text-only turns and non-publishing tool rounds are unchanged.

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -126,8 +126,24 @@ const SILENCING_TOOLS = new Set([
   'skip_reply', 'channel_publish', 'send_message', 'reply_message', 'send_dm',
 ]);
 
-/** World-surface publication names that outrank hybrid prose envelopes. */
-const HYBRID_PUBLICATION_TOOLS = new Set(['say', 'whisper']);
+/**
+ * World-surface publication tools (Eidoverse `say` / `whisper`). An explicit
+ * world utterance is the resident's chosen public speech for that round, so
+ * it silences adjacent auto-routed prose exactly like a channel send — in
+ * EVERY prose-routing mode. Until 2026-09-01 this set was consulted only in
+ * hybrid mode; in locus mode a round of ordinary text + `say` published twice
+ * (Cairn world seq 15146 = the say text, 15147 = the adjacent prose,
+ * byte-for-byte). Hybrid additionally lets these outrank a same-round
+ * `>>>destination` envelope.
+ */
+const WORLD_PUBLICATION_TOOLS = new Set(['say', 'whisper']);
+
+/** True when a tool call (possibly MCPL-prefixed) is an explicit delivery
+ *  that silences the round's auto-routed prose, regardless of mode. */
+const isSilencingTool = (name: string): boolean => {
+  const bare = bareToolName(name);
+  return SILENCING_TOOLS.has(bare) || WORLD_PUBLICATION_TOOLS.has(bare);
+};
 
 /**
  * True when an injected message is real conversational input — something the
@@ -6257,10 +6273,7 @@ export class AgentFramework {
               const hasSameRoundPrivateThink =
                 roundToolNames.includes('think') &&
                 requestSnapshot.sameRoundThinkTextPolicy === 'private';
-              if (roundToolNames.some((n) =>
-                SILENCING_TOOLS.has(bareToolName(n)) ||
-                (agent.proseRouting === 'hybrid' && HYBRID_PUBLICATION_TOOLS.has(bareToolName(n)))
-              )) {
+              if (roundToolNames.some(isSilencingTool)) {
                 turnSilenced = true;
               }
               if (roundContent && roundContent.length > 0) {
@@ -6675,10 +6688,7 @@ export class AgentFramework {
                 .filter((n): n is string => typeof n === 'string');
               const silenced = liveProseRouting
                 ? turnSilenced
-                : turnSilenced || toolNames.some((n) =>
-                  SILENCING_TOOLS.has(bareToolName(n)) ||
-                  (agent.proseRouting === 'hybrid' && HYBRID_PUBLICATION_TOOLS.has(bareToolName(n)))
-                );
+                : turnSilenced || toolNames.some(isSilencingTool);
 
               const segments = splitProseSegments(liveProseRouting ? terminalContent : response.content);
 

--- a/test/present-while-acting.test.ts
+++ b/test/present-while-acting.test.ts
@@ -69,6 +69,18 @@ class RobotModule implements Module {
         description: 'Explicitly send a message',
         inputSchema: { type: 'object', properties: { text: { type: 'string' } } },
       },
+      // World-surface publication verbs (Eidoverse). Bare names matter: the
+      // framework strips the `robot--` prefix before consulting its sets.
+      {
+        name: 'say',
+        description: 'Say something aloud in the world',
+        inputSchema: { type: 'object', properties: { text: { type: 'string' } } },
+      },
+      {
+        name: 'whisper',
+        description: 'Whisper to someone in the world',
+        inputSchema: { type: 'object', properties: { to: { type: 'string' }, text: { type: 'string' } } },
+      },
     ];
   }
 
@@ -615,6 +627,70 @@ describe('present while acting', () => {
     assert.deepEqual(receipts, [
       '[delivered] nothing — 2 plain-speech segment(s) suppressed (explicit send in the same round — resend with a send tool if it was meant to be heard)',
     ]);
+
+    await framework.stop();
+  });
+
+  for (const verb of ['say', 'whisper'] as const) {
+    it(`world \`${verb}\` silences adjacent auto-routed prose in locus mode (no double-publish)`, async () => {
+      // 2026-09-01 (Cairn, locus mode): a round of ordinary text + explicit
+      // world `say` published TWICE — seq 15146 was the say text, seq 15147
+      // the adjacent prose auto-routed to the same world locus, byte-for-byte.
+      // World publication verbs silenced only in hybrid mode; Discord sends
+      // silenced everywhere. An explicit world utterance is the resident's
+      // chosen speech for the round in every mode.
+      const input = verb === 'say'
+        ? { text: 'the intended utterance' }
+        : { to: 'sill', text: 'the intended utterance' };
+      membrane.pushResponse(createMockResponse([
+        { type: 'text', text: 'adjacent prose that must NOT auto-publish' },
+        { type: 'tool_use', id: 'c1', name: `robot--${verb}`, input },
+      ] as ContentBlock[], 'tool_use'));
+      membrane.pushResponse(createMockResponse([
+        { type: 'text', text: 'trailing prose, also suppressed (sticky)' },
+      ] as ContentBlock[]));
+
+      const framework = await createFramework();
+      const routed = stubChannelRegistry(framework);
+
+      trigger(framework);
+      await framework.runUntilIdle();
+
+      assert.deepEqual(routed, [], `${verb}: nothing auto-routed beside the explicit world utterance`);
+      const cm = (framework as unknown as {
+        agents: Map<string, { getContextManager(): { getAllMessages(): Array<{ content: Array<{ type: string; text?: string }> }> } }>;
+      }).agents.get('assistant')!.getContextManager();
+      const receipts = cm.getAllMessages()
+        .flatMap((m) => m.content)
+        .filter((b) => b.type === 'text')
+        .map((b) => b.text ?? '')
+        .filter((t) => t.startsWith('[delivered]'));
+      assert.deepEqual(receipts, [
+        '[delivered] nothing — 2 plain-speech segment(s) suppressed (explicit send in the same round — resend with a send tool if it was meant to be heard)',
+      ], `${verb}: suppression is visible in the receipt`);
+
+      await framework.stop();
+    });
+  }
+
+  it('a non-publishing world tool (move) does not silence — speak-while-acting unchanged', async () => {
+    // Negative control for the world-verb silencing: only publication verbs
+    // silence. Ordinary acting tools still narrate live to the locus.
+    membrane.pushResponse(createMockResponse([
+      { type: 'text', text: 'walking over' },
+      { type: 'tool_use', id: 'c1', name: 'robot--move', input: { dir: 'north' } },
+    ] as ContentBlock[], 'tool_use'));
+    membrane.pushResponse(createMockResponse([
+      { type: 'text', text: 'there' },
+    ] as ContentBlock[]));
+
+    const framework = await createFramework();
+    const routed = stubChannelRegistry(framework);
+
+    trigger(framework);
+    await framework.runUntilIdle();
+
+    assert.deepEqual(routed.map((r) => r.text), ['walking over', 'there']);
 
     await framework.stop();
   });


### PR DESCRIPTION
## Incident

Mica's report `af-world-say-prose-leak-20260901.md` (SHA-256 `9507f309…`): in **locus** prose mode, a round of ordinary text + explicit Eidoverse `say` published **twice** — world seq 15146 = the `say` tool input, seq 15147 = the adjacent ordinary text, byte-for-byte (Cairn provider row 230). Not a `same_round_think_text_policy` bypass; no `think()` was called and provider-native thinking stayed private.

## Root cause (confirmed)

`src/framework.ts` consulted `HYBRID_PUBLICATION_TOOLS` (`say`, `whisper`) only when `agent.proseRouting === 'hybrid'`, at both silencing sites (live round + trailing scan). Introduced by `c83fadb3` (2026-08-14, hybrid envelopes). Discord sends in `SILENCING_TOOLS` silenced in every mode; world verbs did not.

## Fix

Fold the world verbs into one `isSilencingTool(name)` predicate used at both sites. An explicit world utterance now behaves exactly like a channel send in every mode: sticky silencing from that round on, suppression visible in the `[delivered]` receipt. No behavior change for Discord send/reply/DM, `skip_reply`, `think()` privacy, text-only turns, non-publishing tool rounds, `explicit` mode (silencing never applied there), or `disabled` mode.

## Receipts (worktree off `origin/main` `d9fb35b`, node_modules shared)

- typecheck clean
- focused (`present-while-acting`, `explicit-prose-routing`, `same-round-think-policy`, `prose-stream-router`): **74/74**
- full: **0 fail** on both runs (629/633 and 656/660 — totals vary run to run under `--test-force-exit`; base `d9fb35b` was 631/635, also 0 fail)
- **mutation control**: removing `WORLD_PUBLICATION_TOOLS` from the predicate fails both new locus tests *and* the existing hybrid `say` test; the `move` negative control still passes

## Nonblocking notes

- `emote` is also a world publication verb; left out of the set, matching the report's scope. Whether an emote should silence narration is a doctrine call.
- `bareToolName` strips the MCPL prefix, so any server exposing a bare `say`/`whisper` tool (e.g. `tavern-mcpl`) now silences too. Consistent with hybrid's existing behavior.
- Deploy is separate: Mac residents load AF via the `forking-knowledge-miner` symlink to the local checkout, so this lands only on pull + restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017op4YjCZABYS9vWBXxeRwH
