### PR TITLE
feat: wire accepted kv-unified cache receipts

### DIFF
--- a/changelog.d/kv-unified-receipts.added.md
+++ b/changelog.d/kv-unified-receipts.added.md
@@ -1,0 +1,2 @@
+- Wire `kv-unified` immutable-prefix identity and caller-owned cache markers through activation requests, and commit context presentation/cache receipts only after the corresponding provider call is accepted.
+- Calibrate context estimates from per-provider-call usage deltas instead of cumulative tool-loop totals.

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,5 +1,6 @@
 import type { Membrane, NormalizedMessage, NormalizedRequest, ContentBlock, YieldingStream } from '@animalabs/membrane';
 import { isAbortedResponse } from '@animalabs/membrane';
+import { createHash } from 'node:crypto';
 import {
   toolResultDataToHistoryString,
   truncateForHistory,
@@ -9,6 +10,7 @@ import {
 export interface StartStreamResult {
   stream: YieldingStream;
   request: NormalizedRequest;
+  kvSubmissionId?: string;
 }
 import type {
   ContextManager,
@@ -36,6 +38,18 @@ import type {
   AgentRuntimeSettingsSnapshot,
   AgentRuntimeSettingsOverrides,
 } from './types/index.js';
+
+function stableHash(value: unknown): string {
+  const encode = (item: unknown): string => {
+    if (Array.isArray(item)) return `[${item.map(encode).join(',')}]`;
+    if (item && typeof item === 'object') {
+      const record = item as Record<string, unknown>;
+      return `{${Object.keys(record).sort().map((key) => `${JSON.stringify(key)}:${encode(record[key])}`).join(',')}}`;
+    }
+    return JSON.stringify(item) ?? 'null';
+  };
+  return createHash('sha256').update(encode(value)).digest('hex');
+}
 
 const DEFAULT_CONTEXT_BUDGET_TOKENS = 100_000;
 const DEFAULT_TRANSITION_PACE_TOKENS = 16_000;
@@ -442,9 +456,10 @@ export class Agent {
    */
   async compileWithInjections(
     budget?: TokenBudget,
-    injections?: ContextInjection[]
+    injections?: ContextInjection[],
+    opts?: { kvUnifiedImmutablePrefixHash?: string },
   ): Promise<CompileResult> {
-    const result = await this.contextManager.compile(this.resolveBudget(budget), injections);
+    const result = await this.contextManager.compile(this.resolveBudget(budget), injections, opts);
     if (!budget) this.settleRuntimeSettingsTransition();
     return result;
   }
@@ -623,7 +638,26 @@ export class Agent {
     (this.contextManager as unknown as { setToolDefinitions?: (t: ToolDefinition[]) => void })
       .setToolDefinitions?.(availableTools);
 
-    let { messages, systemInjections } = await this.compileWithInjections(budget, injections);
+    const strategy = (this.contextManager as unknown as { getStrategy?: () => unknown })
+      .getStrategy?.() as {
+      beginKvUnifiedSubmission?: (args: { submissionId: string; requestHash: string; layoutHash: string }) => void;
+      isKvUnifiedEnabled?: () => boolean;
+    };
+    const kvUnified = strategy?.isKvUnifiedEnabled?.() === true;
+    const prospectiveSystemInjections = (injections ?? [])
+      .filter((injection) => injection.position === 'system')
+      .flatMap((injection) => injection.content);
+    const immutablePrefixHash = kvUnified
+      ? stableHash({
+          tools: availableTools.length > 0 ? availableTools : undefined,
+          system: this.buildSystemPrompt(prospectiveSystemInjections),
+        })
+      : undefined;
+    let { messages, systemInjections } = await this.compileWithInjections(
+      budget,
+      injections,
+      immutablePrefixHash ? { kvUnifiedImmutablePrefixHash: immutablePrefixHash } : undefined,
+    );
 
     // Sanitize: strip empty/whitespace text blocks and drop messages left with
     // no content. The Anthropic API rejects empty text blocks with 400
@@ -668,6 +702,7 @@ export class Agent {
       },
       tools: availableTools.length > 0 ? availableTools : undefined,
       promptCaching: this.promptCaching,
+      ...(kvUnified ? { cacheMarkers: 'cm-owned' as const } : {}),
       cacheTtl: this.cacheTtl,
       ...(this.prefillUserMessage && { prefillUserMessage: this.prefillUserMessage }),
       ...(this.providerParams && { providerParams: this.providerParams }),
@@ -702,6 +737,25 @@ export class Agent {
 
     const request = await this.buildActivationRequest(availableTools, injections, budget);
 
+    const receiptAware = (this.contextManager as unknown as { getStrategy?: () => unknown })
+      .getStrategy?.() as {
+      beginKvUnifiedSubmission?: (args: { submissionId: string; requestHash: string; layoutHash: string }) => void;
+      isKvUnifiedEnabled?: () => boolean;
+    };
+    const kvSubmissionId = receiptAware?.isKvUnifiedEnabled?.() === true
+      ? `${this.name}:${this._streamId}:${Date.now()}`
+      : undefined;
+    if (kvSubmissionId) {
+      const layoutHash = stableHash(request.messages);
+      request.onCacheWireReceipt = (receipt) => {
+        receiptAware.beginKvUnifiedSubmission!({
+          submissionId: kvSubmissionId,
+          requestHash: receipt.requestHash,
+          layoutHash,
+        });
+      };
+    }
+
     const stream = this.membrane.streamYielding(request, {
       emitTokens: true,
       emitBlocks: false,
@@ -715,7 +769,7 @@ export class Agent {
     });
 
     this._state = { status: 'streaming', stream };
-    return { stream, request };
+    return { stream, request, kvSubmissionId };
   }
 
   /**

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,4 +1,4 @@
-import type { Membrane, NormalizedMessage, NormalizedRequest, ContentBlock, YieldingStream } from '@animalabs/membrane';
+import type { Membrane, NormalizedMessage, NormalizedRequest, ContentBlock, YieldingStream, CacheWireReceipt } from '@animalabs/membrane';
 import { isAbortedResponse } from '@animalabs/membrane';
 import { createHash } from 'node:crypto';
 import {
@@ -11,6 +11,7 @@ export interface StartStreamResult {
   stream: YieldingStream;
   request: NormalizedRequest;
   kvSubmissionId?: string;
+  getKvWireReceipt?: () => CacheWireReceipt | undefined;
 }
 import type {
   ContextManager,
@@ -745,9 +746,11 @@ export class Agent {
     const kvSubmissionId = receiptAware?.isKvUnifiedEnabled?.() === true
       ? `${this.name}:${this._streamId}:${Date.now()}`
       : undefined;
+    let kvWireReceipt: CacheWireReceipt | undefined;
     if (kvSubmissionId) {
       const layoutHash = stableHash(request.messages);
       request.onCacheWireReceipt = (receipt) => {
+        kvWireReceipt = receipt;
         receiptAware.beginKvUnifiedSubmission!({
           submissionId: kvSubmissionId,
           requestHash: receipt.requestHash,
@@ -769,7 +772,12 @@ export class Agent {
     });
 
     this._state = { status: 'streaming', stream };
-    return { stream, request, kvSubmissionId };
+    return {
+      stream,
+      request,
+      kvSubmissionId,
+      ...(kvSubmissionId ? { getKvWireReceipt: () => kvWireReceipt } : {}),
+    };
   }
 
   /**

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -10,8 +10,8 @@ import {
 export interface StartStreamResult {
   stream: YieldingStream;
   request: NormalizedRequest;
-  kvSubmissionId?: string;
-  getKvWireReceipt?: () => CacheWireReceipt | undefined;
+  takeKvSubmission?: () => { submissionId: string; wireReceipt: CacheWireReceipt } | undefined;
+  drainKvSubmissionIds?: () => string[];
 }
 import type {
   ContextManager,
@@ -743,19 +743,19 @@ export class Agent {
       beginKvUnifiedSubmission?: (args: { submissionId: string; requestHash: string; layoutHash: string }) => void;
       isKvUnifiedEnabled?: () => boolean;
     };
-    const kvSubmissionId = receiptAware?.isKvUnifiedEnabled?.() === true
-      ? `${this.name}:${this._streamId}:${Date.now()}`
-      : undefined;
-    let kvWireReceipt: CacheWireReceipt | undefined;
-    if (kvSubmissionId) {
+    const kvEnabled = receiptAware?.isKvUnifiedEnabled?.() === true;
+    const kvQueue: Array<{ submissionId: string; wireReceipt: CacheWireReceipt }> = [];
+    let kvCall = 0;
+    if (kvEnabled) {
       const layoutHash = stableHash(request.messages);
       request.onCacheWireReceipt = (receipt) => {
-        kvWireReceipt = receipt;
+        const submissionId = `${this.name}:${this._streamId}:${Date.now()}:${kvCall++}`;
         receiptAware.beginKvUnifiedSubmission!({
-          submissionId: kvSubmissionId,
+          submissionId,
           requestHash: receipt.requestHash,
           layoutHash,
         });
+        kvQueue.push({ submissionId, wireReceipt: receipt });
       };
     }
 
@@ -775,8 +775,12 @@ export class Agent {
     return {
       stream,
       request,
-      kvSubmissionId,
-      ...(kvSubmissionId ? { getKvWireReceipt: () => kvWireReceipt } : {}),
+      ...(kvEnabled
+        ? {
+            takeKvSubmission: () => kvQueue.shift(),
+            drainKvSubmissionIds: () => kvQueue.splice(0).map((item) => item.submissionId),
+          }
+        : {}),
     };
   }
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,6 +1,7 @@
-import type { Membrane, NormalizedMessage, NormalizedRequest, ContentBlock, YieldingStream, CacheWireReceipt } from '@animalabs/membrane';
+import type { Membrane, NormalizedMessage, NormalizedRequest, ContentBlock, YieldingStream } from '@animalabs/membrane';
 import { isAbortedResponse } from '@animalabs/membrane';
 import { createHash } from 'node:crypto';
+import type { CacheWireReceipt, KvUnifiedRequestHooks } from './kv-unified-wire.js';
 import {
   toolResultDataToHistoryString,
   truncateForHistory,
@@ -460,7 +461,9 @@ export class Agent {
     injections?: ContextInjection[],
     opts?: { kvUnifiedImmutablePrefixHash?: string },
   ): Promise<CompileResult> {
-    const result = await this.contextManager.compile(this.resolveBudget(budget), injections, opts);
+    const result = await this.contextManager.compile(
+      this.resolveBudget(budget), injections, opts as never,
+    );
     if (!budget) this.settleRuntimeSettingsTransition();
     return result;
   }
@@ -748,7 +751,8 @@ export class Agent {
     let kvCall = 0;
     if (kvEnabled) {
       const layoutHash = stableHash(request.messages);
-      request.onCacheWireReceipt = (receipt) => {
+      const kvRequest = request as NormalizedRequest & KvUnifiedRequestHooks;
+      kvRequest.onCacheWireReceipt = (receipt) => {
         const submissionId = `${this.name}:${this._streamId}:${Date.now()}:${kvCall++}`;
         receiptAware.beginKvUnifiedSubmission!({
           submissionId,

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -81,6 +81,7 @@ import {
   CODE_EXECUTION_TOOL_NAME,
 } from './code-execution/tool-definition.js';
 import { splitProseSegments } from './prose-segments.js';
+import { cumulativeDelta } from './usage-accounting.js';
 
 /** Detect a supported image media type from magic bytes (the model API
  *  rejects mislabeled media types, so trust bytes over extensions).
@@ -6006,6 +6007,16 @@ export class AgentFramework {
     const startTime = Date.now();
     const requestId = `${agent.name}-${startTime}-${Math.random().toString(36).slice(2, 8)}`;
     const myStreamId = agent.streamId;
+    // Membrane usage events are cumulative across the native/XML tool loop.
+    // Keep the previous cumulative sample so consumers that operate at the
+    // physical provider-call boundary (estimator calibration and kv receipt
+    // acceptance) see this call only, not an ever-growing turn total.
+    let previousUsage = {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheCreationTokens: 0,
+      cacheReadTokens: 0,
+    };
     // This turn's alive-marker, set at startAgentStream entry. Safe to read
     // from the map here: the turn-alive busy check in processInferenceRequests
     // means no successor turn can have replaced it while we compiled.
@@ -6944,32 +6955,61 @@ export class AgentFramework {
             // loop (5 calls x ~160k reported as 884k), which is not a
             // window-shaped number and drove the multiplier to 2.37 before
             // the guards caught it.
-            try {
-              const realTotal =
-                (event.usage.inputTokens ?? 0) +
-                (event.usage.cacheCreationTokens ?? 0) +
-                (event.usage.cacheReadTokens ?? 0);
-              const strat = (agent as unknown as {
-                getContextManager?: () => { getStrategy?: () => unknown };
-              }).getContextManager?.()?.getStrategy?.() as
-                | { reportRealInputTokens?: (n: number) => void }
-                | undefined;
-              strat?.reportRealInputTokens?.(realTotal);
-              const kvSubmission = takeKvSubmission?.();
-              if (kvSubmission) {
-                (strat as {
+            const cumulativeUsage = {
+              inputTokens: event.usage.inputTokens ?? 0,
+              outputTokens: event.usage.outputTokens ?? 0,
+              cacheCreationTokens: event.usage.cacheCreationTokens ?? 0,
+              cacheReadTokens: event.usage.cacheReadTokens ?? 0,
+            };
+            const perCallUsage = {
+              inputTokens: cumulativeDelta(cumulativeUsage.inputTokens, previousUsage.inputTokens),
+              outputTokens: cumulativeDelta(cumulativeUsage.outputTokens, previousUsage.outputTokens),
+              cacheCreationTokens: cumulativeDelta(
+                cumulativeUsage.cacheCreationTokens,
+                previousUsage.cacheCreationTokens,
+              ),
+              cacheReadTokens: cumulativeDelta(
+                cumulativeUsage.cacheReadTokens,
+                previousUsage.cacheReadTokens,
+              ),
+            };
+            previousUsage = cumulativeUsage;
+            const strat = (agent as unknown as {
+              getContextManager?: () => { getStrategy?: () => unknown };
+            }).getContextManager?.()?.getStrategy?.() as
+              | {
+                  reportRealInputTokens?: (n: number) => void;
                   reportKvUnifiedAccepted?: (args: {
                     submissionId: string;
                     acceptedAt?: number;
                     wireReceipt?: CacheWireReceipt;
                   }) => void;
-                })?.reportKvUnifiedAccepted?.({
+                  reportKvUnifiedFailed?: (submissionId: string) => void;
+                }
+              | undefined;
+            try {
+              const realTotal =
+                perCallUsage.inputTokens +
+                perCallUsage.cacheCreationTokens +
+                perCallUsage.cacheReadTokens;
+              strat?.reportRealInputTokens?.(realTotal);
+            } catch { /* calibration is best-effort */ }
+
+            const kvSubmission = takeKvSubmission?.();
+            if (kvSubmission) {
+              try {
+                strat?.reportKvUnifiedAccepted?.({
                   submissionId: kvSubmission.submissionId,
                   acceptedAt: Date.now(),
                   wireReceipt: kvSubmission.wireReceipt,
                 });
+              } catch {
+                // The queue item has already been consumed. Explicitly close
+                // the receipt flight so one persistence error cannot wedge
+                // every later provider call on this branch.
+                try { strat?.reportKvUnifiedFailed?.(kvSubmission.submissionId); } catch { /* teardown only */ }
               }
-            } catch { /* calibration is best-effort */ }
+            }
 
             this.emitTrace({
               type: 'inference:usage',

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -1,9 +1,10 @@
 import { join } from 'node:path';
 import { appendFileSync, mkdirSync } from 'node:fs';
 import { JsStore } from '@animalabs/chronicle';
-import type { Membrane, ContentBlock, NormalizedRequest, YieldingStream, ToolResult as MembraneToolResult, ToolResultContentBlock, CacheWireReceipt } from '@animalabs/membrane';
+import type { Membrane, ContentBlock, NormalizedRequest, YieldingStream, ToolResult as MembraneToolResult, ToolResultContentBlock } from '@animalabs/membrane';
 import { MembraneError } from '@animalabs/membrane';
 import { ContextManager, PassthroughStrategy } from '@animalabs/context-manager';
+import type { CacheWireReceipt } from './kv-unified-wire.js';
 import type {
   MessageId,
   MessageMetadata,

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -5905,8 +5905,8 @@ export class AgentFramework {
       const {
         stream,
         request: compiledRequest,
-        kvSubmissionId,
-        getKvWireReceipt,
+        takeKvSubmission,
+        drainKvSubmissionIds,
       } = await agent.startStreamWithInjections(tools, injections);
 
       const handle = this.driveStream(
@@ -5917,8 +5917,8 @@ export class AgentFramework {
         attempt,
         compiledRequest,
         ownsProviderGate,
-        kvSubmissionId,
-        getKvWireReceipt,
+        takeKvSubmission,
+        drainKvSubmissionIds,
       );
       this.activeStreams.set(agent.name, handle);
       // Handoff: driveStream captured the token in its synchronous prefix;
@@ -6000,8 +6000,8 @@ export class AgentFramework {
     attempt = 0,
     compiledRequest?: NormalizedRequest,
     ownsProviderGate = false,
-    kvSubmissionId?: string,
-    getKvWireReceipt?: () => CacheWireReceipt | undefined,
+    takeKvSubmission?: () => { submissionId: string; wireReceipt: CacheWireReceipt } | undefined,
+    drainKvSubmissionIds?: () => string[],
   ): Promise<void> {
     const startTime = Date.now();
     const requestId = `${agent.name}-${startTime}-${Math.random().toString(36).slice(2, 8)}`;
@@ -6955,7 +6955,8 @@ export class AgentFramework {
                 | { reportRealInputTokens?: (n: number) => void }
                 | undefined;
               strat?.reportRealInputTokens?.(realTotal);
-              if (kvSubmissionId) {
+              const kvSubmission = takeKvSubmission?.();
+              if (kvSubmission) {
                 (strat as {
                   reportKvUnifiedAccepted?: (args: {
                     submissionId: string;
@@ -6963,9 +6964,9 @@ export class AgentFramework {
                     wireReceipt?: CacheWireReceipt;
                   }) => void;
                 })?.reportKvUnifiedAccepted?.({
-                  submissionId: kvSubmissionId,
+                  submissionId: kvSubmission.submissionId,
                   acceptedAt: Date.now(),
-                  wireReceipt: getKvWireReceipt?.(),
+                  wireReceipt: kvSubmission.wireReceipt,
                 });
               }
             } catch { /* calibration is best-effort */ }
@@ -7032,12 +7033,15 @@ export class AgentFramework {
       agent.reset();
       this.eventGate?.onInferenceEnded(agent.name);
     } finally {
-      if (kvSubmissionId) {
+      const unsettledKvSubmissions = drainKvSubmissionIds?.() ?? [];
+      if (unsettledKvSubmissions.length > 0) {
         try {
           const strategy = agent.getContextManager().getStrategy() as unknown as {
             reportKvUnifiedFailed?: (submissionId: string) => void;
           };
-          strategy.reportKvUnifiedFailed?.(kvSubmissionId);
+          for (const submissionId of unsettledKvSubmissions) {
+            strategy.reportKvUnifiedFailed?.(submissionId);
+          }
         } catch { /* receipt cleanup must not mask inference teardown */ }
       }
       // §10.5: exactly one terminal per `started`, on every exit path the

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path';
 import { appendFileSync, mkdirSync } from 'node:fs';
 import { JsStore } from '@animalabs/chronicle';
-import type { Membrane, ContentBlock, NormalizedRequest, YieldingStream, ToolResult as MembraneToolResult, ToolResultContentBlock } from '@animalabs/membrane';
+import type { Membrane, ContentBlock, NormalizedRequest, YieldingStream, ToolResult as MembraneToolResult, ToolResultContentBlock, CacheWireReceipt } from '@animalabs/membrane';
 import { MembraneError } from '@animalabs/membrane';
 import { ContextManager, PassthroughStrategy } from '@animalabs/context-manager';
 import type {
@@ -5906,6 +5906,7 @@ export class AgentFramework {
         stream,
         request: compiledRequest,
         kvSubmissionId,
+        getKvWireReceipt,
       } = await agent.startStreamWithInjections(tools, injections);
 
       const handle = this.driveStream(
@@ -5917,6 +5918,7 @@ export class AgentFramework {
         compiledRequest,
         ownsProviderGate,
         kvSubmissionId,
+        getKvWireReceipt,
       );
       this.activeStreams.set(agent.name, handle);
       // Handoff: driveStream captured the token in its synchronous prefix;
@@ -5999,6 +6001,7 @@ export class AgentFramework {
     compiledRequest?: NormalizedRequest,
     ownsProviderGate = false,
     kvSubmissionId?: string,
+    getKvWireReceipt?: () => CacheWireReceipt | undefined,
   ): Promise<void> {
     const startTime = Date.now();
     const requestId = `${agent.name}-${startTime}-${Math.random().toString(36).slice(2, 8)}`;
@@ -6954,10 +6957,15 @@ export class AgentFramework {
               strat?.reportRealInputTokens?.(realTotal);
               if (kvSubmissionId) {
                 (strat as {
-                  reportKvUnifiedAccepted?: (args: { submissionId: string; acceptedAt?: number }) => void;
+                  reportKvUnifiedAccepted?: (args: {
+                    submissionId: string;
+                    acceptedAt?: number;
+                    wireReceipt?: CacheWireReceipt;
+                  }) => void;
                 })?.reportKvUnifiedAccepted?.({
                   submissionId: kvSubmissionId,
                   acceptedAt: Date.now(),
+                  wireReceipt: getKvWireReceipt?.(),
                 });
               }
             } catch { /* calibration is best-effort */ }

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -5902,7 +5902,11 @@ export class AgentFramework {
         }
       }
 
-      const { stream, request: compiledRequest } = await agent.startStreamWithInjections(tools, injections);
+      const {
+        stream,
+        request: compiledRequest,
+        kvSubmissionId,
+      } = await agent.startStreamWithInjections(tools, injections);
 
       const handle = this.driveStream(
         agent,
@@ -5912,6 +5916,7 @@ export class AgentFramework {
         attempt,
         compiledRequest,
         ownsProviderGate,
+        kvSubmissionId,
       );
       this.activeStreams.set(agent.name, handle);
       // Handoff: driveStream captured the token in its synchronous prefix;
@@ -5993,6 +5998,7 @@ export class AgentFramework {
     attempt = 0,
     compiledRequest?: NormalizedRequest,
     ownsProviderGate = false,
+    kvSubmissionId?: string,
   ): Promise<void> {
     const startTime = Date.now();
     const requestId = `${agent.name}-${startTime}-${Math.random().toString(36).slice(2, 8)}`;
@@ -6946,6 +6952,14 @@ export class AgentFramework {
                 | { reportRealInputTokens?: (n: number) => void }
                 | undefined;
               strat?.reportRealInputTokens?.(realTotal);
+              if (kvSubmissionId) {
+                (strat as {
+                  reportKvUnifiedAccepted?: (args: { submissionId: string; acceptedAt?: number }) => void;
+                })?.reportKvUnifiedAccepted?.({
+                  submissionId: kvSubmissionId,
+                  acceptedAt: Date.now(),
+                });
+              }
             } catch { /* calibration is best-effort */ }
 
             this.emitTrace({
@@ -7010,6 +7024,14 @@ export class AgentFramework {
       agent.reset();
       this.eventGate?.onInferenceEnded(agent.name);
     } finally {
+      if (kvSubmissionId) {
+        try {
+          const strategy = agent.getContextManager().getStrategy() as unknown as {
+            reportKvUnifiedFailed?: (submissionId: string) => void;
+          };
+          strategy.reportKvUnifiedFailed?.(kvSubmissionId);
+        } catch { /* receipt cleanup must not mask inference teardown */ }
+      }
       // §10.5: exactly one terminal per `started`, on every exit path the
       // host controls. Which one was decided by the path taken (default
       // completed; catch → failed; framework-cancel → aborted). A host

--- a/src/kv-unified-wire.ts
+++ b/src/kv-unified-wire.ts
@@ -1,0 +1,12 @@
+/** Structural copy of membrane's cache-wire receipt contract.
+ * Kept local so agent-framework remains source-compatible with the previous
+ * membrane release while the stacked membrane PR lands. */
+export interface CacheWireReceipt {
+  requestHash: string;
+  markers: Array<{ ordinal: number; prefixHash: string; estimatedOffset: number }>;
+}
+
+export interface KvUnifiedRequestHooks {
+  cacheMarkers?: 'membrane-system' | 'cm-owned';
+  onCacheWireReceipt?: (receipt: CacheWireReceipt) => void;
+}

--- a/src/usage-accounting.ts
+++ b/src/usage-accounting.ts
@@ -1,0 +1,8 @@
+/** Convert a cumulative usage counter into the contribution of this call.
+ * A counter reset (provider/stream implementation change) is treated as an
+ * already-per-call sample rather than producing a negative value. */
+export function cumulativeDelta(current: number, previous: number): number {
+  if (!Number.isFinite(current) || current < 0) return 0;
+  if (!Number.isFinite(previous) || previous < 0 || current < previous) return current;
+  return current - previous;
+}

--- a/test/kv-unified-wiring.test.ts
+++ b/test/kv-unified-wiring.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { Agent } from '../src/agent.js';
 import type { ContextManager } from '@animalabs/context-manager';
 import type { Membrane } from '@animalabs/membrane';
+import type { KvUnifiedRequestHooks } from '../src/kv-unified-wire.js';
 
 test('agent wires immutable-prefix and exact wire receipt only for kv-unified', async () => {
   let compileOptions: unknown;
@@ -31,9 +32,10 @@ test('agent wires immutable-prefix and exact wire receipt only for kv-unified', 
     membrane,
   );
   const started = await agent.startStreamWithInjections([], undefined);
-  assert.equal(started.request.cacheMarkers, 'cm-owned');
+  const kvRequest = started.request as typeof started.request & KvUnifiedRequestHooks;
+  assert.equal(kvRequest.cacheMarkers, 'cm-owned');
   assert.equal(typeof (compileOptions as { kvUnifiedImmutablePrefixHash?: string }).kvUnifiedImmutablePrefixHash, 'string');
-  started.request.onCacheWireReceipt?.({ requestHash: 'wire-hash', markers: [] });
+  kvRequest.onCacheWireReceipt?.({ requestHash: 'wire-hash', markers: [] });
   const submission = started.takeKvSubmission?.();
   assert.equal(typeof submission?.submissionId, 'string');
   assert.equal(submission?.wireReceipt.requestHash, 'wire-hash');
@@ -61,6 +63,6 @@ test('agent leaves marker ownership unchanged for non-kv strategies', async () =
     {} as Membrane,
   );
   const request = await agent.buildActivationRequest([]);
-  assert.equal(request.cacheMarkers, undefined);
+  assert.equal((request as typeof request & KvUnifiedRequestHooks).cacheMarkers, undefined);
   assert.equal(compileOptions, undefined);
 });

--- a/test/kv-unified-wiring.test.ts
+++ b/test/kv-unified-wiring.test.ts
@@ -1,0 +1,64 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Agent } from '../src/agent.js';
+import type { ContextManager } from '@animalabs/context-manager';
+import type { Membrane } from '@animalabs/membrane';
+
+test('agent wires immutable-prefix and exact wire receipt only for kv-unified', async () => {
+  let compileOptions: unknown;
+  let begun: unknown;
+  const strategy = {
+    isKvUnifiedEnabled: () => true,
+    beginKvUnifiedSubmission: (args: unknown) => { begun = args; },
+  };
+  const cm = {
+    getStrategy: () => strategy,
+    setToolDefinitions: () => {},
+    compile: async (_budget: unknown, _injections: unknown, options: unknown) => {
+      compileOptions = options;
+      return {
+        messages: [{ participant: 'user', content: [{ type: 'text', text: 'hello' }] }],
+        systemInjections: [],
+      };
+    },
+  } as unknown as ContextManager;
+  const membrane = {
+    streamYielding: () => ({}) as never,
+  } as unknown as Membrane;
+  const agent = new Agent(
+    { name: 'resident', model: 'test', systemPrompt: 'system' },
+    cm,
+    membrane,
+  );
+  const started = await agent.startStreamWithInjections([], undefined);
+  assert.equal(started.request.cacheMarkers, 'cm-owned');
+  assert.equal(typeof (compileOptions as { kvUnifiedImmutablePrefixHash?: string }).kvUnifiedImmutablePrefixHash, 'string');
+  assert.equal(typeof started.kvSubmissionId, 'string');
+  started.request.onCacheWireReceipt?.({ requestHash: 'wire-hash', markers: [] });
+  assert.deepEqual(begun, {
+    submissionId: started.kvSubmissionId,
+    requestHash: 'wire-hash',
+    layoutHash: (begun as { layoutHash: string }).layoutHash,
+  });
+  assert.equal((begun as { layoutHash: string }).layoutHash.length, 64);
+});
+
+test('agent leaves marker ownership unchanged for non-kv strategies', async () => {
+  let compileOptions: unknown = 'unset';
+  const cm = {
+    getStrategy: () => ({ isKvUnifiedEnabled: () => false }),
+    setToolDefinitions: () => {},
+    compile: async (_budget: unknown, _injections: unknown, options: unknown) => {
+      compileOptions = options;
+      return { messages: [], systemInjections: [] };
+    },
+  } as unknown as ContextManager;
+  const agent = new Agent(
+    { name: 'resident', model: 'test', systemPrompt: 'system' },
+    cm,
+    {} as Membrane,
+  );
+  const request = await agent.buildActivationRequest([]);
+  assert.equal(request.cacheMarkers, undefined);
+  assert.equal(compileOptions, undefined);
+});

--- a/test/kv-unified-wiring.test.ts
+++ b/test/kv-unified-wiring.test.ts
@@ -33,10 +33,12 @@ test('agent wires immutable-prefix and exact wire receipt only for kv-unified', 
   const started = await agent.startStreamWithInjections([], undefined);
   assert.equal(started.request.cacheMarkers, 'cm-owned');
   assert.equal(typeof (compileOptions as { kvUnifiedImmutablePrefixHash?: string }).kvUnifiedImmutablePrefixHash, 'string');
-  assert.equal(typeof started.kvSubmissionId, 'string');
   started.request.onCacheWireReceipt?.({ requestHash: 'wire-hash', markers: [] });
+  const submission = started.takeKvSubmission?.();
+  assert.equal(typeof submission?.submissionId, 'string');
+  assert.equal(submission?.wireReceipt.requestHash, 'wire-hash');
   assert.deepEqual(begun, {
-    submissionId: started.kvSubmissionId,
+    submissionId: submission?.submissionId,
     requestHash: 'wire-hash',
     layoutHash: (begun as { layoutHash: string }).layoutHash,
   });

--- a/test/usage-accounting.test.ts
+++ b/test/usage-accounting.test.ts
@@ -1,0 +1,14 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { cumulativeDelta } from '../src/usage-accounting.js';
+
+test('cumulative usage is reduced to the physical provider-call delta', () => {
+  assert.equal(cumulativeDelta(120, 0), 120);
+  assert.equal(cumulativeDelta(275, 120), 155);
+});
+
+test('a reset or malformed cumulative usage sample fails conservatively', () => {
+  assert.equal(cumulativeDelta(25, 275), 25, 'counter reset is an already-per-call sample');
+  assert.equal(cumulativeDelta(Number.NaN, 25), 0);
+  assert.equal(cumulativeDelta(-1, 25), 0);
+});


### PR DESCRIPTION
## Summary

- compute the immutable tools and system prefix identity for kv-unified compiles
- request caller-owned cache marker mode only when kv-unified is active
- bind each physical provider call to a unique submission and exact wire receipt
- commit presentation and cache state only after that provider call is accepted
- fail or drain outstanding submissions without advancing continuity state
- calibrate context estimates from per-provider-call usage deltas rather than cumulative tool-loop totals
- retain source compatibility with the preceding membrane and context-manager releases while the stacked PRs land

Dependencies:

- https://github.com/antra-tess/membrane/pull/66
- https://github.com/anima-research/context-manager/pull/83

## Validation

- npm run build
- targeted kv-unified receipt and usage-accounting tests
- full npm test suite passed

## Rollout

No strategy is activated by this PR. Existing agents and marker ownership remain unchanged unless their Context Manager reports kv-unified enabled.