### PR TITLE
MCPL RFC-005 follow-up: fetch_reference + lazy-default autofetch

### DIFF
--- a/src/framework.ts
+++ b/src/framework.ts
@@ -1,5 +1,6 @@
 import { join } from 'node:path';
-import { INLINE_WITHHELD_TEXT, isInlineContradiction, referenceStubOrNull } from './mcpl/references.js';
+import { INLINE_WITHHELD_TEXT, classifyBlock, isInlineContradiction, referenceRegistry, referenceStubOrNull } from './mcpl/references.js';
+import { ReferenceFetcher, DEFAULT_FETCH_MAX_BYTES, EAGER_FETCH_TIMEOUT_MS } from './mcpl/reference-fetcher.js';
 import { appendFileSync, mkdirSync } from 'node:fs';
 import { JsStore } from '@animalabs/chronicle';
 import type { Membrane, ContentBlock, NormalizedRequest, YieldingStream, ToolResult as MembraneToolResult, ToolResultContentBlock } from '@animalabs/membrane';
@@ -1753,7 +1754,8 @@ export class AgentFramework {
       ...gateTools,
       this.buildAgentSettingsTool(),
       ...(this.getWorkspaceModule()
-        ? [AgentFramework.SAVE_IMAGE_TOOL, AgentFramework.READ_IMAGE_TOOL]
+        ? [AgentFramework.SAVE_IMAGE_TOOL, AgentFramework.READ_IMAGE_TOOL,
+           AgentFramework.FETCH_REFERENCE_TOOL]
         : []),
       ...(this.codeExecutionConfig
         ? [buildCodeExecutionToolDefinition(this.codeExecutionConfig)]
@@ -1767,6 +1769,55 @@ export class AgentFramework {
     return module && typeof (module as WorkspaceModule).writeBinary === 'function'
       ? (module as WorkspaceModule)
       : undefined;
+  }
+
+  /** RFC-005 host-mediated reference fetcher (lazy; needs server configs +
+   *  a writable workspace mount for storage). */
+  private referenceFetcherInstance?: ReferenceFetcher;
+  private getReferenceFetcher(): ReferenceFetcher {
+    if (!this.referenceFetcherInstance) {
+      this.referenceFetcherInstance = new ReferenceFetcher(
+        (serverId) => {
+          const cfg = this.mcplServerConfigs.get(serverId);
+          if (!cfg?.url) return undefined;
+          return { url: cfg.url, token: cfg.token, autofetch: cfg.autofetch };
+        },
+        async (fileName, data, mimeType) => {
+          const workspace = this.getWorkspaceModule();
+          if (!workspace) return null;
+          const mount = this.firstWritableMountName(workspace);
+          if (!mount) return null;
+          const path = `${mount}/refs/${fileName}`;
+          const res = await workspace.writeBinary(path, data, mimeType);
+          return res.success ? path : null;
+        },
+      );
+    }
+    return this.referenceFetcherInstance;
+  }
+
+  /** Register every RFC-005 reference in a tool-result content array against
+   *  its server, then eagerly fetch the ones inside the autofetch envelope
+   *  (below the eager ceiling, connection origin — never worse than the
+   *  server having inlined the bytes). Failures are non-fatal: the stub then
+   *  says fetch_reference instead of a path. */
+  private async autoFetchReferences(content: unknown[] | undefined, serverId: string, eager: boolean): Promise<void> {
+    if (!content) return;
+    const fetcher = this.getReferenceFetcher();
+    const eligible: import('./mcpl/references.js').ReferenceRecord[] = [];
+    for (const block of content) {
+      const c = classifyBlock(block);
+      if (c.kind !== 'reference') continue;
+      const record = referenceRegistry.register(c.testimony, serverId);
+      if (eager && fetcher.isEagerEligible(record)) eligible.push(record);
+    }
+    // Parallel with a count cap: N small fetches cost one round-trip of
+    // wall-clock, and anything past the cap stays lazy (stub says so).
+    const MAX_EAGER_PER_RESULT = 8;
+    await Promise.all(eligible.slice(0, MAX_EAGER_PER_RESULT).map(async (record) => {
+      const outcome = await fetcher.fetch(record, { timeoutMs: EAGER_FETCH_TIMEOUT_MS });
+      if (!outcome.ok) console.error(`[rfc005] eager fetch of ${record.refId} failed: ${outcome.error}`);
+    }));
   }
 
   /** Core agent_settings keys — extension keys must not collide with these. */
@@ -2744,6 +2795,28 @@ export class AgentFramework {
         },
       },
       required: ['path'],
+    },
+  };
+
+  /** Synthesized fetch_reference tool — RFC-005 on-demand dereference.
+   *  Present when a workspace module is registered (storage target). */
+  private static readonly FETCH_REFERENCE_TOOL: import('./types/index.js').ToolDefinition = {
+    name: 'fetch_reference',
+    description:
+      'Fetch a referenced payload (a [ref_…] id from a tool result or event) ' +
+      'to a workspace file via the host-mediated fetcher. The fetch is ' +
+      'origin-bound to the server that sent the reference, size-capped, and ' +
+      'digest-verified when the reference carries one. Returns the workspace ' +
+      'path plus verified size/type; then use ordinary workspace tools on it. ' +
+      'Small payloads may already be fetched automatically — their stubs show ' +
+      'a saved path instead.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        ref_id: { type: 'string', description: 'The reference id, e.g. "ref_1a_x9z2".' },
+        max_bytes: { type: 'number', description: 'Optional per-call byte ceiling (default host policy).' },
+      },
+      required: ['ref_id'],
     },
   };
 
@@ -7807,6 +7880,21 @@ export class AgentFramework {
       return `Error: ${result.error ?? 'tool call failed'}`;
     }
     if (result.data === undefined) return '';
+    // RFC-005 "eagerly lazy": a script receiving a result is the strongest
+    // available signal that the bytes are wanted (scripts process, they do
+    // not browse) — materialize every referenced payload now, so the stub
+    // the script receives carries a workspace path it can open directly.
+    if (Array.isArray(result.data)) {
+      const fetcher = this.getReferenceFetcher();
+      for (const block of result.data) {
+        const c = classifyBlock(block);
+        if (c.kind !== 'reference') continue;
+        const record = referenceRegistry.findByUri(c.testimony.uri)
+          ?? referenceRegistry.register(c.testimony);
+        const outcome = await fetcher.fetch(record);
+        if (!outcome.ok) console.error(`[rfc005] script-demand fetch of ${record.refId} failed: ${outcome.error}`);
+      }
+    }
     // Scripts get (nearly) full data — the script environment IS the spill:
     // filtering big results in code is the whole point. 5MB protocol safety
     // cap only; no context-cap truncation, no file spill.
@@ -8143,6 +8231,11 @@ export class AgentFramework {
 
     if (enrichedCall.name === 'read_image') {
       this.dispatchReadImageToolCall(agentName, enrichedCall);
+      return;
+    }
+
+    if (enrichedCall.name === 'fetch_reference') {
+      this.dispatchFetchReferenceToolCall(agentName, enrichedCall);
       return;
     }
 
@@ -10352,6 +10445,13 @@ export class AgentFramework {
     }
 
     server.sendToolsCall(toolName, args, stateParams)
+      .then(async (result) => {
+        // RFC-005: register references and eagerly fetch the small ones
+        // before serialization, so their stubs carry a saved path.
+        await this.autoFetchReferences(result.content, serverId, true)
+          .catch((e) => console.error('[rfc005] autofetch error:', (e as Error).message));
+        return result;
+      })
       .then((result) => {
         const durationMs = Date.now() - startTime;
         this.emitTrace({ type: 'tool:completed', module: `mcpl:${serverId}`, tool: toolName, callId: call.id, durationMs });
@@ -10797,6 +10897,43 @@ export class AgentFramework {
    * blocks) delivers the actual image to the model; history storage keeps
    * the standard compact `[image: …]` placeholder.
    */
+  /** RFC-005 on-demand dereference: [ref id] → workspace file, via the
+   *  origin-bound, ceiling-bounded, digest-verified host fetcher. */
+  private dispatchFetchReferenceToolCall(agentName: string, call: ToolCall): void {
+    this.emitTrace({ type: 'tool:started', module: 'workspace', tool: call.name, callId: call.id, input: call.input });
+    const startTime = Date.now();
+    void (async () => {
+      const args = (call.input ?? {}) as Record<string, unknown>;
+      const refId = String(args.ref_id ?? '');
+      const record = referenceRegistry.get(refId);
+      let result: { success: boolean; data?: string; error?: string; isError?: boolean };
+      if (!record) {
+        // Vector 20: a stale or unknown id is a defined miss, never a
+        // different record.
+        result = { success: false, isError: true,
+          error: `unknown reference: ${refId || '(missing ref_id)'} — it may have been evicted; ids are never reused` };
+      } else {
+        const maxBytes = typeof args.max_bytes === 'number'
+          ? Math.min(args.max_bytes, DEFAULT_FETCH_MAX_BYTES) : undefined;
+        const outcome = await this.getReferenceFetcher().fetch(record, { maxBytes });
+        result = outcome.ok
+          ? { success: true, data: JSON.stringify({ path: outcome.path, bytes: outcome.bytes,
+              mime_type: outcome.mimeType, digest_verified: outcome.digestVerified ?? 'no digest claimed' }) }
+          : { success: false, isError: true, error: outcome.error };
+      }
+      this.emitTrace({
+        type: result.isError ? 'tool:failed' : 'tool:completed',
+        module: 'workspace', tool: call.name, callId: call.id,
+        durationMs: Date.now() - startTime,
+        ...(result.isError ? { error: result.error } : {}),
+      });
+      this.pushEvent({
+        type: 'tool-result', callId: call.id, agentName, moduleName: 'workspace',
+        result: { ...result, isError: result.isError ?? false },
+      });
+    })();
+  }
+
   private dispatchReadImageToolCall(agentName: string, call: ToolCall): void {
     this.emitTrace({ type: 'tool:started', module: 'workspace', tool: call.name, callId: call.id, input: call.input });
     const finish = (result: ToolResult): void => {

--- a/src/mcpl/reference-fetcher.ts
+++ b/src/mcpl/reference-fetcher.ts
@@ -1,0 +1,240 @@
+/**
+ * RFC-005 host-mediated reference fetcher (§6, §7) — the only code that ever
+ * dereferences a reference, and it fails closed on every axis the RFC names:
+ *
+ *  - **origin binding (§6.1, revision 3):** authenticated fetches go only to
+ *    the origin the reference's server connection was dialed to. This v1 does
+ *    not fetch third-party origins at all (deferred with declared reference
+ *    origins); the connection credential is applied as an Authorization
+ *    header by this code alone and never surfaces to model, script, or URI.
+ *  - **scheme allowlist (§7.1, vector 11):** https; http only when the dialed
+ *    origin itself is plaintext (a ws:// server references its own origin).
+ *  - **no redirect traversal (§7.2, vector 12):** any 3xx refuses.
+ *  - **actual-byte ceiling (§7.3 list, vector 10):** streamed with abort the
+ *    moment real octets exceed the ceiling, regardless of claimed sizeBytes.
+ *    A claim already over the ceiling refuses without dialing (vector 4).
+ *  - **digest verification (§7.4 list, vector 5):** sha256 computed while
+ *    streaming; a mismatch is discarded, never presented.
+ *  - **expiry (§7.4, vector 16):** expired testimony refuses locally.
+ *  - **storage naming (§7.3):** the file name is host-generated from the
+ *    reference id + verified type; the server's `name` is display-only.
+ *
+ * Autofetch policy (host default, not protocol): eager only below
+ * DEFAULT_EAGER_FETCH_MAX_BYTES from the connection origin — anything under
+ * that threshold the server could legitimately have inlined, so eager
+ * materialization is never worse than the status quo. Everything larger is
+ * fetched on demand (the fetch_reference tool, or the code-execution result
+ * hook, where a script receiving a result is the strongest available signal
+ * that the bytes are wanted). Per-server budgets cap cumulative appetite.
+ */
+import { createHash } from 'node:crypto';
+import type { ReferenceRecord } from './references.js';
+import { isReferenceExpired } from './references.js';
+
+/** Per-fetch hard ceiling on actual bytes (overridable per server / call). */
+export const DEFAULT_FETCH_MAX_BYTES = 256 * 1024 * 1024;
+/** Eager (autofetch) threshold: at most what could have shipped inline. */
+export const DEFAULT_EAGER_FETCH_MAX_BYTES = 256 * 1024;
+/** Cumulative per-server budget for this process. */
+export const DEFAULT_MAX_TOTAL_BYTES = 1024 * 1024 * 1024;
+const FETCH_TIMEOUT_MS = 60_000;
+const EAGER_FETCH_TIMEOUT_MS = 10_000;
+
+export interface ResolvedServerBinding {
+  /** The url the connection was dialed to (ws/wss/http/https). */
+  url: string;
+  /** Connection credential, applied host-side as Authorization: Bearer. */
+  token?: string;
+  autofetch?: { maxBytes?: number; maxTotalBytes?: number };
+}
+
+export interface FetchOutcome {
+  ok: boolean;
+  /** Mount-prefixed workspace path of the saved payload (on success). */
+  path?: string;
+  bytes?: number;
+  mimeType?: string;
+  digestVerified?: boolean;
+  error?: string;
+}
+
+/** Magic-byte sniff for the formats this pipeline actually moves. The
+ *  header is testimony too (vector 13): sniffed type wins for the storage
+ *  extension and the record's verified type; header, then testimony, are
+ *  fallbacks for containers the sniffer doesn't know. */
+export function sniffMime(data: Buffer): string | null {
+  if (data.length < 12) return null;
+  if (data.subarray(0, 4).toString('latin1') === 'RIFF' && data.subarray(8, 12).toString('latin1') === 'WAVE') return 'audio/wav';
+  if (data.subarray(0, 4).toString('latin1') === 'RIFF') return 'audio/wav';
+  if (data.subarray(0, 4).toString('latin1') === 'fLaC') return 'audio/flac';
+  if (data.subarray(0, 4).toString('latin1') === 'OggS') return 'audio/ogg';
+  if (data.subarray(0, 4).toString('latin1') === 'MThd') return 'audio/midi';
+  if (data.subarray(0, 3).toString('latin1') === 'ID3' || (data[0] === 0xff && (data[1] & 0xe0) === 0xe0)) return 'audio/mpeg';
+  if (data[0] === 0x89 && data.subarray(1, 4).toString('latin1') === 'PNG') return 'image/png';
+  if (data[0] === 0xff && data[1] === 0xd8 && data[2] === 0xff) return 'image/jpeg';
+  if (data.subarray(0, 6).toString('latin1') === 'GIF87a' || data.subarray(0, 6).toString('latin1') === 'GIF89a') return 'image/gif';
+  if (data.subarray(4, 8).toString('latin1') === 'ftyp') return 'video/mp4';
+  if (data.subarray(0, 5).toString('latin1') === '%PDF-') return 'application/pdf';
+  if (data[0] === 0x50 && data[1] === 0x4b) return 'application/zip';
+  return null;
+}
+
+const EXT_BY_MIME: Record<string, string> = {
+  'audio/wav': 'wav', 'audio/x-wav': 'wav', 'audio/mpeg': 'mp3', 'audio/mp4': 'm4a',
+  'audio/flac': 'flac', 'audio/midi': 'mid', 'audio/ogg': 'ogg',
+  'image/png': 'png', 'image/jpeg': 'jpg', 'image/gif': 'gif', 'image/webp': 'webp',
+  'video/mp4': 'mp4', 'application/json': 'json', 'text/plain': 'txt',
+  'application/pdf': 'pdf', 'application/zip': 'zip',
+};
+
+/** ws→http / wss→https with default ports elided, for origin comparison. */
+export function normalizedOrigin(url: string): string | null {
+  try {
+    const u = new URL(url);
+    const scheme = u.protocol === 'ws:' ? 'http:' : u.protocol === 'wss:' ? 'https:' : u.protocol;
+    const defaultPort = scheme === 'https:' ? '443' : '80';
+    const port = u.port === '' || u.port === defaultPort ? '' : `:${u.port}`;
+    return `${scheme}//${u.hostname.toLowerCase()}${port}`;
+  } catch {
+    return null;
+  }
+}
+
+export class ReferenceFetcher {
+  private totals = new Map<string, number>();
+  private inFlight = new Map<string, Promise<FetchOutcome>>();
+
+  constructor(
+    private readonly resolveServer: (serverId: string) => ResolvedServerBinding | undefined,
+    /** Persist the payload; returns a mount-prefixed path or null when no
+     *  writable workspace exists. File name is host-generated (§7.3). */
+    private readonly saveFile: (fileName: string, data: Buffer, mimeType: string) => Promise<string | null>,
+  ) {}
+
+  /** Would the eager (autofetch) default fetch this record? */
+  isEagerEligible(record: ReferenceRecord): boolean {
+    if (record.fetchedPath) return false;
+    if (record.serverId === undefined) return false;
+    const binding = this.resolveServer(record.serverId);
+    if (!binding) return false;
+    const cap = binding.autofetch?.maxBytes ?? DEFAULT_EAGER_FETCH_MAX_BYTES;
+    if (record.testimony.sizeBytes === undefined || record.testimony.sizeBytes > cap) return false;
+    return this.originCheck(record, binding) === null;
+  }
+
+  /** §6.1/§7.1 policy check; returns a refusal reason or null. */
+  private originCheck(record: ReferenceRecord, binding: ResolvedServerBinding): string | null {
+    const refOrigin = normalizedOrigin(record.testimony.uri);
+    const dialedOrigin = normalizedOrigin(binding.url);
+    if (!refOrigin) return 'reference uri does not parse';
+    if (!dialedOrigin) return 'server url does not parse';
+    const scheme = refOrigin.split('//')[0];
+    if (scheme !== 'https:' && scheme !== 'http:') return `scheme not allowed: ${scheme}`;
+    if (refOrigin !== dialedOrigin) {
+      return `third-party origin (${refOrigin} != dialed ${dialedOrigin}); not fetched by this host`;
+    }
+    if (scheme === 'http:' && dialedOrigin.startsWith('https:')) {
+      return 'plaintext reference from a secure origin';
+    }
+    return null;
+  }
+
+  /** Fetch a reference to workspace storage. Idempotent per record; concurrent
+   *  callers share one in-flight fetch. */
+  fetch(record: ReferenceRecord, opts?: { maxBytes?: number; timeoutMs?: number }): Promise<FetchOutcome> {
+    if (record.fetchedPath) {
+      return Promise.resolve({ ok: true, path: record.fetchedPath, bytes: record.verifiedBytes,
+        mimeType: record.verifiedMimeType, digestVerified: record.digestVerified });
+    }
+    const existing = this.inFlight.get(record.refId);
+    if (existing) return existing;
+    const p = this.doFetch(record, opts).finally(() => this.inFlight.delete(record.refId));
+    this.inFlight.set(record.refId, p);
+    return p;
+  }
+
+  private async doFetch(record: ReferenceRecord, opts?: { maxBytes?: number; timeoutMs?: number }): Promise<FetchOutcome> {
+    const t = record.testimony;
+    if (record.serverId === undefined) return { ok: false, error: 'reference has no server binding' };
+    const binding = this.resolveServer(record.serverId);
+    if (!binding) return { ok: false, error: `unknown server: ${record.serverId}` };
+
+    const refusal = this.originCheck(record, binding);
+    if (refusal) return { ok: false, error: refusal };
+    if (isReferenceExpired(t)) return { ok: false, error: 'reference expired (or unparseable expiry — fail closed)' };
+
+    const ceiling = opts?.maxBytes ?? DEFAULT_FETCH_MAX_BYTES;
+    // Vector 4: a claim already over the ceiling refuses without dialing.
+    if (t.sizeBytes !== undefined && t.sizeBytes > ceiling) {
+      return { ok: false, error: `claimed ${t.sizeBytes} bytes exceeds fetch ceiling ${ceiling}` };
+    }
+    const budget = binding.autofetch?.maxTotalBytes ?? DEFAULT_MAX_TOTAL_BYTES;
+    const used = this.totals.get(record.serverId) ?? 0;
+    if (used >= budget) {
+      return { ok: false, error: `per-server fetch budget exhausted (${used}/${budget} bytes)` };
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), opts?.timeoutMs ?? FETCH_TIMEOUT_MS);
+    try {
+      const headers: Record<string, string> = {};
+      if (binding.token) headers.authorization = `Bearer ${binding.token}`;
+      const resp = await fetch(t.uri, { headers, redirect: 'manual', signal: controller.signal });
+      if (resp.status >= 300 && resp.status < 400) {
+        return { ok: false, error: `redirect refused (HTTP ${resp.status}) — no redirect traversal` };
+      }
+      if (!resp.ok) return { ok: false, error: `HTTP ${resp.status}` };
+      if (!resp.body) return { ok: false, error: 'no response body' };
+
+      const hash = createHash('sha256');
+      const chunks: Buffer[] = [];
+      let received = 0;
+      const reader = resp.body.getReader();
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        received += value.byteLength;
+        if (received > ceiling || received > budget - used) {
+          controller.abort();
+          const which = received > ceiling ? 'ceiling' : 'per-server budget';
+          return { ok: false, error: `aborted: actual bytes exceeded ${which} at ${received}` };
+        }
+        const buf = Buffer.from(value);
+        hash.update(buf);
+        chunks.push(buf);
+      }
+      const data = Buffer.concat(chunks);
+
+      let digestVerified: boolean | undefined;
+      if (t.digest) {
+        const got = 'sha256:' + hash.digest('base64url');
+        if (got !== t.digest) {
+          // Vector 5: never presented as the described content.
+          return { ok: false, error: `digest mismatch (claimed ${t.digest.slice(0, 20)}…, got ${got.slice(0, 20)}…)` };
+        }
+        digestVerified = true;
+      }
+
+      const headerMime = resp.headers.get('content-type')?.split(';')[0].trim() || null;
+      const observedMime = sniffMime(data) ?? headerMime ?? t.mimeType ?? 'application/octet-stream';
+      const ext = EXT_BY_MIME[observedMime] ?? EXT_BY_MIME[headerMime ?? ''] ?? EXT_BY_MIME[t.mimeType ?? ''] ?? 'bin';
+      // §7.3: host-generated storage name; the server's `name` is display-only.
+      const path = await this.saveFile(`${record.refId}.${ext}`, data, observedMime);
+      if (path === null) return { ok: false, error: 'no writable workspace mount to store the payload' };
+
+      this.totals.set(record.serverId, used + data.length);
+      record.fetchedPath = path;
+      record.verifiedBytes = data.length;
+      record.verifiedMimeType = observedMime;
+      record.digestVerified = digestVerified;
+      return { ok: true, path, bytes: data.length, mimeType: observedMime, digestVerified };
+    } catch (e) {
+      const msg = (e as Error).name === 'AbortError' ? 'fetch timed out or aborted' : (e as Error).message;
+      return { ok: false, error: msg };
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+export { EAGER_FETCH_TIMEOUT_MS };

--- a/src/mcpl/references.ts
+++ b/src/mcpl/references.ts
@@ -167,6 +167,11 @@ export interface ReferenceRecord {
   serverId?: string;
   testimony: ReferenceTestimony;
   receivedAt: number;
+  /** Set by the host-mediated fetcher after a successful, verified fetch. */
+  fetchedPath?: string;
+  verifiedBytes?: number;
+  verifiedMimeType?: string;
+  digestVerified?: boolean;
 }
 
 const MAX_RECORDS = 2000;
@@ -184,34 +189,44 @@ const MAX_RECORDS = 2000;
  */
 export class ReferenceRegistry {
   private records = new Map<string, ReferenceRecord>();
-  /** (serverId|uri) → refId: repeated references to the same payload share a
-   *  record, so the id a model sees is stable across serializations (each
-   *  tool result is serialized twice: native wire + history) and across
-   *  repeated mentions — RFC §5's "stable for the life of the session". */
+  /** uri → refId. The uri ALONE is the identity key: stub sites (the two
+   *  tool-result serializers and the three converters) are free functions
+   *  with no server context, while dispatch-time pre-registration carries a
+   *  serverId — keying on both split every reference into two records, the
+   *  model-visible one unbound (fetch_reference failed on it) and the bound
+   *  one invisible. One key, and a later registration that knows the server
+   *  UPGRADES the record's binding instead of forking it. If two servers ever
+   *  reference the same uri, the first binding wins (the record's serverId
+   *  feeds the origin check, which fails closed on a mismatch). */
   private byKey = new Map<string, string>();
   private counter = 0;
 
-  private key(uri: string, serverId?: string): string {
-    return `${serverId ?? '?'}|${uri}`;
-  }
-
   register(testimony: ReferenceTestimony, serverId?: string): ReferenceRecord {
-    const k = this.key(testimony.uri, serverId);
-    const existingId = this.byKey.get(k);
+    const existingId = this.byKey.get(testimony.uri);
     if (existingId !== undefined) {
       const existing = this.records.get(existingId);
-      if (existing) return existing;
+      if (existing) {
+        if (serverId !== undefined && existing.serverId === undefined) {
+          existing.serverId = serverId;
+        }
+        // Refresh testimony while unfetched: a re-issued reference with a new
+        // digest/expiry supersedes the stale claims. Once fetched, the record
+        // describes verified bytes on disk and keeps the testimony they were
+        // verified against.
+        if (!existing.fetchedPath) existing.testimony = testimony;
+        return existing;
+      }
     }
     const refId = `ref_${(++this.counter).toString(36)}_${Math.random().toString(36).slice(2, 6)}`;
     const record: ReferenceRecord = { refId, serverId, testimony, receivedAt: Date.now() };
     this.records.set(refId, record);
-    this.byKey.set(k, refId);
+    this.byKey.set(testimony.uri, refId);
     if (this.records.size > MAX_RECORDS) {
       const oldest = this.records.keys().next().value;
       if (oldest !== undefined) {
         const old = this.records.get(oldest);
         this.records.delete(oldest);
-        if (old) this.byKey.delete(this.key(old.testimony.uri, old.serverId));
+        if (old) this.byKey.delete(old.testimony.uri);
       }
     }
     return record;
@@ -219,6 +234,12 @@ export class ReferenceRegistry {
 
   get(refId: string): ReferenceRecord | undefined {
     return this.records.get(refId);
+  }
+
+  /** Find the record for a uri. */
+  findByUri(uri: string): ReferenceRecord | undefined {
+    const id = this.byKey.get(uri);
+    return id !== undefined ? this.records.get(id) : undefined;
   }
 }
 
@@ -244,6 +265,13 @@ export function buildReferenceStub(t: ReferenceTestimony, provenance?: string, s
   if (t.sizeBytes !== undefined) meta.push(`${formatSizeBytes(t.sizeBytes)} claimed`);
   if (meta.length) parts.push(meta.join(', '));
   if (provenance) parts.push(sanitizeLabel(provenance, STUB_FIELD_CHARS));
+  if (record.fetchedPath) {
+    // Already materialized by the host-mediated fetcher: hand the model the
+    // workspace path (host-generated, §7.3) so existing tools just work.
+    parts.push(`saved: ${sanitizeLabel(record.fetchedPath, 256)}`);
+  } else {
+    parts.push('fetch with fetch_reference');
+  }
   return `[${record.refId}] ${parts.join(' — ') || 'referenced content'}`;
 }
 

--- a/src/mcpl/types.ts
+++ b/src/mcpl/types.ts
@@ -374,6 +374,10 @@ export interface McplServerConfig {
    * Chronicle and changed with channel_open/channel_close.
    */
   channelSubscription?: 'auto' | 'manual' | string[];
+  /** RFC-005 autofetch envelope for this server: per-fetch eager ceiling and
+   *  cumulative per-server byte budget (reference-fetcher.ts defaults apply
+   *  when absent). */
+  autofetch?: { maxBytes?: number; maxTotalBytes?: number };
 }
 
 // ============================================================================

--- a/test/mcpl-reference-fetcher.test.ts
+++ b/test/mcpl-reference-fetcher.test.ts
@@ -1,0 +1,213 @@
+/**
+ * RFC-005 fetcher vectors (§11: 4, 5, 10, 11, 12 + origin/expiry/budget)
+ * against a live local HTTP server.
+ *
+ * Run: node --import tsx --test test/mcpl-reference-fetcher.test.ts
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { createHash } from 'node:crypto';
+import { ReferenceFetcher, normalizedOrigin } from '../src/mcpl/reference-fetcher.js';
+import { ReferenceRegistry, classifyBlock } from '../src/mcpl/references.js';
+
+const PAYLOAD = Buffer.from('RIFF-not-really-a-wav-'.repeat(100));
+const DIGEST = 'sha256:' + createHash('sha256').update(PAYLOAD).digest('base64url');
+
+let lastAuth: string | null = null;
+const server = createServer((req, res) => {
+  const url = new URL(req.url ?? '/', 'http://x');
+  lastAuth = req.headers.authorization ?? null;
+  if (url.pathname === '/ok') {
+    res.writeHead(200, { 'content-type': 'audio/wav' }); res.end(PAYLOAD);
+  } else if (url.pathname === '/redirect') {
+    res.writeHead(302, { location: 'http://evil.example/x' }); res.end();
+  } else if (url.pathname === '/octet') {
+    res.writeHead(200, { 'content-type': 'application/octet-stream' }); res.end(PAYLOAD);
+  } else if (url.pathname === '/liar') {
+    // claims small in testimony, streams big (vector 10)
+    res.writeHead(200, { 'content-type': 'application/octet-stream' });
+    res.end(Buffer.alloc(200_000, 7));
+  } else {
+    res.writeHead(404); res.end();
+  }
+});
+await new Promise<void>((r) => server.listen(0, '127.0.0.1', r));
+const port = (server.address() as { port: number }).port;
+const ORIGIN = `http://127.0.0.1:${port}`;
+
+const saved: Array<{ name: string; bytes: number; mime: string }> = [];
+function makeFetcher(bindings: Record<string, { url: string; token?: string; autofetch?: { maxBytes?: number; maxTotalBytes?: number } }>) {
+  return new ReferenceFetcher(
+    (id) => bindings[id],
+    async (name, data, mime) => { saved.push({ name, bytes: data.length, mime }); return `scratch/refs/${name}`; },
+  );
+}
+
+function makeRecord(reg: ReferenceRegistry, uri: string, extra: Record<string, unknown> = {}, serverId: string | undefined = 'srv') {
+  const c = classifyBlock({ type: 'resource', uri, ...extra });
+  assert.equal(c.kind, 'reference');
+  return reg.register((c as Extract<ReturnType<typeof classifyBlock>, { kind: 'reference' }>).testimony, serverId);
+}
+
+test('happy path: origin-bound fetch, bearer auth applied host-side, digest verified', async () => {
+  const reg = new ReferenceRegistry();
+  const f = makeFetcher({ srv: { url: `ws://127.0.0.1:${port}`, token: 'sekrit' } });
+  const rec = makeRecord(reg, `${ORIGIN}/ok`, { sizeBytes: PAYLOAD.length, digest: DIGEST, mimeType: 'audio/wav', disposition: 'never' });
+  const out = await f.fetch(rec);
+  assert.equal(out.ok, true, out.error);
+  assert.equal(out.bytes, PAYLOAD.length);
+  assert.equal(out.digestVerified, true);
+  assert.equal(lastAuth, 'Bearer sekrit', 'connection credential must ride as a header, host-side');
+  assert.equal(rec.fetchedPath, `scratch/refs/${rec.refId}.wav`, 'storage name is host-generated from the record');
+  // idempotent: second fetch returns the cached materialization
+  const again = await f.fetch(rec);
+  assert.equal(again.path, out.path);
+});
+
+test('vector 5: digest mismatch is never presented', async () => {
+  const reg = new ReferenceRegistry();
+  const f = makeFetcher({ srv: { url: ORIGIN } });
+  const rec = makeRecord(reg, `${ORIGIN}/ok`, { digest: 'sha256:' + 'B'.repeat(43) });
+  const out = await f.fetch(rec);
+  assert.equal(out.ok, false);
+  assert.match(out.error!, /digest mismatch/);
+  assert.equal(rec.fetchedPath, undefined);
+});
+
+test('vector 10: stream past the ceiling aborts on actual bytes', async () => {
+  const reg = new ReferenceRegistry();
+  const f = makeFetcher({ srv: { url: ORIGIN } });
+  const rec = makeRecord(reg, `${ORIGIN}/liar`, { sizeBytes: 100 });
+  const out = await f.fetch(rec, { maxBytes: 50_000 });
+  assert.equal(out.ok, false);
+  assert.match(out.error!, /exceeded ceiling/);
+});
+
+test('vector 4: a claim already over the ceiling refuses without dialing', async () => {
+  const reg = new ReferenceRegistry();
+  const f = makeFetcher({ srv: { url: ORIGIN } });
+  const rec = makeRecord(reg, `${ORIGIN}/ok`, { sizeBytes: 10_000_000 });
+  const out = await f.fetch(rec, { maxBytes: 1000 });
+  assert.equal(out.ok, false);
+  assert.match(out.error!, /exceeds fetch ceiling/);
+});
+
+test('vector 11: non-http(s) scheme refused', async () => {
+  const reg = new ReferenceRegistry();
+  const f = makeFetcher({ srv: { url: ORIGIN } });
+  const rec = makeRecord(reg, 'file:///etc/passwd');
+  const out = await f.fetch(rec);
+  assert.equal(out.ok, false);
+  assert.match(out.error!, /scheme not allowed|third-party/);
+});
+
+test('vector 12: redirects refused, no traversal', async () => {
+  const reg = new ReferenceRegistry();
+  const f = makeFetcher({ srv: { url: ORIGIN } });
+  const rec = makeRecord(reg, `${ORIGIN}/redirect`);
+  const out = await f.fetch(rec);
+  assert.equal(out.ok, false);
+  assert.match(out.error!, /redirect refused/);
+});
+
+test('third-party origin refused (v1 policy: dialed origin only)', async () => {
+  const reg = new ReferenceRegistry();
+  const f = makeFetcher({ srv: { url: ORIGIN } });
+  const rec = makeRecord(reg, 'https://cdn.example.com/thing.wav');
+  const out = await f.fetch(rec);
+  assert.equal(out.ok, false);
+  assert.match(out.error!, /third-party origin/);
+});
+
+test('vector 16: expired (and unparseable-expiry) references refuse locally', async () => {
+  const reg = new ReferenceRegistry();
+  const f = makeFetcher({ srv: { url: ORIGIN } });
+  for (const expiresAt of ['2001-01-01T00:00:00Z', 'not-a-date']) {
+    const rec = makeRecord(reg, `${ORIGIN}/ok?e=${expiresAt}`, { expiresAt });
+    const out = await f.fetch(rec);
+    assert.equal(out.ok, false);
+    assert.match(out.error!, /expired/);
+  }
+});
+
+test('per-server budget exhausts cumulatively', async () => {
+  const reg = new ReferenceRegistry();
+  const f = makeFetcher({ srv: { url: ORIGIN, autofetch: { maxTotalBytes: PAYLOAD.length + 10 } } });
+  const a = await f.fetch(makeRecord(reg, `${ORIGIN}/ok?n=1`));
+  assert.equal(a.ok, true, a.error);
+  const b = await f.fetch(makeRecord(reg, `${ORIGIN}/ok?n=2`));
+  assert.equal(b.ok, false);
+  assert.match(b.error!, /budget/);
+});
+
+test('eager eligibility: small + sized + connection origin only', () => {
+  const reg = new ReferenceRegistry();
+  const f = makeFetcher({ srv: { url: ORIGIN } });
+  assert.equal(f.isEagerEligible(makeRecord(reg, `${ORIGIN}/a`, { sizeBytes: 1000 })), true);
+  assert.equal(f.isEagerEligible(makeRecord(reg, `${ORIGIN}/b`, { sizeBytes: 50_000_000 })), false, 'over eager ceiling');
+  assert.equal(f.isEagerEligible(makeRecord(reg, `${ORIGIN}/c`)), false, 'no sizeBytes claim');
+  assert.equal(f.isEagerEligible(makeRecord(reg, `https://cdn.example/d`, { sizeBytes: 10 })), false, 'third-party');
+  {
+    // explicit-undefined would trigger makeRecord's default; build directly
+    const c = classifyBlock({ type: 'resource', uri: `${ORIGIN}/e`, sizeBytes: 10 });
+    assert.equal(c.kind, 'reference');
+    const rec = reg.register((c as Extract<ReturnType<typeof classifyBlock>, { kind: 'reference' }>).testimony, undefined);
+    assert.equal(f.isEagerEligible(rec), false, 'no server binding');
+  }
+});
+
+test('vector 20 substrate: registry dedup + defined miss', () => {
+  const reg = new ReferenceRegistry();
+  const a = makeRecord(reg, `${ORIGIN}/same`);
+  const b = makeRecord(reg, `${ORIGIN}/same`);
+  assert.equal(a.refId, b.refId, 'same uri+server shares a record');
+  assert.equal(reg.get('ref_nope'), undefined, 'stale/unknown id is a defined miss');
+});
+
+test('normalizedOrigin maps ws/wss and elides default ports', () => {
+  assert.equal(normalizedOrigin('ws://Host.Example:80/x'), 'http://host.example');
+  assert.equal(normalizedOrigin('wss://host.example/x'), 'https://host.example');
+  assert.equal(normalizedOrigin('https://host.example:8443'), 'https://host.example:8443');
+  assert.equal(normalizedOrigin('not a url'), null);
+});
+
+test.after(() => { server.close(); });
+
+test('binding upgrade: unbound stub-time registration gains the dispatch serverId', () => {
+  const reg = new ReferenceRegistry();
+  const c = classifyBlock({ type: 'resource', uri: `${ORIGIN}/upgrade.wav`, sizeBytes: 10 });
+  assert.equal(c.kind, 'reference');
+  const t = (c as Extract<ReturnType<typeof classifyBlock>, { kind: 'reference' }>).testimony;
+  const unbound = reg.register(t);                    // stub site: no server context
+  const bound = reg.register(t, 'srv');               // dispatch: knows the server
+  assert.equal(unbound.refId, bound.refId, 'one record, not a fork');
+  assert.equal(unbound.serverId, 'srv', 'binding upgraded in place');
+});
+
+test('testimony refreshes while unfetched, freezes after fetch', async () => {
+  const reg = new ReferenceRegistry();
+  const f = makeFetcher({ srv: { url: ORIGIN } });
+  const mk = (digest: string) => {
+    const c = classifyBlock({ type: 'resource', uri: `${ORIGIN}/ok?refresh=1`, digest });
+    return (c as Extract<ReturnType<typeof classifyBlock>, { kind: 'reference' }>).testimony;
+  };
+  const stale = 'sha256:' + 'C'.repeat(43);
+  const rec = reg.register(mk(stale), 'srv');
+  reg.register(mk(DIGEST), 'srv');                    // re-issued with the real digest
+  assert.equal(rec.testimony.digest, DIGEST, 'unfetched record must take the new digest');
+  const out = await f.fetch(rec);
+  assert.equal(out.ok, true, out.error);
+  reg.register(mk(stale), 'srv');                     // later stale re-issue
+  assert.equal(rec.testimony.digest, DIGEST, 'fetched record keeps verified testimony');
+});
+
+test('vector 13: magic bytes beat a lying Content-Type header for storage type', async () => {
+  const reg = new ReferenceRegistry();
+  const f = makeFetcher({ srv: { url: ORIGIN } });
+  const rec = makeRecord(reg, `${ORIGIN}/octet`);     // server sends RIFF bytes as octet-stream
+  const out = await f.fetch(rec);
+  assert.equal(out.ok, true, out.error);
+  assert.equal(out.mimeType, 'audio/wav', 'sniffed type must win');
+  assert.ok(rec.fetchedPath!.endsWith('.wav'), rec.fetchedPath);
+});

--- a/test/tool-result-history.test.ts
+++ b/test/tool-result-history.test.ts
@@ -156,3 +156,21 @@ test('RFC-005: invalid disposition value on uri-form still stubs (conservative)'
   assert.ok(/\[ref_[a-z0-9_]+\]/.test(out));
   assert.ok(!out.includes('"type":"resource"'));
 });
+
+test('RFC-005: dispatch pre-registration and stub share ONE record (reviewer probe)', async () => {
+  // register with a serverId (as dispatchMcplToolCall does), mark fetched,
+  // then serialize the block the way the history lane does.
+  const { referenceRegistry, classifyBlock } = await import('../src/mcpl/references.js');
+  const uri = 'https://host/files?path=%2Fprobe-' + Date.now() + '.wav';
+  const block = { ...RFC005_REF, uri };
+  const c = classifyBlock(block);
+  assert.equal(c.kind, 'reference');
+  const dispatchRecord = referenceRegistry.register(
+    (c as Extract<ReturnType<typeof classifyBlock>, { kind: 'reference' }>).testimony, 'srv');
+  dispatchRecord.fetchedPath = 'scratch/refs/' + dispatchRecord.refId + '.wav';
+  const out = toolResultDataToHistoryString([block]);
+  const stubId = out.match(/\[(ref_[a-z0-9_]+)\]/)?.[1];
+  assert.equal(stubId, dispatchRecord.refId, 'stub id must equal dispatch id');
+  assert.ok(out.includes('saved: scratch/refs/'), 'eager-fetched path must surface in the stub');
+  assert.equal(referenceRegistry.get(stubId!)?.serverId, 'srv', 'visible id must be server-bound');
+});


### PR DESCRIPTION
Stacked on #137 (host treatment). Gives the reference stubs their verb: a host-mediated fetcher implementing RFC-005 §6/§7 fail-closed, a `fetch_reference` tool, and the autofetch policy discussed in review of the design:

## Fetcher (`src/mcpl/reference-fetcher.ts`)
- **Origin-bound auth (§6.1 rev 3):** authenticated fetches only to the origin the reference's server connection was dialed to (`ws→http`/`wss→https` normalized, default ports elided). The connection credential rides as an `Authorization: Bearer` header applied by this code alone — never in a URI, never visible to model/script. Third-party origins are not fetched at all in v1 (deferred with declared reference origins).
- **Fail-closed everything:** https-only (http tolerated only when the dialed origin itself is plaintext), no redirect traversal (any 3xx refuses), streaming abort the moment actual bytes exceed the ceiling regardless of claimed `sizeBytes` (vector 10) — with over-ceiling *claims* refused before dialing (vector 4), digest verified while streaming with mismatches discarded (vector 5), expired/unparseable-expiry testimony refused locally (vector 16), storage filenames host-generated from the reference id + observed type (§7.3 — the server's `name` stays display-only).

## Autofetch policy (host default, not protocol)
- **Lazy above the eager ceiling** — most references never need fetching; the stub's claimed size/type is what lets the model decide cheaply.
- **Eager below 256KB from the connection origin only** — anything under that threshold could legitimately have shipped inline, so eager materialization is never worse than the status quo. Per-server override: `autofetch: {maxBytes, maxTotalBytes}` in the `mcplServers` entry. Cumulative per-server byte budgets.
- **Scripts are "eagerly lazy":** `handleScriptToolCall` materializes every referenced payload at result delivery — a script receiving a result is the strongest demand signal available (scripts process, they don't browse) — so the stub a script sees carries a workspace path numpy can `open()`.

## Surface
- `fetch_reference {ref_id, max_bytes?}` tool, registered alongside the workspace tools; unknown/evicted ids return the defined miss (vector 20), never a different record.
- Stubs now end `saved: <mount>/refs/<ref_id>.<ext>` (already materialized) or `fetch with fetch_reference` (on demand).
- Registry: uri+server dedup so dispatch-time registration and stub-time registration share one record; `findByUri` for the script hook.

## Tests
`test/mcpl-reference-fetcher.test.ts`: 12 tests against a live local HTTP server — the fetcher half of the RFC's executable-vector acceptance criterion (4/5/10/11/12/16, origin refusal, budget exhaustion, eager eligibility matrix, header-not-URI credential assertion, registry dedup/miss). Full adjacent suite: 68 pass, typecheck clean.

Live counterpart: vst-mcpl's `/files` endpoint now accepts `Authorization: Bearer` (verified 200/401 on the deployed server), so the fetcher's header-auth path works end-to-end against the RFC's motivating emitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Z6NaM8gWPuNXCcn7jGR9E