### PR TITLE
fix(save_recent_image): retain tool-result images with provenance; fail closed (#104)

### DIFF
--- a/changelog.d/104-save-recent-image-provenance.fixed.md
+++ b/changelog.d/104-save-recent-image-provenance.fixed.md
@@ -1,0 +1,16 @@
+- **`save_recent_image` can no longer save the wrong image** (#104). Tool-result
+  images never reached the persisted window — history keeps a text placeholder
+  and only the live wire copy carries bytes — so the recency scan walked past a
+  snapshot the resident had just seen and quietly saved an OLDER attachment
+  under the snapshot's filename (or reported "no images found"). Every
+  tool-result image is now retained per agent at ingestion in a bounded
+  in-memory ledger with provenance (tool call, block, MIME, size, SHA-256), and
+  the history placeholder carries its handle:
+  `[image: image/png, ~691KB, ref img_7]`. The tool walks one ordered inventory
+  across attachments, tool images and image-typed RFC-005 reference stubs; when
+  the image at the requested index cannot be produced (evicted, from an earlier
+  process, a pre-retention placeholder, a quoted/forged placeholder whose ref
+  belongs to another call, or a reference whose bytes live behind
+  `fetch_reference`) it fails **at that index** and writes nothing — it never
+  substitutes an older image. New `ref` argument saves by provenance; receipts
+  report source, tool call, MIME, byte size and SHA-256.

--- a/changelog.d/104-save-recent-image-provenance.fixed.md
+++ b/changelog.d/104-save-recent-image-provenance.fixed.md
@@ -14,3 +14,16 @@
   `fetch_reference`) it fails **at that index** and writes nothing — it never
   substitutes an older image. New `ref` argument saves by provenance; receipts
   report source, tool call, MIME, byte size and SHA-256.
+  Second review round (#140) closed three more representations of the same
+  failure: truncation/spill now re-appends every image slot that fell past the
+  cut (the stored text is the only place the inventory finds tool images, and
+  the wire delivered them regardless); a save dispatched in the same batch as
+  the tool that produced the image waits for its siblings to settle (bounded,
+  fail-closed) and classifies their results with the commit-path serializer;
+  refs are namespaced per ledger (`img_k7x3q2_7`) so a placeholder from a
+  previous process resolves to nothing rather than to today's seventh image,
+  and a direct `ref` is saved through its visible placeholder (same provenance
+  cross-check as by index). Mime types normalize to a type/subtype essence
+  (parameters dropped, nonconforming → `application/octet-stream`) so the
+  placeholder always re-parses; large payloads are digested chunked; the
+  ledgers are released on framework `stop()`.

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -78,6 +78,7 @@ import {
   truncateForHistory,
   DEFAULT_TOOL_RESULT_INLINE_MAX_CHARS,
 } from './tool-result-history.js';
+import { ToolImageLedger, parseImagePlaceholders, sha256Hex, type ParsedImagePlaceholder } from './tool-image-ledger.js';
 import { randomUUID } from 'node:crypto';
 import { PyRunner, buildInjectedTools } from './code-execution/py-runner.js';
 import {
@@ -942,6 +943,11 @@ export class AgentFramework {
    *  framework state like the core runtime settings and restored at create
    *  (antra + Sol, 08-06); reset clears it back to the residence default. */
   private toolResultInlineMaxCharsOverride: Map<string, number> = new Map();
+  /** Per-agent retention of tool-result images with provenance (issue
+   *  #104). In-memory and bounded by design: history keeps only the
+   *  placeholder; this is what lets `save_recent_image` reach the bytes the
+   *  resident actually saw — or fail at that exact index when they're gone. */
+  private toolImageLedgers: Map<string, ToolImageLedger> = new Map();
   /** Durable residence-configured inline cap from
    *  FrameworkConfig.toolResultInlineMaxChars; null → house default. */
   private toolResultInlineMaxCharsConfig: number | null = null;
@@ -2639,6 +2645,7 @@ export class AgentFramework {
         this.eventGate?.onInferenceEnded(agent.name);
         this.agents.delete(agent.name);
       }
+      this.toolImageLedgers.delete(agent.name);
       // Spawn-and-dispose bookkeeping (main, d453165/fee96a7): without this,
       // ephemeral agents leave checkpoint-tree keys and diagnostics map
       // entries behind for the life of the store/session.
@@ -2857,11 +2864,17 @@ export class AgentFramework {
     name: 'save_recent_image',
     description:
       'Save one or more recent images from your own context to workspace files. ' +
-      'Images are counted back from the most recent (index 0). A single image is ' +
+      'Images are counted back from the most recent (index 0), across BOTH ' +
+      'attachments in messages and images returned by tools (their history ' +
+      'placeholder shows a ref like `[image: image/png, ~691KB, ref img_7]`; pass ' +
+      '`ref` to save that exact image regardless of position). A single image is ' +
       'written to `path` as given (e.g. "project/photos/cat.png"); when `count` > 1 ' +
       'the range index..index+count-1 is saved with numeric suffixes ' +
-      '("cat-0.png", "cat-1.png", …; 0 = the newest of the range). Saved files are ' +
-      'visible via workspace tools and the /files/ endpoint.',
+      '("cat-0.png", "cat-1.png", …; 0 = the newest of the range). If the image at ' +
+      'the requested position is no longer retained (evicted, or from before a ' +
+      'restart) the call fails and writes nothing — it never substitutes an older ' +
+      'image. Receipts carry source tool call, MIME, byte size and SHA-256. Saved ' +
+      'files are visible via workspace tools and the /files/ endpoint.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -2876,6 +2889,12 @@ export class AgentFramework {
         count: {
           type: 'number',
           description: 'How many images to save, starting at `index` and going further back. Default 1.',
+        },
+        ref: {
+          type: 'string',
+          description:
+            'Save a specific tool-result image by its history ref (e.g. "img_7") instead of by position. ' +
+            'Mutually exclusive with `index`/`count`.',
         },
       },
       required: ['path'],
@@ -4240,7 +4259,7 @@ export class AgentFramework {
           // byte-matched (the window stores what the membrane sends;
           // divergence breaks the compile prefix).
           const { blocks: toolResultContent, spilled } =
-            await this.buildStoredToolResultContent(currentState.toolResults, maxChars);
+            await this.buildStoredToolResultContent(agent.name, currentState.toolResults, maxChars);
           agent.getContextManager().addMessage('user', toolResultContent);
 
           // Flush any messages that were deferred while this turn was in
@@ -4894,6 +4913,7 @@ export class AgentFramework {
     const channelId = this.conversationAgentHomes.get(agentName);
     const agent = this.agents.get(agentName);
     this.agents.delete(agentName);
+    this.toolImageLedgers.delete(agentName);
     this.agentConfigs.delete(agentName);
     this.conversationAgentHomes.delete(agentName);
     this.evictTurnCheckpoints(agentName);
@@ -6624,6 +6644,7 @@ export class AgentFramework {
               const readyState = agent.state as AgentState;
               if (readyState.status === 'ready') {
                 const { blocks: toolResultContent } = await this.buildStoredToolResultContent(
+                  agent.name,
                   readyState.toolResults,
                   this.resolveToolResultInlineCap(agent).cap,
                 );
@@ -7554,6 +7575,7 @@ export class AgentFramework {
     // never between tool_use and its tool_result. The two addMessage calls
     // below are synchronous and adjacent — nothing can interleave.
     const { blocks } = await this.buildStoredToolResultContent(
+      agentName,
       [{ id: toolUseId, name: toolName, input, result, durationMs }],
       this.resolveToolResultInlineCap(agent).cap,
     );
@@ -8060,6 +8082,7 @@ export class AgentFramework {
    * live wire copy can reuse the identical strings.
    */
   private async buildStoredToolResultContent(
+    agentName: string,
     toolResults: CompletedToolCall[],
     maxChars: number | undefined,
   ): Promise<{
@@ -8068,10 +8091,22 @@ export class AgentFramework {
   }> {
     const spilled = new Map<string, { text: string; filePath: string | null }>();
     const dateLabel = new Date().toISOString().slice(0, 10);
+    const ledger = this.toolImageLedgerFor(agentName);
     for (const tc of toolResults) {
+      // Retain every image the result carries BEFORE the placeholder is
+      // written (issue #104): the placeholder embeds the ref, so the image
+      // stays reachable by provenance after the bytes leave the wire.
       const raw = tc.result.isError
         ? tc.result.error ?? 'Unknown error'
-        : toolResultDataToHistoryString(tc.result.data, undefined);
+        : toolResultDataToHistoryString(tc.result.data, undefined, {
+          imageRef: (blockIndex, image) => ledger.retain({
+            toolCallId: tc.id,
+            toolName: tc.name,
+            blockIndex,
+            data: image.data,
+            mediaType: image.mimeType,
+          }).ref,
+        });
       spilled.set(tc.id, await this.spillOrTruncate(raw, maxChars, `${dateLabel}-${tc.id}`));
     }
     const blocks: ContentBlock[] = toolResults.map(tc => ({
@@ -8353,6 +8388,15 @@ export class AgentFramework {
       }
     }
     return hasImage ? blocks : null;
+  }
+
+  private toolImageLedgerFor(agentName: string): ToolImageLedger {
+    let ledger = this.toolImageLedgers.get(agentName);
+    if (!ledger) {
+      ledger = new ToolImageLedger();
+      this.toolImageLedgers.set(agentName, ledger);
+    }
+    return ledger;
   }
 
   /** Strategy-derived per-message bound (maxMessageTokens * 4 chars). */
@@ -11332,10 +11376,18 @@ export class AgentFramework {
   }
 
   /**
-   * Handle the synthesized `save_recent_image` tool: locate the requested
-   * image blocks in the calling agent's context (blobs re-inlined, counted
-   * back from the most recent) and write their bytes to a workspace mount
-   * via WorkspaceModule.writeBinary.
+   * Handle the synthesized `save_recent_image` tool (issue #104): build ONE
+   * ordered inventory of every image the calling agent has seen — attachment
+   * image blocks (blobs re-inlined) AND tool-result images (their history
+   * placeholders carry a ref, resolved through the agent's ToolImageLedger)
+   * — counted back from the most recent, then write the requested bytes to
+   * a workspace mount via WorkspaceModule.writeBinary.
+   *
+   * Fail-closed: when the image at a requested position cannot be produced
+   * (bytes evicted, minted by an earlier process, or a placeholder written
+   * before retention existed) the call fails AT THAT INDEX and writes
+   * nothing. It never slides to an older image — a filename must not
+   * authenticate bytes from another surface.
    */
   private dispatchSaveImageToolCall(agentName: string, call: ToolCall): void {
     this.emitTrace({ type: 'tool:started', module: 'workspace', tool: call.name, callId: call.id, input: call.input });
@@ -11350,79 +11402,271 @@ export class AgentFramework {
       });
       this.pushEvent({ type: 'tool-result', callId: call.id, agentName, moduleName: 'workspace', result });
     };
+    type Candidate =
+      | { kind: 'attachment'; data: string | null; mediaType: string; messagesBack: number }
+      | {
+        kind: 'tool';
+        ref: string | null;
+        /** The tool_result block the placeholder was found in — NOT trusted
+         *  text; a resolved ref must belong to this very call. */
+        toolCallId: string;
+        toolName: string;
+        mediaType: string;
+        messagesBack: number;
+      }
+      | {
+        kind: 'reference';
+        refId: string;
+        mediaType: string;
+        toolCallId: string;
+        toolName: string;
+        messagesBack: number;
+      };
+    interface Resolved {
+      rangeOffset: number;
+      data: string;
+      mediaType: string;
+      receipt: Record<string, unknown>;
+    }
     void (async (): Promise<void> => {
       try {
         const workspace = this.getWorkspaceModule();
         if (!workspace) throw new Error('save_recent_image requires a workspace module');
         const agent = this.agents.get(agentName);
         if (!agent) throw new Error(`Unknown agent: ${agentName}`);
-        const input = (call.input ?? {}) as { path?: unknown; index?: unknown; count?: unknown };
+        const input = (call.input ?? {}) as { path?: unknown; index?: unknown; count?: unknown; ref?: unknown };
         if (typeof input.path !== 'string' || input.path.length === 0) {
           throw new Error('save_recent_image: `path` (mount-prefixed) is required');
         }
-        const index = input.index === undefined ? 0 : Number(input.index);
-        if (!Number.isInteger(index) || index < 0) {
-          throw new Error('save_recent_image: `index` must be a non-negative integer');
-        }
-        const count = input.count === undefined ? 1 : Number(input.count);
-        const MAX_COUNT = 20;
-        if (!Number.isInteger(count) || count < 1 || count > MAX_COUNT) {
-          throw new Error(`save_recent_image: \`count\` must be an integer in 1..${MAX_COUNT}`);
-        }
-        const lastWanted = index + count - 1;
+        const ledger = this.toolImageLedgerFor(agentName);
 
-        // Walk the message store tail-first in bounded windows, re-inlining
-        // blob media, until we've collected the requested range. Scanning is
-        // capped so a pathological index can't drag the whole store through
-        // blob resolution.
-        const MAX_SCAN = 500;
-        const WINDOW = 25;
-        const cm = agent.getContextManager();
-        const total = cm.getMessageCount();
-        let seen = 0;
-        let scanned = 0;
-        const found: Array<{
-          rangeOffset: number;
-          data: string;
-          mediaType: string;
-          messagesBack: number;
-        }> = [];
-        for (let end = total; end > 0 && scanned < MAX_SCAN && found.length < count; end -= WINDOW) {
-          const start = Math.max(0, end - WINDOW);
-          const { messages } = cm.getMessageWindow(start, end - start, { resolveBlobs: true });
-          scanned += end - start;
-          for (let i = messages.length - 1; i >= 0 && found.length < count; i--) {
-            const content = messages[i]?.content;
-            if (!Array.isArray(content)) continue;
-            for (let b = content.length - 1; b >= 0 && found.length < count; b--) {
-              const block = content[b] as {
-                type?: string;
-                source?: { type?: string; data?: string; mediaType?: string };
-              };
-              if (block?.type !== 'image') continue;
-              if (seen >= index && seen <= lastWanted) {
-                if (block.source?.type !== 'base64' || typeof block.source.data !== 'string') {
-                  throw new Error(
-                    `save_recent_image: image at index ${seen} is not stored inline (base64) — cannot save it`,
-                  );
-                }
-                found.push({
-                  rangeOffset: seen - index,
-                  data: block.source.data,
-                  mediaType: block.source.mediaType ?? 'image/png',
-                  messagesBack: total - (start + i),
-                });
+        const describeTool = (c: { toolName: string; toolCallId: string }): string =>
+          `${c.toolName} (call ${c.toolCallId})`;
+        const unavailable = (status: 'evicted' | 'unknown'): string =>
+          status === 'evicted'
+            ? 'its bytes were evicted from the bounded retention budget'
+            : 'this process has no record of that ref (refs are per-process and a restart clears them; ' +
+              'very old refs age out; a mistyped ref looks the same)';
+        const resolve = (candidate: Candidate, position: number): Resolved => {
+          const rangeOffset = 0; // filled by the caller
+          if (candidate.kind === 'attachment') {
+            if (candidate.data === null) {
+              throw new Error(
+                `save_recent_image: image at index ${position} is not stored inline (base64) — cannot save it. Nothing written.`,
+              );
+            }
+            const bytes = Buffer.from(candidate.data, 'base64');
+            return {
+              rangeOffset,
+              data: candidate.data,
+              mediaType: candidate.mediaType,
+              receipt: {
+                source: 'attachment',
+                mediaType: candidate.mediaType,
+                byteSize: bytes.byteLength,
+                sha256: sha256Hex(bytes),
+                messagesBack: candidate.messagesBack,
+              },
+            };
+          }
+          if (candidate.kind === 'reference') {
+            throw new Error(
+              `save_recent_image: image at index ${position} is a reference (${candidate.refId}, ${candidate.mediaType}, ` +
+              `from ${describeTool(candidate)}) — its bytes are not held here. Nothing written. ` +
+              'Fetch it with fetch_reference and save the materialized file instead.',
+            );
+          }
+          if (candidate.ref === null) {
+            throw new Error(
+              `save_recent_image: image at index ${position} is a tool-result image from ${describeTool(candidate)} ` +
+              'recorded before tool-image retention existed — its bytes are not available. Nothing written. ' +
+              'Re-run the tool for a fresh image rather than saving an older one.',
+            );
+          }
+          const lookup = ledger.lookup(candidate.ref);
+          // The placeholder came out of stored TEXT, which a tool result can
+          // quote from anywhere (a fetch_history of a channel where someone
+          // pasted their save receipt). A genuine placeholder is written by
+          // its own call's serialization, so the ref's provenance names that
+          // call; a quoted or forged one cannot. Refuse the mismatch.
+          if (lookup.status !== 'unknown' && lookup.image.toolCallId !== candidate.toolCallId) {
+            throw new Error(
+              `save_recent_image: image at index ${position} cites ${candidate.ref}, but that image belongs to ` +
+              `${describeTool(lookup.image)}, not to ${describeTool(candidate)} where the placeholder appears — ` +
+              'the placeholder is quoted or forged text, not this result\'s own image. Nothing written.',
+            );
+          }
+          if (lookup.status !== 'retained') {
+            throw new Error(
+              `save_recent_image: image at index ${position} (${candidate.ref}, from ${describeTool(candidate)}) ` +
+              `is no longer retained — ${unavailable(lookup.status)}. Nothing written. ` +
+              'Re-run the tool for a fresh image rather than saving an older one.',
+            );
+          }
+          const image = lookup.image;
+          return {
+            rangeOffset,
+            data: image.data,
+            mediaType: image.mediaType,
+            receipt: {
+              source: 'tool-result',
+              ref: image.ref,
+              toolName: image.toolName,
+              toolCallId: image.toolCallId,
+              blockIndex: image.blockIndex,
+              mediaType: image.mediaType,
+              byteSize: image.byteSize,
+              sha256: image.sha256,
+              messagesBack: candidate.messagesBack,
+            },
+          };
+        };
+
+        const found: Resolved[] = [];
+        let index = 0;
+        let count = 1;
+        if (input.ref !== undefined) {
+          if (typeof input.ref !== 'string' || !/^img_\d+$/.test(input.ref)) {
+            throw new Error('save_recent_image: `ref` must look like "img_7" (see the image placeholder in your context)');
+          }
+          if (input.index !== undefined || input.count !== undefined) {
+            throw new Error('save_recent_image: `ref` is mutually exclusive with `index`/`count`');
+          }
+          const lookup = ledger.lookup(input.ref);
+          if (lookup.status !== 'retained') {
+            throw new Error(
+              `save_recent_image: ref ${input.ref}` +
+              (lookup.status === 'evicted' ? ` (from ${describeTool(lookup.image)})` : '') +
+              ` cannot be saved — ${unavailable(lookup.status)}. Nothing written.`,
+            );
+          }
+          found.push(resolve({
+            kind: 'tool',
+            ref: input.ref,
+            toolCallId: lookup.image.toolCallId,
+            toolName: lookup.image.toolName,
+            mediaType: lookup.image.mediaType,
+            messagesBack: 0,
+          }, 0));
+        } else {
+          index = input.index === undefined ? 0 : Number(input.index);
+          if (!Number.isInteger(index) || index < 0) {
+            throw new Error('save_recent_image: `index` must be a non-negative integer');
+          }
+          count = input.count === undefined ? 1 : Number(input.count);
+          const MAX_COUNT = 20;
+          if (!Number.isInteger(count) || count < 1 || count > MAX_COUNT) {
+            throw new Error(`save_recent_image: \`count\` must be an integer in 1..${MAX_COUNT}`);
+          }
+          const lastWanted = index + count - 1;
+          let seen = 0;
+          const consider = (candidate: Candidate): void => {
+            if (seen >= index && seen <= lastWanted) {
+              const resolved = resolve(candidate, seen);
+              resolved.rangeOffset = seen - index;
+              found.push(resolved);
+            }
+            seen++;
+          };
+          const considerToolResultImages = (
+            toolCallId: string,
+            toolName: string,
+            placeholders: ParsedImagePlaceholder[],
+            messagesBack: number,
+          ): void => {
+            for (let p = placeholders.length - 1; p >= 0 && found.length < count; p--) {
+              const ph = placeholders[p]!;
+              if (ph.kind === 'inline') {
+                consider({ kind: 'tool', ref: ph.ref, toolCallId, toolName, mediaType: ph.mediaType, messagesBack });
+                continue;
               }
-              seen++;
+              // Reference stub: the registry's testimony (when this process
+              // still has the record) says whether it was an image; the
+              // sniffed stub text is the fallback. Non-image references
+              // are not slots.
+              const testimony = referenceRegistry.get(ph.refId)?.testimony.mimeType?.toLowerCase() ?? ph.mediaType;
+              if (!testimony || !testimony.startsWith('image/')) continue;
+              consider({ kind: 'reference', refId: ph.refId, mediaType: testimony, toolCallId, toolName, messagesBack });
+            }
+          };
+
+          // Same-batch results that completed before this call (e.g. a
+          // snapshot dispatched alongside the save) are not in the store
+          // yet but ARE the newest images. Retain them now — retention is
+          // idempotent per block, so the placeholder written at commit time
+          // carries the same ref.
+          const state = agent.state;
+          if (state.status === 'waiting_for_tools') {
+            for (let i = state.completed.length - 1; i >= 0 && found.length < count; i--) {
+              const tc = state.completed[i]!;
+              if (tc.result.isError || !Array.isArray(tc.result.data)) continue;
+              const placeholders: ParsedImagePlaceholder[] = [];
+              for (const [blockIndex, raw] of tc.result.data.entries()) {
+                const b = raw as { type?: unknown; data?: unknown; mimeType?: unknown };
+                if (b?.type === 'image' && typeof b.data === 'string' && typeof b.mimeType === 'string') {
+                  const retained = ledger.retain({
+                    toolCallId: tc.id, toolName: tc.name, blockIndex, data: b.data, mediaType: b.mimeType,
+                  });
+                  placeholders.push({
+                    kind: 'inline', mediaType: retained.mediaType, sizeLabel: '', ref: retained.ref, offset: blockIndex,
+                  });
+                }
+              }
+              considerToolResultImages(tc.id, tc.name, placeholders, 0);
             }
           }
-        }
-        if (found.length === 0) {
-          throw new Error(
-            seen === 0
-              ? `save_recent_image: no images found in the most recent ${Math.min(scanned, MAX_SCAN)} messages`
-              : `save_recent_image: only ${seen} image(s) found in the most recent ${Math.min(scanned, MAX_SCAN)} messages (asked for index ${index})`,
-          );
+
+          // Walk the message store tail-first in bounded windows, re-inlining
+          // blob media, until we've collected the requested range. Scanning is
+          // capped so a pathological index can't drag the whole store through
+          // blob resolution.
+          const MAX_SCAN = 500;
+          const WINDOW = 25;
+          const cm = agent.getContextManager();
+          const total = cm.getMessageCount();
+          let scanned = 0;
+          for (let end = total; end > 0 && scanned < MAX_SCAN && found.length < count; end -= WINDOW) {
+            const start = Math.max(0, end - WINDOW);
+            const { messages } = cm.getMessageWindow(start, end - start, { resolveBlobs: true });
+            scanned += end - start;
+            for (let i = messages.length - 1; i >= 0 && found.length < count; i--) {
+              const content = messages[i]?.content;
+              if (!Array.isArray(content)) continue;
+              const messagesBack = total - (start + i);
+              for (let b = content.length - 1; b >= 0 && found.length < count; b--) {
+                const block = content[b] as {
+                  type?: string;
+                  source?: { type?: string; data?: string; mediaType?: string };
+                  toolUseId?: string;
+                  toolName?: string;
+                  content?: unknown;
+                };
+                if (block?.type === 'image') {
+                  const inline = block.source?.type === 'base64' && typeof block.source.data === 'string';
+                  consider({
+                    kind: 'attachment',
+                    data: inline ? block.source!.data! : null,
+                    mediaType: block.source?.mediaType ?? 'image/png',
+                    messagesBack,
+                  });
+                } else if (block?.type === 'tool_result' && typeof block.content === 'string') {
+                  considerToolResultImages(
+                    block.toolUseId ?? 'unknown',
+                    block.toolName ?? 'unknown tool',
+                    parseImagePlaceholders(block.content),
+                    messagesBack,
+                  );
+                }
+              }
+            }
+          }
+          if (found.length === 0) {
+            throw new Error(
+              seen === 0
+                ? `save_recent_image: no images found in the most recent ${Math.min(scanned, MAX_SCAN)} messages`
+                : `save_recent_image: only ${seen} image(s) found in the most recent ${Math.min(scanned, MAX_SCAN)} messages (asked for index ${index})`,
+            );
+          }
         }
 
         // Single image → path as given. Range → numeric suffix before the
@@ -11456,7 +11700,7 @@ export class AgentFramework {
           savedFiles.push({
             ...(result.data as Record<string, unknown>),
             imageIndex: index + image.rangeOffset,
-            messagesBack: image.messagesBack,
+            ...image.receipt,
           });
         }
         finish({

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -78,7 +78,15 @@ import {
   truncateForHistory,
   DEFAULT_TOOL_RESULT_INLINE_MAX_CHARS,
 } from './tool-result-history.js';
-import { ToolImageLedger, parseImagePlaceholders, sha256Hex, type ParsedImagePlaceholder } from './tool-image-ledger.js';
+import {
+  TOOL_IMAGE_REF_RE,
+  ToolImageLedger,
+  formatPreservedImageSlots,
+  parseImagePlaceholders,
+  sha256Hex,
+  splitPreservingImageSlots,
+  type ParsedImagePlaceholder,
+} from './tool-image-ledger.js';
 import { randomUUID } from 'node:crypto';
 import { PyRunner, buildInjectedTools } from './code-execution/py-runner.js';
 import {
@@ -1356,6 +1364,9 @@ export class AgentFramework {
       record.runner.dispose();
     }
     this.backgroundScripts.clear();
+    // Retained tool images are per-process by design; a retained stopped
+    // framework must not keep up to the whole ledger budget referenced.
+    this.toolImageLedgers.clear();
 
     // A stopped host must never hang behind its own cooldown.
     this.cancelProviderAdmission();
@@ -2866,14 +2877,15 @@ export class AgentFramework {
       'Save one or more recent images from your own context to workspace files. ' +
       'Images are counted back from the most recent (index 0), across BOTH ' +
       'attachments in messages and images returned by tools (their history ' +
-      'placeholder shows a ref like `[image: image/png, ~691KB, ref img_7]`; pass ' +
+      'placeholder shows a ref like `[image: image/png, ~691KB, ref img_k7x3q2_7]`; pass ' +
       '`ref` to save that exact image regardless of position). A single image is ' +
       'written to `path` as given (e.g. "project/photos/cat.png"); when `count` > 1 ' +
       'the range index..index+count-1 is saved with numeric suffixes ' +
       '("cat-0.png", "cat-1.png", …; 0 = the newest of the range). If the image at ' +
       'the requested position is no longer retained (evicted, or from before a ' +
       'restart) the call fails and writes nothing — it never substitutes an older ' +
-      'image. Receipts carry source tool call, MIME, byte size and SHA-256. Saved ' +
+      'image. When other tool calls in the same batch are still running, the save ' +
+      'waits for them so their images are counted. Receipts carry source tool call, MIME, byte size and SHA-256. Saved ' +
       'files are visible via workspace tools and the /files/ endpoint.',
     inputSchema: {
       type: 'object',
@@ -2893,7 +2905,7 @@ export class AgentFramework {
         ref: {
           type: 'string',
           description:
-            'Save a specific tool-result image by its history ref (e.g. "img_7") instead of by position. ' +
+            'Save a specific tool-result image by its history ref (e.g. "img_k7x3q2_7", as shown in its placeholder in your context) instead of by position. ' +
             'Mutually exclusive with `index`/`count`.',
         },
       },
@@ -8127,6 +8139,13 @@ export class AgentFramework {
     label: string,
   ): Promise<{ text: string; filePath: string | null }> {
     if (!cap || content.length <= cap) return { text: content, filePath: null };
+    // The stored text is the only place save_recent_image discovers tool
+    // images, and the live wire delivers every image regardless of text
+    // length — so an image slot dropped by the cut is an image the resident
+    // saw that the index would silently slide past (issue #104). Keep the
+    // slots at or past the cut, re-appended after the notice.
+    const { head, tail } = splitPreservingImageSlots(content, cap);
+    const kept = formatPreservedImageSlots(tail);
 
     const workspace = this.getWorkspaceModule();
     const mountName = workspace ? this.firstWritableMountName(workspace) : null;
@@ -8138,10 +8157,11 @@ export class AgentFramework {
         const result = await workspace.writeBinary(path, Buffer.from(content, 'utf8'), 'text/plain');
         if (result.success) {
           return {
-            text: safeSlice(content, 0, cap)
-              + `\n\n[truncated — showing ${cap} of ${content.length} chars; full content: workspace file ${path}. `
+            text: head
+              + `\n\n[truncated — showing ${head.length} of ${content.length} chars; full content: workspace file ${path}. `
               + 'Read/grep it with your file tools, or raise the inline cap via '
-              + 'agent_settings update tool_result_inline_max_chars.]',
+              + 'agent_settings update tool_result_inline_max_chars.]'
+              + kept,
             filePath: path,
           };
         }
@@ -8164,15 +8184,17 @@ export class AgentFramework {
         `[spill] workspace write failed for ${path} (${content.length} chars): ${failure}`,
       );
       return {
-        text: safeSlice(content, 0, cap)
-          + `\n\n[truncated — showing ${cap} of ${content.length} chars; spill to workspace file ${path} FAILED`
-          + ` (${failure}); content over the cap was not retained]`,
+        text: head
+          + `\n\n[truncated — showing ${head.length} of ${content.length} chars; spill to workspace file ${path} FAILED`
+          + ` (${failure}); content over the cap was not retained]`
+          + kept,
         filePath: null,
       };
     }
     return {
-      text: safeSlice(content, 0, cap)
-        + '\n\n[truncated — original was ' + content.length + ' chars; no writable workspace, full content not retained]',
+      text: head
+        + '\n\n[truncated — original was ' + content.length + ' chars; no writable workspace, full content not retained]'
+        + kept,
       filePath: null,
     };
   }
@@ -11376,6 +11398,41 @@ export class AgentFramework {
   }
 
   /**
+   * `save_recent_image` barrier. Module tool calls in a batch are only
+   * ENQUEUED by dispatch, while the save runs at once — so a [snap, save]
+   * round would inventory before the snapshot exists and silently save the
+   * newest OLDER image (issue #104, same-batch representation). Wait for
+   * every sibling in the round to settle; if one never does, fail closed
+   * rather than trust an index the batch may still change. Sibling saves
+   * produce no images and are not waited on (two saves in one batch would
+   * otherwise deadlock into a double timeout). Script-inner calls
+   * (`pytc-…`) run sequentially inside their script host and skip the
+   * barrier — the host call itself is the only pending sibling they'd see.
+   */
+  private async awaitSiblingToolCalls(agent: Agent, call: ToolCall): Promise<void> {
+    if (call.id.startsWith('pytc-')) return;
+    const BARRIER_MS = 120_000;
+    const POLL_MS = 20;
+    const startedAt = Date.now();
+    for (;;) {
+      const state = agent.state;
+      // Idle (puppet path) or the round was torn down: nothing to wait on.
+      if (state.status !== 'waiting_for_tools') return;
+      const open = [...state.pending.values()].filter((p) => p.id !== call.id && p.name !== 'save_recent_image');
+      if (open.length === 0) return;
+      if (Date.now() - startedAt > BARRIER_MS) {
+        throw new Error(
+          `save_recent_image: ${open.length} sibling tool call(s) in this batch still pending after ` +
+          `${Math.round(BARRIER_MS / 1000)}s (${open.map((p) => `${p.name} (call ${p.id})`).join(', ')}) — their results ` +
+          'may carry newer images than anything in your context, so no index can be trusted yet. Nothing written. ' +
+          'Save again once they have finished.',
+        );
+      }
+      await new Promise((r) => setTimeout(r, POLL_MS));
+    }
+  }
+
+  /**
    * Handle the synthesized `save_recent_image` tool (issue #104): build ONE
    * ordered inventory of every image the calling agent has seen — attachment
    * image blocks (blobs re-inlined) AND tool-result images (their history
@@ -11479,7 +11536,8 @@ export class AgentFramework {
           if (candidate.ref === null) {
             throw new Error(
               `save_recent_image: image at index ${position} is a tool-result image from ${describeTool(candidate)} ` +
-              'recorded before tool-image retention existed — its bytes are not available. Nothing written. ' +
+              'recorded without a retention ref (written before tool-image retention existed, or inside a ' +
+              'script run, where tool images are not retained) — its bytes are not available. Nothing written. ' +
               'Re-run the tool for a fresh image rather than saving an older one.',
             );
           }
@@ -11522,32 +11580,24 @@ export class AgentFramework {
           };
         };
 
+        // Barrier: a save dispatched alongside other calls in one batch must
+        // not inventory before their results exist — those are the newest
+        // images. Waits (bounded) for every sibling to settle, or fails closed.
+        await this.awaitSiblingToolCalls(agent, call);
+
         const found: Resolved[] = [];
         let index = 0;
         let count = 1;
+        /** Direct-ref mode: the one ref to find in the scannable context. */
+        let wantedRef: string | null = null;
         if (input.ref !== undefined) {
-          if (typeof input.ref !== 'string' || !/^img_\d+$/.test(input.ref)) {
-            throw new Error('save_recent_image: `ref` must look like "img_7" (see the image placeholder in your context)');
+          if (typeof input.ref !== 'string' || !TOOL_IMAGE_REF_RE.test(input.ref)) {
+            throw new Error('save_recent_image: `ref` must look like "img_k7x3q2_7" (copy it from the image placeholder in your context)');
           }
           if (input.index !== undefined || input.count !== undefined) {
             throw new Error('save_recent_image: `ref` is mutually exclusive with `index`/`count`');
           }
-          const lookup = ledger.lookup(input.ref);
-          if (lookup.status !== 'retained') {
-            throw new Error(
-              `save_recent_image: ref ${input.ref}` +
-              (lookup.status === 'evicted' ? ` (from ${describeTool(lookup.image)})` : '') +
-              ` cannot be saved — ${unavailable(lookup.status)}. Nothing written.`,
-            );
-          }
-          found.push(resolve({
-            kind: 'tool',
-            ref: input.ref,
-            toolCallId: lookup.image.toolCallId,
-            toolName: lookup.image.toolName,
-            mediaType: lookup.image.mediaType,
-            messagesBack: 0,
-          }, 0));
+          wantedRef = input.ref;
         } else {
           index = input.index === undefined ? 0 : Number(input.index);
           if (!Number.isInteger(index) || index < 0) {
@@ -11558,115 +11608,134 @@ export class AgentFramework {
           if (!Number.isInteger(count) || count < 1 || count > MAX_COUNT) {
             throw new Error(`save_recent_image: \`count\` must be an integer in 1..${MAX_COUNT}`);
           }
-          const lastWanted = index + count - 1;
-          let seen = 0;
-          const consider = (candidate: Candidate): void => {
-            if (seen >= index && seen <= lastWanted) {
-              const resolved = resolve(candidate, seen);
-              resolved.rangeOffset = seen - index;
-              found.push(resolved);
+        }
+        const lastWanted = index + count - 1;
+        let seen = 0;
+        const collecting = (): boolean => (wantedRef !== null ? found.length === 0 : found.length < count);
+        // One walk serves both modes. By index: the requested range of the
+        // ordered inventory. By ref: the slot whose placeholder cites that
+        // ref — the ref is resolved THROUGH its occurrence in context, so
+        // the same provenance cross-check applies (a ref that is not visible
+        // in the scannable window — an undone branch, quoted text naming a
+        // real ref — is not saveable by name either).
+        const consider = (candidate: Candidate): void => {
+          if (wantedRef !== null) {
+            if (candidate.kind === 'tool' && candidate.ref === wantedRef && found.length === 0) {
+              found.push(resolve(candidate, seen));
             }
-            seen++;
-          };
-          const considerToolResultImages = (
-            toolCallId: string,
-            toolName: string,
-            placeholders: ParsedImagePlaceholder[],
-            messagesBack: number,
-          ): void => {
-            for (let p = placeholders.length - 1; p >= 0 && found.length < count; p--) {
-              const ph = placeholders[p]!;
-              if (ph.kind === 'inline') {
-                consider({ kind: 'tool', ref: ph.ref, toolCallId, toolName, mediaType: ph.mediaType, messagesBack });
-                continue;
-              }
-              // Reference stub: the registry's testimony (when this process
-              // still has the record) says whether it was an image; the
-              // sniffed stub text is the fallback. Non-image references
-              // are not slots.
-              const testimony = referenceRegistry.get(ph.refId)?.testimony.mimeType?.toLowerCase() ?? ph.mediaType;
-              if (!testimony || !testimony.startsWith('image/')) continue;
-              consider({ kind: 'reference', refId: ph.refId, mediaType: testimony, toolCallId, toolName, messagesBack });
+          } else if (seen >= index && seen <= lastWanted) {
+            const resolved = resolve(candidate, seen);
+            resolved.rangeOffset = seen - index;
+            found.push(resolved);
+          }
+          seen++;
+        };
+        const considerToolResultImages = (
+          toolCallId: string,
+          toolName: string,
+          placeholders: ParsedImagePlaceholder[],
+          messagesBack: number,
+        ): void => {
+          for (let p = placeholders.length - 1; p >= 0 && collecting(); p--) {
+            const ph = placeholders[p]!;
+            if (ph.kind === 'inline') {
+              consider({ kind: 'tool', ref: ph.ref, toolCallId, toolName, mediaType: ph.mediaType, messagesBack });
+              continue;
             }
-          };
+            // Reference stub: the registry's testimony (when this process
+            // still has the record) says whether it was an image; the
+            // sniffed stub text is the fallback. Non-image references
+            // are not slots.
+            const testimony = referenceRegistry.get(ph.refId)?.testimony.mimeType?.toLowerCase() ?? ph.mediaType;
+            if (!testimony || !testimony.startsWith('image/')) continue;
+            consider({ kind: 'reference', refId: ph.refId, mediaType: testimony, toolCallId, toolName, messagesBack });
+          }
+        };
 
-          // Same-batch results that completed before this call (e.g. a
-          // snapshot dispatched alongside the save) are not in the store
-          // yet but ARE the newest images. Retain them now — retention is
-          // idempotent per block, so the placeholder written at commit time
-          // carries the same ref.
-          const state = agent.state;
-          if (state.status === 'waiting_for_tools') {
-            for (let i = state.completed.length - 1; i >= 0 && found.length < count; i--) {
-              const tc = state.completed[i]!;
-              if (tc.result.isError || !Array.isArray(tc.result.data)) continue;
-              const placeholders: ParsedImagePlaceholder[] = [];
-              for (const [blockIndex, raw] of tc.result.data.entries()) {
-                const b = raw as { type?: unknown; data?: unknown; mimeType?: unknown };
-                if (b?.type === 'image' && typeof b.data === 'string' && typeof b.mimeType === 'string') {
-                  const retained = ledger.retain({
-                    toolCallId: tc.id, toolName: tc.name, blockIndex, data: b.data, mediaType: b.mimeType,
-                  });
-                  placeholders.push({
-                    kind: 'inline', mediaType: retained.mediaType, sizeLabel: '', ref: retained.ref, offset: blockIndex,
-                  });
-                }
+        // Same-batch results (e.g. a snapshot dispatched alongside the save)
+        // are not in the store yet but ARE the newest images. Classify them
+        // with the very serializer the commit path will run — contradiction
+        // blocks withheld, uri-form blocks as reference stubs, unknown shapes
+        // as no slot at all — so the inventory means the same thing before
+        // and after commit. Retention is idempotent per block, so the
+        // placeholder written at commit time carries the same ref.
+        const state = agent.state;
+        if (state.status === 'waiting_for_tools') {
+          for (let i = state.completed.length - 1; i >= 0 && collecting(); i--) {
+            const tc = state.completed[i]!;
+            if (tc.result.isError) continue;
+            const text = toolResultDataToHistoryString(tc.result.data, undefined, {
+              imageRef: (blockIndex, image) => ledger.retain({
+                toolCallId: tc.id, toolName: tc.name, blockIndex, data: image.data, mediaType: image.mimeType,
+              }).ref,
+            });
+            considerToolResultImages(tc.id, tc.name, parseImagePlaceholders(text), 0);
+          }
+        }
+
+        // Walk the message store tail-first in bounded windows, re-inlining
+        // blob media, until we've collected the requested range. Scanning is
+        // capped so a pathological index can't drag the whole store through
+        // blob resolution.
+        const MAX_SCAN = 500;
+        const WINDOW = 25;
+        const cm = agent.getContextManager();
+        const total = cm.getMessageCount();
+        let scanned = 0;
+        for (let end = total; end > 0 && scanned < MAX_SCAN && collecting(); end -= WINDOW) {
+          const start = Math.max(0, end - WINDOW);
+          // By ref, attachment bytes are never needed — skip blob resolution.
+          const { messages } = cm.getMessageWindow(start, end - start, { resolveBlobs: wantedRef === null });
+          scanned += end - start;
+          for (let i = messages.length - 1; i >= 0 && collecting(); i--) {
+            const content = messages[i]?.content;
+            if (!Array.isArray(content)) continue;
+            const messagesBack = total - (start + i);
+            for (let b = content.length - 1; b >= 0 && collecting(); b--) {
+              const block = content[b] as {
+                type?: string;
+                source?: { type?: string; data?: string; mediaType?: string };
+                toolUseId?: string;
+                toolName?: string;
+                content?: unknown;
+              };
+              if (block?.type === 'image') {
+                const inline = block.source?.type === 'base64' && typeof block.source.data === 'string';
+                consider({
+                  kind: 'attachment',
+                  data: inline ? block.source!.data! : null,
+                  mediaType: block.source?.mediaType ?? 'image/png',
+                  messagesBack,
+                });
+              } else if (block?.type === 'tool_result' && typeof block.content === 'string') {
+                considerToolResultImages(
+                  block.toolUseId ?? 'unknown',
+                  block.toolName ?? 'unknown tool',
+                  parseImagePlaceholders(block.content),
+                  messagesBack,
+                );
               }
-              considerToolResultImages(tc.id, tc.name, placeholders, 0);
             }
           }
-
-          // Walk the message store tail-first in bounded windows, re-inlining
-          // blob media, until we've collected the requested range. Scanning is
-          // capped so a pathological index can't drag the whole store through
-          // blob resolution.
-          const MAX_SCAN = 500;
-          const WINDOW = 25;
-          const cm = agent.getContextManager();
-          const total = cm.getMessageCount();
-          let scanned = 0;
-          for (let end = total; end > 0 && scanned < MAX_SCAN && found.length < count; end -= WINDOW) {
-            const start = Math.max(0, end - WINDOW);
-            const { messages } = cm.getMessageWindow(start, end - start, { resolveBlobs: true });
-            scanned += end - start;
-            for (let i = messages.length - 1; i >= 0 && found.length < count; i--) {
-              const content = messages[i]?.content;
-              if (!Array.isArray(content)) continue;
-              const messagesBack = total - (start + i);
-              for (let b = content.length - 1; b >= 0 && found.length < count; b--) {
-                const block = content[b] as {
-                  type?: string;
-                  source?: { type?: string; data?: string; mediaType?: string };
-                  toolUseId?: string;
-                  toolName?: string;
-                  content?: unknown;
-                };
-                if (block?.type === 'image') {
-                  const inline = block.source?.type === 'base64' && typeof block.source.data === 'string';
-                  consider({
-                    kind: 'attachment',
-                    data: inline ? block.source!.data! : null,
-                    mediaType: block.source?.mediaType ?? 'image/png',
-                    messagesBack,
-                  });
-                } else if (block?.type === 'tool_result' && typeof block.content === 'string') {
-                  considerToolResultImages(
-                    block.toolUseId ?? 'unknown',
-                    block.toolName ?? 'unknown tool',
-                    parseImagePlaceholders(block.content),
-                    messagesBack,
-                  );
-                }
-              }
-            }
-          }
-          if (found.length === 0) {
+        }
+        if (found.length === 0) {
+          if (wantedRef !== null) {
+            const lookup = ledger.lookup(wantedRef);
             throw new Error(
-              seen === 0
-                ? `save_recent_image: no images found in the most recent ${Math.min(scanned, MAX_SCAN)} messages`
-                : `save_recent_image: only ${seen} image(s) found in the most recent ${Math.min(scanned, MAX_SCAN)} messages (asked for index ${index})`,
+              lookup.status === 'unknown'
+                ? `save_recent_image: ref ${wantedRef} cannot be saved — ${unavailable('unknown')}. Nothing written.`
+                : `save_recent_image: ref ${wantedRef} (from ${describeTool(lookup.image)}) does not appear in your recent ` +
+                  `context (scanned ${Math.min(scanned, MAX_SCAN)} messages) — a ref is saved through its placeholder, ` +
+                  'which must be visible to you' +
+                  (lookup.status === 'evicted' ? '; its bytes were also evicted from the bounded retention budget' : '') +
+                  '. Nothing written.',
             );
           }
+          throw new Error(
+            seen === 0
+              ? `save_recent_image: no images found in the most recent ${Math.min(scanned, MAX_SCAN)} messages`
+              : `save_recent_image: only ${seen} image(s) found in the most recent ${Math.min(scanned, MAX_SCAN)} messages (asked for index ${index})`,
+          );
         }
 
         // Single image → path as given. Range → numeric suffix before the

--- a/src/tool-image-ledger.ts
+++ b/src/tool-image-ledger.ts
@@ -1,0 +1,230 @@
+/**
+ * Per-agent retention of tool-result images, with provenance (issue #104).
+ *
+ * History keeps a compact text placeholder for every image a tool returns —
+ * the bytes only ever ride the live wire copy of that one turn. That policy
+ * is right (megabytes of base64 in the persisted window would be sliced,
+ * compressed, and replayed forever), but it left `save_recent_image` with no
+ * way to reach an image the resident had just seen: the scanner walked past
+ * the byteless placeholder and quietly saved whichever OLDER attachment came
+ * next, under the filename the resident chose for the new one.
+ *
+ * This ledger is the missing half. At ingestion every tool-result image is
+ * retained here under a stable per-agent ref (`img_7`) bound to the exact
+ * tool call and block it came from, with its digest. The history placeholder
+ * carries the ref, so the ordered inventory `save_recent_image` walks can
+ * include tool images at their true position — and when the bytes behind a
+ * ref are gone (bounded eviction, or a restart: the ledger is in-memory by
+ * design, so it never adds to blob growth), the save fails AT THAT INDEX with
+ * a specific error instead of sliding to an older image. Silent substitution
+ * of bytes from another surface is the failure this exists to end.
+ */
+
+import { createHash } from 'node:crypto';
+
+export interface RetainedToolImage {
+  /** Stable per-agent handle, minted once per (toolCallId, blockIndex). */
+  ref: string;
+  toolCallId: string;
+  toolName: string;
+  /** Position of the image block inside the tool result's content array. */
+  blockIndex: number;
+  mediaType: string;
+  byteSize: number;
+  sha256: string;
+  retainedAt: number;
+}
+
+/** A retained image whose bytes are still held. */
+export interface RetainedToolImageWithData extends RetainedToolImage {
+  /** Base64 payload, exactly as the tool returned it. */
+  data: string;
+}
+
+export type ToolImageLookup =
+  | { status: 'retained'; image: RetainedToolImageWithData }
+  /** The ref was issued by this ledger but its bytes were evicted (bounded budget). */
+  | { status: 'evicted'; image: RetainedToolImage }
+  /** Never issued by this ledger — a typo, or a ref minted before a restart. */
+  | { status: 'unknown' };
+
+export interface ToolImageLedgerOptions {
+  /** Total base64 chars held across retained images (≈ bytes × 4/3). */
+  maxChars?: number;
+  /** Maximum number of images whose bytes are held. */
+  maxEntries?: number;
+}
+
+/** 96 MB of base64 ≈ 72 MB of image bytes — a few dozen world snapshots. */
+export const DEFAULT_TOOL_IMAGE_LEDGER_MAX_CHARS = 96 * 1024 * 1024;
+export const DEFAULT_TOOL_IMAGE_LEDGER_MAX_ENTRIES = 64;
+
+export class ToolImageLedger {
+  private nextSeq = 1;
+  /** Insertion-ordered (oldest first) — eviction pops from the front. */
+  private readonly retained = new Map<string, RetainedToolImageWithData>();
+  /** Provenance for every ref ever issued, bytes or not (bounded separately). */
+  private readonly issued = new Map<string, RetainedToolImage>();
+  private readonly refByKey = new Map<string, string>();
+  private heldChars = 0;
+  private readonly maxChars: number;
+  private readonly maxEntries: number;
+
+  constructor(options: ToolImageLedgerOptions = {}) {
+    this.maxChars = options.maxChars ?? DEFAULT_TOOL_IMAGE_LEDGER_MAX_CHARS;
+    this.maxEntries = options.maxEntries ?? DEFAULT_TOOL_IMAGE_LEDGER_MAX_ENTRIES;
+  }
+
+  /**
+   * Retain one image block from a tool result. Idempotent per
+   * (toolCallId, blockIndex): the same block always yields the same ref, so
+   * a result serialized twice (or retained early, then serialized) agrees
+   * with itself.
+   */
+  retain(source: {
+    toolCallId: string;
+    toolName: string;
+    blockIndex: number;
+    data: string;
+    mediaType: string;
+  }): RetainedToolImage {
+    const key = `${source.toolCallId}:${source.blockIndex}`;
+    const existingRef = this.refByKey.get(key);
+    if (existingRef !== undefined) {
+      const known = this.issued.get(existingRef);
+      if (known) return known;
+    }
+    const ref = `img_${this.nextSeq++}`;
+    const bytes = Buffer.from(source.data, 'base64');
+    const image: RetainedToolImageWithData = {
+      ref,
+      toolCallId: source.toolCallId,
+      toolName: source.toolName,
+      blockIndex: source.blockIndex,
+      // Tools send mime types unvalidated; the placeholder grammar is
+      // lowercase, so normalize here and at format time (same rule) or an
+      // `Image/PNG` would write a placeholder that never re-parses — an
+      // invisible slot, i.e. a silent index slide.
+      mediaType: normalizeMediaType(source.mediaType),
+      byteSize: bytes.byteLength,
+      sha256: sha256Hex(bytes),
+      retainedAt: Date.now(),
+      data: source.data,
+    };
+    const { data: _data, ...provenance } = image;
+    this.refByKey.set(key, ref);
+    this.issued.set(ref, provenance);
+    // A single image over the whole budget is issued (so the placeholder is
+    // honest about its provenance) but never held.
+    if (source.data.length <= this.maxChars) {
+      this.retained.set(ref, image);
+      this.heldChars += source.data.length;
+      this.evictOverBudget();
+    }
+    this.trimProvenance();
+    return provenance;
+  }
+
+  lookup(ref: string): ToolImageLookup {
+    const held = this.retained.get(ref);
+    if (held) return { status: 'retained', image: held };
+    const known = this.issued.get(ref);
+    if (known) return { status: 'evicted', image: known };
+    return { status: 'unknown' };
+  }
+
+  /** Ref already minted for this block, if any (no retention side effect). */
+  refFor(toolCallId: string, blockIndex: number): string | undefined {
+    return this.refByKey.get(`${toolCallId}:${blockIndex}`);
+  }
+
+  /** Count of images whose bytes are currently held. */
+  get size(): number {
+    return this.retained.size;
+  }
+
+  private evictOverBudget(): void {
+    for (const [ref, image] of this.retained) {
+      if (this.retained.size <= this.maxEntries && this.heldChars <= this.maxChars) break;
+      this.retained.delete(ref);
+      this.heldChars -= image.data.length;
+    }
+  }
+
+  /** Provenance for evicted refs is kept for a while so the error can name
+   *  the tool call; bounded so a long-lived agent can't grow it forever. */
+  private trimProvenance(): void {
+    const keep = Math.max(this.maxEntries * 4, 256);
+    while (this.issued.size > keep) {
+      const oldest = this.issued.keys().next().value;
+      if (oldest === undefined) break;
+      const image = this.issued.get(oldest);
+      this.issued.delete(oldest);
+      if (image) this.refByKey.delete(`${image.toolCallId}:${image.blockIndex}`);
+    }
+  }
+}
+
+/** Lowercase, trimmed — the one spelling the placeholder grammar accepts. */
+export function normalizeMediaType(mediaType: string): string {
+  return mediaType.trim().toLowerCase();
+}
+
+/** History placeholder for a retained tool image: `[image: image/png, ~691KB, ref img_7]`. */
+export function formatToolImagePlaceholder(mediaType: string, sizeLabel: string, ref: string | null): string {
+  const mime = normalizeMediaType(mediaType);
+  return ref === null
+    ? `[image: ${mime}, ${sizeLabel}]`
+    : `[image: ${mime}, ${sizeLabel}, ref ${ref}]`;
+}
+
+export type ParsedImagePlaceholder =
+  /** An inline tool image the serializer replaced with a placeholder. */
+  | {
+    kind: 'inline';
+    mediaType: string;
+    sizeLabel: string;
+    /** null for placeholders written before retention existed (unsaveable). */
+    ref: string | null;
+    /** Character offset in the scanned text — for ordering within a block. */
+    offset: number;
+  }
+  /** An RFC-005 reference stub whose testimony says image — bytes live
+   *  behind fetch_reference, never in this ledger. Occupies a slot so the
+   *  index cannot slide past it. */
+  | {
+    kind: 'reference';
+    refId: string;
+    /** Mime sniffed from the stub text; null when the stub names none. */
+    mediaType: string | null;
+    offset: number;
+  };
+
+const PLACEHOLDER_RE = /\[image: ([a-z]+\/[a-z0-9.+-]+), (~?[\d.]+(?:B|KB|MB))(?:, ref (img_\d+))?\]/g;
+/** `[ref_1_ab3d] cam.png — image/png, 1.2MB claimed — from tool result — …` (one line). */
+const REFERENCE_STUB_RE = /^\[(ref_[0-9a-z]+_[0-9a-z]+)\] ([^\n]*)$/gm;
+const IMAGE_MIME_RE = /\bimage\/[a-z0-9.+-]+/i;
+
+/**
+ * Every image slot in a stored tool-result string, in text order: inline
+ * placeholders and image-typed reference stubs. Text-derived and therefore
+ * untrusted — a tool result can quote someone else's placeholder verbatim —
+ * so the caller MUST cross-check a resolved ref's provenance against the
+ * tool_result block it was found in before handing out bytes.
+ */
+export function parseImagePlaceholders(text: string): ParsedImagePlaceholder[] {
+  const out: ParsedImagePlaceholder[] = [];
+  for (const m of text.matchAll(PLACEHOLDER_RE)) {
+    out.push({ kind: 'inline', mediaType: m[1]!, sizeLabel: m[2]!, ref: m[3] ?? null, offset: m.index ?? 0 });
+  }
+  for (const m of text.matchAll(REFERENCE_STUB_RE)) {
+    const mime = m[2]!.match(IMAGE_MIME_RE);
+    out.push({ kind: 'reference', refId: m[1]!, mediaType: mime ? mime[0].toLowerCase() : null, offset: m.index ?? 0 });
+  }
+  out.sort((a, b) => a.offset - b.offset);
+  return out;
+}
+
+export function sha256Hex(bytes: Buffer): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}

--- a/src/tool-image-ledger.ts
+++ b/src/tool-image-ledger.ts
@@ -10,9 +10,15 @@
  * next, under the filename the resident chose for the new one.
  *
  * This ledger is the missing half. At ingestion every tool-result image is
- * retained here under a stable per-agent ref (`img_7`) bound to the exact
- * tool call and block it came from, with its digest. The history placeholder
- * carries the ref, so the ordered inventory `save_recent_image` walks can
+ * retained here under a stable per-agent ref (`img_k7x3q2_7`) bound to the
+ * exact tool call and block it came from, with its digest. The ref carries a
+ * per-ledger nonce: ledgers live and die with the process, but the persisted
+ * store keeps yesterday's placeholders visible in context, so a bare sequence
+ * number would let a stale `img_7` resolve to whatever this process minted
+ * seventh. A stale ref must resolve `unknown`, never to other bytes.
+ *
+ * The history placeholder carries the ref, so the ordered inventory
+ * `save_recent_image` walks can
  * include tool images at their true position — and when the bytes behind a
  * ref are gone (bounded eviction, or a restart: the ledger is in-memory by
  * design, so it never adds to blob growth), the save fails AT THAT INDEX with
@@ -20,10 +26,11 @@
  * of bytes from another surface is the failure this exists to end.
  */
 
-import { createHash } from 'node:crypto';
+import { createHash, randomBytes } from 'node:crypto';
+import { safeSlice } from './safe-slice.js';
 
 export interface RetainedToolImage {
-  /** Stable per-agent handle, minted once per (toolCallId, blockIndex). */
+  /** Stable per-ledger handle (`img_<nonce>_<seq>`), minted once per (toolCallId, blockIndex). */
   ref: string;
   toolCallId: string;
   toolName: string;
@@ -60,6 +67,9 @@ export const DEFAULT_TOOL_IMAGE_LEDGER_MAX_CHARS = 96 * 1024 * 1024;
 export const DEFAULT_TOOL_IMAGE_LEDGER_MAX_ENTRIES = 64;
 
 export class ToolImageLedger {
+  /** Namespace for every ref this ledger mints; a fresh ledger (new process,
+   *  agent re-registration) never shares one with its predecessors. */
+  readonly nonce: string = mintLedgerNonce();
   private nextSeq = 1;
   /** Insertion-ordered (oldest first) — eviction pops from the front. */
   private readonly retained = new Map<string, RetainedToolImageWithData>();
@@ -77,9 +87,12 @@ export class ToolImageLedger {
 
   /**
    * Retain one image block from a tool result. Idempotent per
-   * (toolCallId, blockIndex): the same block always yields the same ref, so
-   * a result serialized twice (or retained early, then serialized) agrees
-   * with itself.
+   * (toolCallId, blockIndex) for as long as that block's provenance record
+   * is held (bounded — see trimProvenance): within that window the same
+   * block always yields the same ref, so a result serialized twice (or
+   * retained early in a tool batch, then serialized at commit) agrees with
+   * itself. A block re-serialized after its record aged out mints a fresh
+   * ref; the old one resolves `evicted`/`unknown`, never to other bytes.
    */
   retain(source: {
     toolCallId: string;
@@ -94,8 +107,11 @@ export class ToolImageLedger {
       const known = this.issued.get(existingRef);
       if (known) return known;
     }
-    const ref = `img_${this.nextSeq++}`;
-    const bytes = Buffer.from(source.data, 'base64');
+    const ref = `img_${this.nonce}_${this.nextSeq++}`;
+    // Digest without materializing the whole decoded image: a 96MB base64
+    // field would otherwise transiently allocate ~72MB more and the ledger
+    // would be the one asking for it. Chunked decode keeps the peak small.
+    const { byteSize, sha256 } = digestBase64(source.data);
     const image: RetainedToolImageWithData = {
       ref,
       toolCallId: source.toolCallId,
@@ -106,8 +122,8 @@ export class ToolImageLedger {
       // `Image/PNG` would write a placeholder that never re-parses — an
       // invisible slot, i.e. a silent index slide.
       mediaType: normalizeMediaType(source.mediaType),
-      byteSize: bytes.byteLength,
-      sha256: sha256Hex(bytes),
+      byteSize,
+      sha256,
       retainedAt: Date.now(),
       data: source.data,
     };
@@ -165,9 +181,30 @@ export class ToolImageLedger {
   }
 }
 
-/** Lowercase, trimmed — the one spelling the placeholder grammar accepts. */
+/** Six random base36 chars — one per ledger lifetime, embedded in every ref. */
+function mintLedgerNonce(): string {
+  return randomBytes(4).readUInt32BE(0).toString(36).padStart(6, '0').slice(-6);
+}
+
+/** Grammar of a ref this module mints: `img_<ledger nonce>_<sequence>`. */
+export const TOOL_IMAGE_REF_RE = /^img_[0-9a-z]+_\d+$/;
+
+/** RFC 6838 type/subtype token characters (lowercased); no parameters. */
+const MEDIA_TYPE_ESSENCE_RE = /^[a-z0-9!#$&^_.+-]+\/[a-z0-9!#$&^_.+-]+$/;
+export const FALLBACK_MEDIA_TYPE = 'application/octet-stream';
+
+/**
+ * The one spelling the placeholder grammar accepts: trimmed, lowercased, the
+ * `type/subtype` essence only (parameters such as `; charset=binary` are
+ * dropped), and — because `mimeType` arrives from external MCPL servers
+ * unvalidated — anything that still is not a well-formed type/subtype falls
+ * back to `application/octet-stream`. The invariant this buys: the
+ * serializer can NEVER write a placeholder that does not re-parse, so a
+ * strange mime can never produce an invisible slot (a silent index slide).
+ */
 export function normalizeMediaType(mediaType: string): string {
-  return mediaType.trim().toLowerCase();
+  const essence = mediaType.split(';', 1)[0]!.trim().toLowerCase();
+  return MEDIA_TYPE_ESSENCE_RE.test(essence) ? essence : FALLBACK_MEDIA_TYPE;
 }
 
 /** History placeholder for a retained tool image: `[image: image/png, ~691KB, ref img_7]`. */
@@ -188,6 +225,8 @@ export type ParsedImagePlaceholder =
     ref: string | null;
     /** Character offset in the scanned text — for ordering within a block. */
     offset: number;
+    /** The placeholder exactly as it appears in the text. */
+    text: string;
   }
   /** An RFC-005 reference stub whose testimony says image — bytes live
    *  behind fetch_reference, never in this ledger. Occupies a slot so the
@@ -198,12 +237,14 @@ export type ParsedImagePlaceholder =
     /** Mime sniffed from the stub text; null when the stub names none. */
     mediaType: string | null;
     offset: number;
+    /** The stub line exactly as it appears in the text. */
+    text: string;
   };
 
-const PLACEHOLDER_RE = /\[image: ([a-z]+\/[a-z0-9.+-]+), (~?[\d.]+(?:B|KB|MB))(?:, ref (img_\d+))?\]/g;
+const PLACEHOLDER_RE = /\[image: ([a-z0-9!#$&^_.+-]+\/[a-z0-9!#$&^_.+-]+), (~?[\d.]+(?:B|KB|MB))(?:, ref (img_[0-9a-z]+_\d+))?\]/g;
 /** `[ref_1_ab3d] cam.png — image/png, 1.2MB claimed — from tool result — …` (one line). */
 const REFERENCE_STUB_RE = /^\[(ref_[0-9a-z]+_[0-9a-z]+)\] ([^\n]*)$/gm;
-const IMAGE_MIME_RE = /\bimage\/[a-z0-9.+-]+/i;
+const IMAGE_MIME_RE = /\bimage\/[a-z0-9!#$&^_.+-]+/i;
 
 /**
  * Every image slot in a stored tool-result string, in text order: inline
@@ -215,16 +256,79 @@ const IMAGE_MIME_RE = /\bimage\/[a-z0-9.+-]+/i;
 export function parseImagePlaceholders(text: string): ParsedImagePlaceholder[] {
   const out: ParsedImagePlaceholder[] = [];
   for (const m of text.matchAll(PLACEHOLDER_RE)) {
-    out.push({ kind: 'inline', mediaType: m[1]!, sizeLabel: m[2]!, ref: m[3] ?? null, offset: m.index ?? 0 });
+    out.push({ kind: 'inline', mediaType: m[1]!, sizeLabel: m[2]!, ref: m[3] ?? null, offset: m.index ?? 0, text: m[0] });
   }
   for (const m of text.matchAll(REFERENCE_STUB_RE)) {
     const mime = m[2]!.match(IMAGE_MIME_RE);
-    out.push({ kind: 'reference', refId: m[1]!, mediaType: mime ? mime[0].toLowerCase() : null, offset: m.index ?? 0 });
+    out.push({ kind: 'reference', refId: m[1]!, mediaType: mime ? mime[0].toLowerCase() : null, offset: m.index ?? 0, text: m[0] });
   }
   out.sort((a, b) => a.offset - b.offset);
   return out;
 }
 
+/**
+ * Cut `text` to at most `cap` chars WITHOUT losing or splitting an image
+ * slot. The stored tool_result text is the only place the inventory
+ * discovers tool images, while the live wire still delivers every image
+ * regardless of text length — so a slot dropped by truncation is an image
+ * the resident saw that the index silently slides past (the #104 failure,
+ * one representation over). Returns the head to keep and the slots that
+ * fell at or past the cut, to be re-appended verbatim after the truncation
+ * notice. A slot straddling the cut moves the cut back to its start, so the
+ * head never contains a partial slot (a partial reference-stub line would
+ * otherwise still re-parse and be counted twice).
+ */
+export function splitPreservingImageSlots(text: string, cap: number): { head: string; tail: string[] } {
+  const slots = parseImagePlaceholders(text);
+  let cutAt = cap;
+  for (const slot of slots) {
+    if (slot.offset < cutAt && slot.offset + slot.text.length > cutAt) cutAt = slot.offset;
+  }
+  return {
+    head: safeSlice(text, 0, cutAt),
+    tail: slots.filter((slot) => slot.offset >= cutAt).map((slot) => slot.text),
+  };
+}
+
+/** Text to append after a truncation notice so the preserved slots stay
+ *  parseable (each reference stub on its own line). Empty when none. */
+export function formatPreservedImageSlots(tail: string[]): string {
+  if (tail.length === 0) return '';
+  return `\n[${tail.length} image slot(s) fell past the cut; kept here in order so save_recent_image still counts them:]\n`
+    + tail.join('\n');
+}
+
 export function sha256Hex(bytes: Buffer): string {
   return createHash('sha256').update(bytes).digest('hex');
+}
+
+/** Only the base64 alphabet, with nothing but trailing `=` padding after it. */
+function isCleanBase64(data: string): boolean {
+  const m = /[^A-Za-z0-9+/]/.exec(data);
+  if (!m) return true;
+  const rest = data.length - m.index;
+  return rest <= 2 && /^=+$/.test(data.slice(m.index));
+}
+
+/**
+ * Byte length and SHA-256 of a base64 payload, decoded in 4-char-aligned
+ * chunks so the peak allocation stays at one chunk rather than the whole
+ * image. Falls back to a whole decode when the string carries whitespace
+ * or embedded padding (chunk alignment would no longer be trustworthy) —
+ * the digest must describe exactly the bytes a later whole decode writes.
+ */
+function digestBase64(data: string): { byteSize: number; sha256: string } {
+  if (!isCleanBase64(data)) {
+    const bytes = Buffer.from(data, 'base64');
+    return { byteSize: bytes.byteLength, sha256: sha256Hex(bytes) };
+  }
+  const CHUNK = 1 << 20; // multiple of 4
+  const hash = createHash('sha256');
+  let byteSize = 0;
+  for (let i = 0; i < data.length; i += CHUNK) {
+    const bytes = Buffer.from(data.slice(i, i + CHUNK), 'base64');
+    hash.update(bytes);
+    byteSize += bytes.byteLength;
+  }
+  return { byteSize, sha256: hash.digest('hex') };
 }

--- a/src/tool-result-history.ts
+++ b/src/tool-result-history.ts
@@ -16,6 +16,17 @@
 
 import { safeSlice } from './safe-slice.js';
 import { INLINE_WITHHELD_TEXT, isInlineContradiction, referenceStubOrNull } from './mcpl/references.js';
+import { formatToolImagePlaceholder } from './tool-image-ledger.js';
+
+export interface HistorySerializeOptions {
+  /**
+   * Called for every image block the serializer replaces with a placeholder
+   * (issue #104). Returns the retention ref to embed in the placeholder —
+   * `[image: image/png, ~691KB, ref img_7]` — so the image keeps a saveable
+   * handle in history; null leaves the legacy ref-less form.
+   */
+  imageRef?: (blockIndex: number, image: { data: string; mimeType: string }) => string | null;
+}
 
 /**
  * House-safe default inline cap (chars) for tool results, error results, and
@@ -36,8 +47,12 @@ import { INLINE_WITHHELD_TEXT, isInlineContradiction, referenceStubOrNull } from
  */
 export const DEFAULT_TOOL_RESULT_INLINE_MAX_CHARS = 24000;
 
-export function toolResultDataToHistoryString(data: unknown, maxChars?: number): string {
-  const fromArray = tryHistoryStringFromContentArray(data);
+export function toolResultDataToHistoryString(
+  data: unknown,
+  maxChars?: number,
+  options?: HistorySerializeOptions,
+): string {
+  const fromArray = tryHistoryStringFromContentArray(data, options);
   const str = fromArray ?? JSON.stringify(data);
   return maxChars ? truncateForHistory(str, maxChars) : str;
 }
@@ -54,10 +69,10 @@ export function truncateForHistory(str: string, maxChars: number): string {
  * recognize, return a history-safe string (images → placeholders). Otherwise
  * return `null` to defer to the caller's fallback (JSON, usually).
  */
-function tryHistoryStringFromContentArray(data: unknown): string | null {
+function tryHistoryStringFromContentArray(data: unknown, options?: HistorySerializeOptions): string | null {
   if (!Array.isArray(data)) return null;
   const parts: string[] = [];
-  for (const raw of data) {
+  for (const [blockIndex, raw] of data.entries()) {
     if (!raw || typeof raw !== 'object') return null;
     const b = raw as { type?: unknown; text?: unknown; data?: unknown; mimeType?: unknown };
     if (b.type === 'text' && typeof b.text === 'string') {
@@ -69,10 +84,14 @@ function tryHistoryStringFromContentArray(data: unknown): string | null {
     } else if (b.type === 'image' && typeof b.data === 'string' && typeof b.mimeType === 'string') {
       // Decoded byte estimate from base64 length (3/4 ratio, rounded).
       const approxBytes = Math.floor(b.data.length * 3 / 4);
-      parts.push(`[image: ${b.mimeType}, ${formatSize(approxBytes)}]`);
+      const ref = options?.imageRef?.(blockIndex, { data: b.data, mimeType: b.mimeType }) ?? null;
+      parts.push(formatToolImagePlaceholder(b.mimeType, formatSize(approxBytes), ref));
     } else if (b.type === 'resource' || ((b.type === 'image' || b.type === 'audio') && typeof (b as { uri?: unknown }).uri === 'string')) {
       // RFC-005 reference block: a bounded stub, never the raw block JSON
       // (which used to inline the URI — and the whole array — into history).
+      // Image-typed stubs still occupy a slot in save_recent_image's
+      // inventory (a failing one — bytes live behind fetch_reference), so
+      // the index never slides past an image the resident saw.
       const stub = referenceStubOrNull(b, 'from tool result');
       if (stub === null) return null;
       parts.push(stub);

--- a/src/tool-result-history.ts
+++ b/src/tool-result-history.ts
@@ -14,9 +14,8 @@
  * For anything else it falls back to JSON.
  */
 
-import { safeSlice } from './safe-slice.js';
 import { INLINE_WITHHELD_TEXT, isInlineContradiction, referenceStubOrNull } from './mcpl/references.js';
-import { formatToolImagePlaceholder } from './tool-image-ledger.js';
+import { formatPreservedImageSlots, formatToolImagePlaceholder, splitPreservingImageSlots } from './tool-image-ledger.js';
 
 export interface HistorySerializeOptions {
   /**
@@ -57,11 +56,14 @@ export function toolResultDataToHistoryString(
   return maxChars ? truncateForHistory(str, maxChars) : str;
 }
 
-/** Bounded copy of an arbitrary string with the standard truncation notice. */
+/** Bounded copy of an arbitrary string with the standard truncation notice.
+ *  Image slots past the cut are re-appended, never dropped (issue #104). */
 export function truncateForHistory(str: string, maxChars: number): string {
   if (str.length <= maxChars) return str;
-  return safeSlice(str, 0, maxChars)
-    + '\n\n[truncated — original was ' + str.length + ' chars]';
+  const { head, tail } = splitPreservingImageSlots(str, maxChars);
+  return head
+    + '\n\n[truncated — original was ' + str.length + ' chars]'
+    + formatPreservedImageSlots(tail);
 }
 
 /**

--- a/test/puppet-tool-call.test.ts
+++ b/test/puppet-tool-call.test.ts
@@ -42,6 +42,7 @@ function puppetHarness(opts?: {
   const framework = Object.create(AgentFramework.prototype) as AgentFramework;
   (framework as unknown as { agents: Map<string, unknown> }).agents =
     new Map([['princess', agent]]);
+  (framework as unknown as { toolImageLedgers: Map<string, unknown> }).toolImageLedgers = new Map();
   (framework as unknown as Record<string, unknown>).getToolsForAgent =
     () => surface.map((name) => ({ name }));
   (framework as unknown as Record<string, unknown>).executeToolCall =

--- a/test/save-recent-image.test.ts
+++ b/test/save-recent-image.test.ts
@@ -1,0 +1,472 @@
+/**
+ * `save_recent_image` provenance — issue #104.
+ *
+ * Tool-result images never reached the persisted window (history keeps a
+ * text placeholder), so the recency scan walked past a snapshot the resident
+ * had just seen and quietly saved an OLDER attachment under the snapshot's
+ * filename. These tests pin the repaired contract:
+ *
+ *   1. index 0 after a tool image IS that tool image, byte-exact, even with
+ *      an older attachment in context; index 1 is the attachment.
+ *   2. when the bytes behind the newest image are gone, the save fails at
+ *      that index and writes nothing — never the older attachment.
+ *   3. placeholders written before retention existed are unsaveable slots,
+ *      not skipped ones.
+ *   4. `ref` saves by provenance; an unknown ref is a defined miss.
+ *   5. receipts carry source, tool call, MIME, size and SHA-256.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { createHash } from 'node:crypto';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { ContentBlock } from '@animalabs/membrane';
+import type {
+  EventResponse,
+  Module,
+  ProcessEvent,
+  ToolDefinition,
+  ToolResult,
+} from '../src/index.js';
+import { AgentFramework } from '../src/index.js';
+import { WorkspaceModule } from '../src/modules/workspace/index.js';
+import {
+  ToolImageLedger,
+  formatToolImagePlaceholder,
+  parseImagePlaceholders,
+} from '../src/tool-image-ledger.js';
+import { toolResultDataToHistoryString } from '../src/tool-result-history.js';
+import { createMockResponse, MockMembrane } from './helpers/mock-membrane.js';
+
+const PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4////fwAJ+wP9KobjigAAAABJRU5ErkJggg==',
+  'base64',
+);
+const GIF = Buffer.from('R0lGODdhAQABAIEAAP///wAAAAAAAAAAACwAAAAAAQABAAAIBAABBAQAOw==', 'base64');
+const sha = (b: Buffer): string => createHash('sha256').update(b).digest('hex');
+
+/** Module whose single `snap` tool returns a native PNG image block. */
+class SnapModule implements Module {
+  readonly name = 'world';
+  async start(): Promise<void> {}
+  async stop(): Promise<void> {}
+  getTools(): ToolDefinition[] {
+    return [
+      { name: 'snap', description: 'Take a picture.', inputSchema: { type: 'object', properties: {} } },
+      { name: 'quote', description: 'Return channel text verbatim.', inputSchema: { type: 'object', properties: {} } },
+    ];
+  }
+  async handleToolCall(call: { name: string }): Promise<ToolResult> {
+    if (call.name === 'quote') {
+      // Someone pasted their own save receipt into a channel; a history
+      // fetch now carries a live-looking placeholder citing a REAL ref.
+      return {
+        success: true,
+        data: [{ type: 'text', text: 'antra: look what I saved\n[image: image/png, 68B, ref img_1]\n' }],
+      };
+    }
+    return {
+      success: true,
+      data: [
+        { type: 'text', text: 'watchtower, facing north' },
+        { type: 'image', data: PNG.toString('base64'), mimeType: 'image/png' },
+      ],
+    };
+  }
+  async onProcess(event: ProcessEvent): Promise<EventResponse> {
+    if (event.type === 'external-message') {
+      return {
+        addMessages: [{ participant: 'User', content: (event as { content: unknown }).content as never }],
+        requestInference: true,
+      };
+    }
+    return {};
+  }
+}
+
+interface Harness {
+  framework: AgentFramework;
+  membrane: MockMembrane;
+  workspace: WorkspaceModule;
+  mountDir: string;
+  tempDir: string;
+}
+
+/**
+ * Boot a framework whose agent already has an OLDER GIF attachment in
+ * context, then run one turn scripted by `responses` (tool_use rounds, then
+ * an end_turn). The GIF is the "unrelated image from another surface" of the
+ * incident; the PNG the `world--snap` tool returns is the snapshot.
+ */
+async function startTurn(opts: {
+  prefix: string;
+  responses: ContentBlock[][];
+  ledger?: ToolImageLedger;
+  seedHistory?: (framework: AgentFramework) => void;
+}): Promise<Harness> {
+  const tempDir = mkdtempSync(join(tmpdir(), opts.prefix));
+  const mountDir = join(tempDir, 'mount');
+  mkdirSync(mountDir, { recursive: true });
+  const membrane = new MockMembrane();
+  for (const content of opts.responses) {
+    const hasToolUse = content.some((b) => b.type === 'tool_use');
+    membrane.pushResponse(createMockResponse(content, hasToolUse ? 'tool_use' : 'end_turn'));
+  }
+  const workspace = new WorkspaceModule({
+    mounts: [{ name: 'files', path: mountDir, mode: 'read-write', watch: 'never' }],
+  });
+  const framework = await AgentFramework.create({
+    storePath: join(tempDir, 'store'),
+    membrane: membrane.asMembrane(),
+    agents: [{ name: 'prime', model: 'test-model', systemPrompt: 'You are prime.', allowedTools: 'all' }],
+    modules: [new SnapModule(), workspace as unknown as Module],
+    syncIntervalMs: 0,
+  });
+  workspace.initStore(framework.getStore());
+  if (opts.ledger) {
+    (framework as unknown as { toolImageLedgers: Map<string, ToolImageLedger> })
+      .toolImageLedgers.set('prime', opts.ledger);
+  }
+  // The older attachment: a GIF the resident saw in an ordinary message.
+  framework.getAgent('prime')!.getContextManager().addMessage('user', [
+    { type: 'text', text: 'here is my avatar' },
+    { type: 'image', source: { type: 'base64', data: GIF.toString('base64'), mediaType: 'image/gif' } },
+  ] as ContentBlock[]);
+  opts.seedHistory?.(framework);
+  framework.start();
+  framework.pushEvent({
+    type: 'external-message',
+    source: 'test',
+    content: [{ type: 'text', text: 'take a picture and save it' }],
+    metadata: {},
+    triggerInference: true,
+  } as unknown as ProcessEvent);
+  return { framework, membrane, workspace, mountDir, tempDir };
+}
+
+/** Stored tool_result for `callId`, once the framework has committed it. */
+async function waitForToolResult(
+  framework: AgentFramework,
+  callId: string,
+  timeoutMs = 20_000,
+): Promise<{ content: string; isError: boolean }> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 50));
+    const cm = framework.getAgent('prime')?.getContextManager();
+    const msgs = (cm?.queryMessages({}).messages ?? []) as unknown as Array<{
+      content: Array<{ type: string; toolUseId?: string; content?: unknown; isError?: boolean }>;
+    }>;
+    for (const m of msgs) {
+      for (const b of m.content ?? []) {
+        if (b.type === 'tool_result' && b.toolUseId === callId) {
+          return { content: b.content as string, isError: b.isError === true };
+        }
+      }
+    }
+  }
+  throw new Error(`no stored tool_result for ${callId} within ${timeoutMs}ms`);
+}
+
+/** Bytes at a mount path via the workspace's own read path (tree-first), or null. */
+async function fileBytes(h: Harness, path: string): Promise<Buffer | null> {
+  const read = await h.workspace.readBinary(path);
+  return 'data' in read ? read.data : null;
+}
+
+function saved(result: { content: string; isError: boolean }): Array<Record<string, unknown>> {
+  assert.strictEqual(result.isError, false, `expected success, got: ${result.content}`);
+  const parsed = JSON.parse(result.content) as { saved: Array<Record<string, unknown>> };
+  return parsed.saved;
+}
+
+const snapCall = (id: string): ContentBlock =>
+  ({ type: 'tool_use', id, name: 'world--snap', input: {} }) as ContentBlock;
+const saveCall = (id: string, input: Record<string, unknown>): ContentBlock =>
+  ({ type: 'tool_use', id, name: 'save_recent_image', input }) as ContentBlock;
+const done: ContentBlock[] = [{ type: 'text', text: 'Done.' }];
+
+describe('save_recent_image provenance (issue #104)', () => {
+  it('index 0 after a tool image saves THAT image byte-exactly; index 1 is the older attachment', async () => {
+    const h = await startTurn({
+      prefix: 'sri-order-',
+      responses: [
+        [snapCall('call_snap')],
+        [saveCall('call_save0', { path: 'files/watchtower.png', index: 0 })],
+        [saveCall('call_save1', { path: 'files/avatar.gif', index: 1 })],
+        done,
+      ],
+    });
+    try {
+      const snap = await waitForToolResult(h.framework, 'call_snap');
+      assert.match(snap.content, /\[image: image\/png, \d+B, ref img_1\]/, 'placeholder carries the ref');
+      assert.ok(!snap.content.includes(PNG.toString('base64')), 'history never holds the base64');
+
+      const first = saved(await waitForToolResult(h.framework, 'call_save0'));
+      assert.strictEqual(first.length, 1);
+      assert.strictEqual(first[0]!.source, 'tool-result');
+      assert.strictEqual(first[0]!.ref, 'img_1');
+      assert.strictEqual(first[0]!.toolName, 'world--snap');
+      assert.strictEqual(first[0]!.toolCallId, 'call_snap');
+      assert.strictEqual(first[0]!.mediaType, 'image/png');
+      assert.strictEqual(first[0]!.byteSize, PNG.byteLength);
+      assert.strictEqual(first[0]!.sha256, sha(PNG));
+      assert.strictEqual(first[0]!.imageIndex, 0);
+      assert.ok((await fileBytes(h, 'files/watchtower.png'))?.equals(PNG), 'saved bytes are the snapshot');
+
+      const second = saved(await waitForToolResult(h.framework, 'call_save1'));
+      assert.strictEqual(second[0]!.source, 'attachment');
+      assert.strictEqual(second[0]!.sha256, sha(GIF));
+      assert.strictEqual(second[0]!.imageIndex, 1);
+      assert.ok((await fileBytes(h, 'files/avatar.gif'))?.equals(GIF), 'index 1 is the attachment');
+    } finally {
+      await h.framework.stop();
+      rmSync(h.tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails at the exact index when the newest image was evicted — never saves the older attachment', async () => {
+    // A ledger that holds nothing: every retained image is evicted at once,
+    // which is what a restart or a blown budget looks like from the scan.
+    const h = await startTurn({
+      prefix: 'sri-evicted-',
+      responses: [
+        [snapCall('call_snap')],
+        [saveCall('call_save', { path: 'files/watchtower.png', index: 0 })],
+        done,
+      ],
+      ledger: new ToolImageLedger({ maxEntries: 0 }),
+    });
+    try {
+      const snap = await waitForToolResult(h.framework, 'call_snap');
+      assert.match(snap.content, /ref img_1\]/, 'ref is still issued so the placeholder is honest');
+      const result = await waitForToolResult(h.framework, 'call_save');
+      assert.strictEqual(result.isError, true);
+      assert.match(result.content, /image at index 0 \(img_1, from world--snap \(call call_snap\)\) is no longer retained/);
+      assert.match(result.content, /evicted/);
+      assert.match(result.content, /Nothing written/);
+      assert.ok((await fileBytes(h, 'files/watchtower.png')) === null, 'no file under the snapshot name');
+      assert.ok((await fileBytes(h, 'files/avatar.gif')) === null);
+    } finally {
+      await h.framework.stop();
+      rmSync(h.tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('a placeholder from before retention existed is an unsaveable slot, not a skipped one', async () => {
+    const h = await startTurn({
+      prefix: 'sri-legacy-',
+      responses: [
+        [saveCall('call_save', { path: 'files/phoenix.png', index: 0 })],
+        done,
+      ],
+      seedHistory: (framework) => {
+        framework.getAgent('prime')!.getContextManager().addMessage('user', [{
+          type: 'tool_result',
+          toolUseId: 'call_old',
+          toolName: 'world--snap',
+          content: 'phoenix over the field\n[image: image/png, ~691KB]',
+          isError: false,
+        }] as ContentBlock[]);
+      },
+    });
+    try {
+      const result = await waitForToolResult(h.framework, 'call_save');
+      assert.strictEqual(result.isError, true);
+      assert.match(result.content, /index 0 is a tool-result image from world--snap \(call call_old\) recorded before tool-image retention existed/);
+      assert.ok((await fileBytes(h, 'files/phoenix.png')) === null, 'the older GIF must not be written under the PNG name');
+    } finally {
+      await h.framework.stop();
+      rmSync(h.tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('`ref` saves by provenance; an unknown ref is a defined miss', async () => {
+    const h = await startTurn({
+      prefix: 'sri-ref-',
+      responses: [
+        [snapCall('call_snap')],
+        [saveCall('call_by_ref', { path: 'files/by-ref.png', ref: 'img_1' })],
+        [saveCall('call_bad_ref', { path: 'files/ghost.png', ref: 'img_42' })],
+        [saveCall('call_mixed', { path: 'files/mixed.png', ref: 'img_1', index: 0 })],
+        done,
+      ],
+    });
+    try {
+      const byRef = saved(await waitForToolResult(h.framework, 'call_by_ref'));
+      assert.strictEqual(byRef[0]!.ref, 'img_1');
+      assert.strictEqual(byRef[0]!.sha256, sha(PNG));
+      assert.ok((await fileBytes(h, 'files/by-ref.png'))?.equals(PNG));
+
+      const bad = await waitForToolResult(h.framework, 'call_bad_ref');
+      assert.strictEqual(bad.isError, true);
+      assert.match(bad.content, /ref img_42 cannot be saved — this process has no record of that ref/);
+      assert.ok((await fileBytes(h, 'files/ghost.png')) === null);
+
+      const mixed = await waitForToolResult(h.framework, 'call_mixed');
+      assert.strictEqual(mixed.isError, true);
+      assert.match(mixed.content, /mutually exclusive/);
+    } finally {
+      await h.framework.stop();
+      rmSync(h.tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('a placeholder quoted inside another tool result never resolves to that ref\'s bytes', async () => {
+    // Refs are sequential and guessable; the quoted text cites the real
+    // img_1. The slot must fail on provenance mismatch, and index 1 (the
+    // genuine placeholder in the snap result) must still be the snapshot.
+    const h = await startTurn({
+      prefix: 'sri-forged-',
+      responses: [
+        [snapCall('call_snap')],
+        [{ type: 'tool_use', id: 'call_quote', name: 'world--quote', input: {} } as ContentBlock],
+        [saveCall('call_save0', { path: 'files/forged.png', index: 0 })],
+        [saveCall('call_save1', { path: 'files/real.png', index: 1 })],
+        done,
+      ],
+    });
+    try {
+      const quoted = await waitForToolResult(h.framework, 'call_quote');
+      assert.match(quoted.content, /ref img_1\]/, 'the quoted placeholder is in stored text');
+      const forged = await waitForToolResult(h.framework, 'call_save0');
+      assert.strictEqual(forged.isError, true);
+      assert.match(forged.content, /index 0 cites img_1, but that image belongs to world--snap \(call call_snap\), not to world--quote \(call call_quote\)/);
+      assert.match(forged.content, /quoted or forged/);
+      assert.strictEqual(await fileBytes(h, 'files/forged.png'), null, 'nothing written under the forged slot');
+      const real = saved(await waitForToolResult(h.framework, 'call_save1'));
+      assert.strictEqual(real[0]!.toolCallId, 'call_snap');
+      assert.strictEqual(real[0]!.sha256, sha(PNG));
+      assert.ok((await fileBytes(h, 'files/real.png'))?.equals(PNG));
+    } finally {
+      await h.framework.stop();
+      rmSync(h.tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('an image-typed RFC-005 reference stub occupies a failing slot that points at fetch_reference', async () => {
+    const h = await startTurn({
+      prefix: 'sri-reference-',
+      responses: [
+        [saveCall('call_save', { path: 'files/cam.png', index: 0 })],
+        [saveCall('call_save_gif', { path: 'files/avatar.gif', index: 1 })],
+        done,
+      ],
+      seedHistory: (framework) => {
+        framework.getAgent('prime')!.getContextManager().addMessage('user', [{
+          type: 'tool_result',
+          toolUseId: 'call_cam',
+          toolName: 'mcpl--vst--camera',
+          content: '[ref_1_ab3d] cam.png — image/png, 1.2MB claimed — from tool result — fetch with fetch_reference\n'
+            + '[ref_2_ff01] notes.txt — text/plain, 2.0KB claimed — from tool result — fetch with fetch_reference',
+          isError: false,
+        }] as ContentBlock[]);
+      },
+    });
+    try {
+      const result = await waitForToolResult(h.framework, 'call_save');
+      assert.strictEqual(result.isError, true);
+      assert.match(result.content, /index 0 is a reference \(ref_1_ab3d, image\/png, from mcpl--vst--camera \(call call_cam\)\)/);
+      assert.match(result.content, /fetch_reference/);
+      assert.strictEqual(await fileBytes(h, 'files/cam.png'), null);
+      // The text/plain reference is not an image slot: index 1 is the GIF.
+      const gif = saved(await waitForToolResult(h.framework, 'call_save_gif'));
+      assert.strictEqual(gif[0]!.source, 'attachment');
+      assert.strictEqual(gif[0]!.sha256, sha(GIF));
+    } finally {
+      await h.framework.stop();
+      rmSync(h.tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('ToolImageLedger', () => {
+  it('mints one ref per (call, block), idempotently, with digest provenance', () => {
+    const ledger = new ToolImageLedger();
+    const a = ledger.retain({ toolCallId: 'c1', toolName: 't', blockIndex: 1, data: PNG.toString('base64'), mediaType: 'image/png' });
+    const again = ledger.retain({ toolCallId: 'c1', toolName: 't', blockIndex: 1, data: PNG.toString('base64'), mediaType: 'image/png' });
+    const b = ledger.retain({ toolCallId: 'c1', toolName: 't', blockIndex: 3, data: GIF.toString('base64'), mediaType: 'image/gif' });
+    assert.strictEqual(a.ref, 'img_1');
+    assert.strictEqual(again.ref, 'img_1');
+    assert.strictEqual(b.ref, 'img_2');
+    assert.strictEqual(a.sha256, sha(PNG));
+    assert.strictEqual(a.byteSize, PNG.byteLength);
+    assert.strictEqual(ledger.refFor('c1', 3), 'img_2');
+    const hit = ledger.lookup('img_1');
+    assert.strictEqual(hit.status, 'retained');
+    assert.strictEqual(hit.status === 'retained' ? hit.image.data : null, PNG.toString('base64'));
+    assert.strictEqual(ledger.lookup('img_9').status, 'unknown');
+  });
+
+  it('evicts oldest-first over the budget but keeps provenance for the error', () => {
+    const ledger = new ToolImageLedger({ maxEntries: 2 });
+    for (let i = 0; i < 3; i++) {
+      ledger.retain({ toolCallId: `c${i}`, toolName: 'snap', blockIndex: 0, data: PNG.toString('base64'), mediaType: 'image/png' });
+    }
+    assert.strictEqual(ledger.size, 2);
+    const evicted = ledger.lookup('img_1');
+    assert.strictEqual(evicted.status, 'evicted');
+    assert.strictEqual(evicted.status === 'evicted' ? evicted.image.toolCallId : null, 'c0');
+    assert.strictEqual(ledger.lookup('img_2').status, 'retained');
+    assert.strictEqual(ledger.lookup('img_3').status, 'retained');
+  });
+
+  it('placeholders round-trip through the serializer, with and without a ref', () => {
+    const data = [
+      { type: 'text', text: 'two frames' },
+      { type: 'image', data: PNG.toString('base64'), mimeType: 'image/png' },
+      { type: 'image', data: GIF.toString('base64'), mimeType: 'image/gif' },
+    ];
+    const legacy = toolResultDataToHistoryString(data);
+    const refsOf = (text: string) => parseImagePlaceholders(text).map((p) => (p.kind === 'inline' ? p.ref : p.refId));
+    assert.deepStrictEqual(parseImagePlaceholders(legacy).map((p) => [p.mediaType, p.kind === 'inline' ? p.ref : 'ref']), [
+      ['image/png', null],
+      ['image/gif', null],
+    ]);
+    const seen: number[] = [];
+    const withRefs = toolResultDataToHistoryString(data, undefined, {
+      imageRef: (blockIndex) => { seen.push(blockIndex); return `img_${blockIndex}`; },
+    });
+    assert.deepStrictEqual(seen, [1, 2], 'block indices are positions in the content array');
+    // Size label is the serializer's base64-derived estimate, not the exact byte count.
+    assert.match(withRefs, /\[image: image\/png, \d+B, ref img_1\]/);
+    assert.strictEqual(formatToolImagePlaceholder('image/png', '~691KB', 'img_7'), '[image: image/png, ~691KB, ref img_7]');
+    assert.deepStrictEqual(refsOf(withRefs), ['img_1', 'img_2']);
+    assert.ok(!withRefs.includes(PNG.toString('base64')));
+  });
+
+  it('an uppercase mime from a tool still round-trips (normalized at retain and format time)', () => {
+    const ledger = new ToolImageLedger();
+    const retained = ledger.retain({ toolCallId: 'c', toolName: 't', blockIndex: 0, data: PNG.toString('base64'), mediaType: 'Image/PNG ' });
+    assert.strictEqual(retained.mediaType, 'image/png');
+    const text = toolResultDataToHistoryString(
+      [{ type: 'image', data: PNG.toString('base64'), mimeType: 'Image/PNG' }],
+      undefined,
+      { imageRef: () => retained.ref },
+    );
+    const parsed = parseImagePlaceholders(text);
+    assert.strictEqual(parsed.length, 1, `placeholder must re-parse: ${text}`);
+    assert.strictEqual(parsed[0]!.kind === 'inline' ? parsed[0]!.ref : null, 'img_1');
+    assert.strictEqual(parsed[0]!.mediaType, 'image/png');
+  });
+
+  it('parses image-typed reference stubs as slots, in text order with inline placeholders', () => {
+    const text = [
+      'frame one',
+      '[image: image/png, ~12KB, ref img_3]',
+      '[ref_1_ab3d] cam.png — image/jpeg, 1.2MB claimed — from tool result — fetch with fetch_reference',
+      '[ref_2_zz9q] chord.wav — audio/wav, ~4.0MB claimed — from tool result — fetch with fetch_reference',
+    ].join('\n');
+    const slots = parseImagePlaceholders(text);
+    assert.deepStrictEqual(
+      slots.map((s) => (s.kind === 'inline' ? ['inline', s.ref, s.mediaType] : ['reference', s.refId, s.mediaType])),
+      [
+        ['inline', 'img_3', 'image/png'],
+        ['reference', 'ref_1_ab3d', 'image/jpeg'],
+        ['reference', 'ref_2_zz9q', null],
+      ],
+    );
+  });
+});

--- a/test/save-recent-image.test.ts
+++ b/test/save-recent-image.test.ts
@@ -14,6 +14,13 @@
  *      not skipped ones.
  *   4. `ref` saves by provenance; an unknown ref is a defined miss.
  *   5. receipts carry source, tool call, MIME, size and SHA-256.
+ *
+ * Second review round (#140) added three more representations of the same
+ * failure, each pinned below:
+ *   6. truncation/spill never drops an image slot from the stored text.
+ *   7. a save dispatched in the same batch as the snapshot waits for it.
+ *   8. refs are namespaced per ledger — a stale ref resolves to nothing,
+ *      and a direct `ref` is saved through its occurrence in context.
  */
 
 import { describe, it } from 'node:test';
@@ -33,11 +40,16 @@ import type {
 import { AgentFramework } from '../src/index.js';
 import { WorkspaceModule } from '../src/modules/workspace/index.js';
 import {
+  FALLBACK_MEDIA_TYPE,
+  TOOL_IMAGE_REF_RE,
   ToolImageLedger,
+  formatPreservedImageSlots,
   formatToolImagePlaceholder,
+  normalizeMediaType,
   parseImagePlaceholders,
+  splitPreservingImageSlots,
 } from '../src/tool-image-ledger.js';
-import { toolResultDataToHistoryString } from '../src/tool-result-history.js';
+import { toolResultDataToHistoryString, truncateForHistory } from '../src/tool-result-history.js';
 import { createMockResponse, MockMembrane } from './helpers/mock-membrane.js';
 
 const PNG = Buffer.from(
@@ -46,34 +58,60 @@ const PNG = Buffer.from(
 );
 const GIF = Buffer.from('R0lGODdhAQABAIEAAP///wAAAAAAAAAAACwAAAAAAQABAAAIBAABBAQAOw==', 'base64');
 const sha = (b: Buffer): string => createHash('sha256').update(b).digest('hex');
+const REF_1 = /^img_[0-9a-z]+_1$/;
+/** ~30k chars — past the smallest allowed inline cap (1000) many times over. */
+const LONG_TEXT = 'line of scan output\n'.repeat(1500);
 
-/** Module whose single `snap` tool returns a native PNG image block. */
+/** World module: `snap` returns a native PNG image block; the other tools
+ *  are the review's representations of the same result, one shape each. */
 class SnapModule implements Module {
   readonly name = 'world';
+  /** The `quote` tool cites this ref — set by the test once it knows it. */
+  quotedRef = 'img_zzzzzz_1';
+  /** Delay before `snap` resolves — proves the same-batch barrier waits. */
+  snapDelayMs = 0;
   async start(): Promise<void> {}
   async stop(): Promise<void> {}
   getTools(): ToolDefinition[] {
+    const schema = { type: 'object', properties: {} } as const;
     return [
-      { name: 'snap', description: 'Take a picture.', inputSchema: { type: 'object', properties: {} } },
-      { name: 'quote', description: 'Return channel text verbatim.', inputSchema: { type: 'object', properties: {} } },
+      { name: 'snap', description: 'Take a picture.', inputSchema: schema },
+      { name: 'quote', description: 'Return channel text verbatim.', inputSchema: schema },
+      { name: 'snap_long', description: 'Long scan then a picture.', inputSchema: schema },
+      { name: 'snap_sandwich', description: 'Picture, long scan, picture.', inputSchema: schema },
+      { name: 'snap_contradiction', description: 'RFC-005 vector-2 image.', inputSchema: schema },
+      { name: 'snap_uri', description: 'RFC-005 reference image.', inputSchema: schema },
     ];
   }
   async handleToolCall(call: { name: string }): Promise<ToolResult> {
-    if (call.name === 'quote') {
-      // Someone pasted their own save receipt into a channel; a history
-      // fetch now carries a live-looking placeholder citing a REAL ref.
-      return {
-        success: true,
-        data: [{ type: 'text', text: 'antra: look what I saved\n[image: image/png, 68B, ref img_1]\n' }],
-      };
+    const png = { type: 'image', data: PNG.toString('base64'), mimeType: 'image/png' };
+    switch (call.name) {
+      case 'quote':
+        // Someone pasted their own save receipt into a channel; a history
+        // fetch now carries a live-looking placeholder citing a REAL ref.
+        return {
+          success: true,
+          data: [{ type: 'text', text: `antra: look what I saved\n[image: image/png, 68B, ref ${this.quotedRef}]\n` }],
+        };
+      case 'snap_long':
+        return { success: true, data: [{ type: 'text', text: LONG_TEXT }, png] };
+      case 'snap_sandwich':
+        return {
+          success: true,
+          data: [png, { type: 'text', text: LONG_TEXT }, { type: 'image', data: GIF.toString('base64'), mimeType: 'image/gif' }],
+        };
+      case 'snap_contradiction':
+        // Inline data claiming a disposition: withheld by every lane.
+        return { success: true, data: [{ type: 'text', text: 'cam' }, { ...png, disposition: 'ref' }] };
+      case 'snap_uri':
+        return {
+          success: true,
+          data: [{ type: 'text', text: 'cam' }, { type: 'image', uri: 'https://cam.example/latest.png', mimeType: 'image/png', sizeBytes: 1200 }],
+        };
+      default:
+        if (this.snapDelayMs > 0) await new Promise((r) => setTimeout(r, this.snapDelayMs));
+        return { success: true, data: [{ type: 'text', text: 'watchtower, facing north' }, png] };
     }
-    return {
-      success: true,
-      data: [
-        { type: 'text', text: 'watchtower, facing north' },
-        { type: 'image', data: PNG.toString('base64'), mimeType: 'image/png' },
-      ],
-    };
   }
   async onProcess(event: ProcessEvent): Promise<EventResponse> {
     if (event.type === 'external-message') {
@@ -90,6 +128,8 @@ interface Harness {
   framework: AgentFramework;
   membrane: MockMembrane;
   workspace: WorkspaceModule;
+  world: SnapModule;
+  ledger: ToolImageLedger;
   mountDir: string;
   tempDir: string;
 }
@@ -105,6 +145,8 @@ async function startTurn(opts: {
   responses: ContentBlock[][];
   ledger?: ToolImageLedger;
   seedHistory?: (framework: AgentFramework) => void;
+  toolResultInlineMaxChars?: number;
+  world?: (module: SnapModule) => void;
 }): Promise<Harness> {
   const tempDir = mkdtempSync(join(tmpdir(), opts.prefix));
   const mountDir = join(tempDir, 'mount');
@@ -117,18 +159,21 @@ async function startTurn(opts: {
   const workspace = new WorkspaceModule({
     mounts: [{ name: 'files', path: mountDir, mode: 'read-write', watch: 'never' }],
   });
+  const world = new SnapModule();
+  opts.world?.(world);
   const framework = await AgentFramework.create({
     storePath: join(tempDir, 'store'),
     membrane: membrane.asMembrane(),
     agents: [{ name: 'prime', model: 'test-model', systemPrompt: 'You are prime.', allowedTools: 'all' }],
-    modules: [new SnapModule(), workspace as unknown as Module],
+    modules: [world, workspace as unknown as Module],
     syncIntervalMs: 0,
+    ...(opts.toolResultInlineMaxChars !== undefined ? { toolResultInlineMaxChars: opts.toolResultInlineMaxChars } : {}),
   });
   workspace.initStore(framework.getStore());
-  if (opts.ledger) {
-    (framework as unknown as { toolImageLedgers: Map<string, ToolImageLedger> })
-      .toolImageLedgers.set('prime', opts.ledger);
-  }
+  // Install the ledger up front so tests know the nonce its refs will carry.
+  const ledger = opts.ledger ?? new ToolImageLedger();
+  (framework as unknown as { toolImageLedgers: Map<string, ToolImageLedger> })
+    .toolImageLedgers.set('prime', ledger);
   // The older attachment: a GIF the resident saw in an ordinary message.
   framework.getAgent('prime')!.getContextManager().addMessage('user', [
     { type: 'text', text: 'here is my avatar' },
@@ -143,8 +188,9 @@ async function startTurn(opts: {
     metadata: {},
     triggerInference: true,
   } as unknown as ProcessEvent);
-  return { framework, membrane, workspace, mountDir, tempDir };
+  return { framework, membrane, workspace, world, ledger, mountDir, tempDir };
 }
+const refOf = (h: Harness, seq: number): string => `img_${h.ledger.nonce}_${seq}`;
 
 /** Stored tool_result for `callId`, once the framework has committed it. */
 async function waitForToolResult(
@@ -201,13 +247,13 @@ describe('save_recent_image provenance (issue #104)', () => {
     });
     try {
       const snap = await waitForToolResult(h.framework, 'call_snap');
-      assert.match(snap.content, /\[image: image\/png, \d+B, ref img_1\]/, 'placeholder carries the ref');
+      assert.match(snap.content, /\[image: image\/png, \d+B, ref img_[0-9a-z]+_1\]/, 'placeholder carries the ref');
       assert.ok(!snap.content.includes(PNG.toString('base64')), 'history never holds the base64');
 
       const first = saved(await waitForToolResult(h.framework, 'call_save0'));
       assert.strictEqual(first.length, 1);
       assert.strictEqual(first[0]!.source, 'tool-result');
-      assert.strictEqual(first[0]!.ref, 'img_1');
+      assert.strictEqual(first[0]!.ref, refOf(h, 1));
       assert.strictEqual(first[0]!.toolName, 'world--snap');
       assert.strictEqual(first[0]!.toolCallId, 'call_snap');
       assert.strictEqual(first[0]!.mediaType, 'image/png');
@@ -241,10 +287,10 @@ describe('save_recent_image provenance (issue #104)', () => {
     });
     try {
       const snap = await waitForToolResult(h.framework, 'call_snap');
-      assert.match(snap.content, /ref img_1\]/, 'ref is still issued so the placeholder is honest');
+      assert.match(snap.content, /ref img_[0-9a-z]+_1\]/, 'ref is still issued so the placeholder is honest');
       const result = await waitForToolResult(h.framework, 'call_save');
       assert.strictEqual(result.isError, true);
-      assert.match(result.content, /image at index 0 \(img_1, from world--snap \(call call_snap\)\) is no longer retained/);
+      assert.match(result.content, new RegExp(`image at index 0 \\(${refOf(h, 1)}, from world--snap \\(call call_snap\\)\\) is no longer retained`));
       assert.match(result.content, /evicted/);
       assert.match(result.content, /Nothing written/);
       assert.ok((await fileBytes(h, 'files/watchtower.png')) === null, 'no file under the snapshot name');
@@ -275,7 +321,7 @@ describe('save_recent_image provenance (issue #104)', () => {
     try {
       const result = await waitForToolResult(h.framework, 'call_save');
       assert.strictEqual(result.isError, true);
-      assert.match(result.content, /index 0 is a tool-result image from world--snap \(call call_old\) recorded before tool-image retention existed/);
+      assert.match(result.content, /index 0 is a tool-result image from world--snap \(call call_old\) recorded without a retention ref/);
       assert.ok((await fileBytes(h, 'files/phoenix.png')) === null, 'the older GIF must not be written under the PNG name');
     } finally {
       await h.framework.stop();
@@ -284,26 +330,36 @@ describe('save_recent_image provenance (issue #104)', () => {
   });
 
   it('`ref` saves by provenance; an unknown ref is a defined miss', async () => {
+    const ledger = new ToolImageLedger();
+    const ref1 = `img_${ledger.nonce}_1`;
     const h = await startTurn({
       prefix: 'sri-ref-',
+      ledger,
       responses: [
         [snapCall('call_snap')],
-        [saveCall('call_by_ref', { path: 'files/by-ref.png', ref: 'img_1' })],
-        [saveCall('call_bad_ref', { path: 'files/ghost.png', ref: 'img_42' })],
-        [saveCall('call_mixed', { path: 'files/mixed.png', ref: 'img_1', index: 0 })],
+        [saveCall('call_by_ref', { path: 'files/by-ref.png', ref: ref1 })],
+        [saveCall('call_bad_ref', { path: 'files/ghost.png', ref: `img_${ledger.nonce}_42` })],
+        [saveCall('call_bad_grammar', { path: 'files/ghost2.png', ref: 'img_1' })],
+        [saveCall('call_mixed', { path: 'files/mixed.png', ref: ref1, index: 0 })],
         done,
       ],
     });
     try {
       const byRef = saved(await waitForToolResult(h.framework, 'call_by_ref'));
-      assert.strictEqual(byRef[0]!.ref, 'img_1');
+      assert.strictEqual(byRef[0]!.ref, ref1);
       assert.strictEqual(byRef[0]!.sha256, sha(PNG));
+      assert.strictEqual(byRef[0]!.toolCallId, 'call_snap');
       assert.ok((await fileBytes(h, 'files/by-ref.png'))?.equals(PNG));
 
       const bad = await waitForToolResult(h.framework, 'call_bad_ref');
       assert.strictEqual(bad.isError, true);
-      assert.match(bad.content, /ref img_42 cannot be saved — this process has no record of that ref/);
+      assert.match(bad.content, new RegExp(`ref img_${ledger.nonce}_42 cannot be saved — this process has no record of that ref`));
       assert.ok((await fileBytes(h, 'files/ghost.png')) === null);
+
+      // The pre-nonce spelling is not a ref at all.
+      const grammar = await waitForToolResult(h.framework, 'call_bad_grammar');
+      assert.strictEqual(grammar.isError, true);
+      assert.match(grammar.content, /`ref` must look like/);
 
       const mixed = await waitForToolResult(h.framework, 'call_mixed');
       assert.strictEqual(mixed.isError, true);
@@ -318,8 +374,11 @@ describe('save_recent_image provenance (issue #104)', () => {
     // Refs are sequential and guessable; the quoted text cites the real
     // img_1. The slot must fail on provenance mismatch, and index 1 (the
     // genuine placeholder in the snap result) must still be the snapshot.
+    const ledger = new ToolImageLedger();
     const h = await startTurn({
       prefix: 'sri-forged-',
+      ledger,
+      world: (world) => { world.quotedRef = `img_${ledger.nonce}_1`; },
       responses: [
         [snapCall('call_snap')],
         [{ type: 'tool_use', id: 'call_quote', name: 'world--quote', input: {} } as ContentBlock],
@@ -330,10 +389,10 @@ describe('save_recent_image provenance (issue #104)', () => {
     });
     try {
       const quoted = await waitForToolResult(h.framework, 'call_quote');
-      assert.match(quoted.content, /ref img_1\]/, 'the quoted placeholder is in stored text');
+      assert.match(quoted.content, new RegExp(`ref img_${ledger.nonce}_1\\]`), 'the quoted placeholder is in stored text');
       const forged = await waitForToolResult(h.framework, 'call_save0');
       assert.strictEqual(forged.isError, true);
-      assert.match(forged.content, /index 0 cites img_1, but that image belongs to world--snap \(call call_snap\), not to world--quote \(call call_quote\)/);
+      assert.match(forged.content, new RegExp(`index 0 cites img_${ledger.nonce}_1, but that image belongs to world--snap \\(call call_snap\\), not to world--quote \\(call call_quote\\)`));
       assert.match(forged.content, /quoted or forged/);
       assert.strictEqual(await fileBytes(h, 'files/forged.png'), null, 'nothing written under the forged slot');
       const real = saved(await waitForToolResult(h.framework, 'call_save1'));
@@ -380,6 +439,188 @@ describe('save_recent_image provenance (issue #104)', () => {
       rmSync(h.tempDir, { recursive: true, force: true });
     }
   });
+
+  it('truncation past the inline cap keeps the image slot: index 0 is still the snapshot', async () => {
+    // [30k text, image] at the smallest allowed cap. The wire delivered the
+    // image; the stored text must still carry its slot after the cut.
+    const h = await startTurn({
+      prefix: 'sri-truncated-',
+      toolResultInlineMaxChars: 1000,
+      responses: [
+        [{ type: 'tool_use', id: 'call_long', name: 'world--snap_long', input: {} } as ContentBlock],
+        [saveCall('call_save', { path: 'files/after-cut.png', index: 0 })],
+        done,
+      ],
+    });
+    try {
+      const stored = await waitForToolResult(h.framework, 'call_long');
+      assert.match(stored.content, /\[truncated — showing \d+ of \d+ chars/);
+      assert.match(stored.content, /1 image slot\(s\) fell past the cut/);
+      const slots = parseImagePlaceholders(stored.content);
+      assert.strictEqual(slots.length, 1, `exactly one slot survives the cut: ${stored.content.slice(-300)}`);
+      assert.strictEqual(slots[0]!.kind === 'inline' ? slots[0]!.ref : null, refOf(h, 1));
+
+      const receipt = saved(await waitForToolResult(h.framework, 'call_save'));
+      assert.strictEqual(receipt[0]!.toolCallId, 'call_long');
+      assert.strictEqual(receipt[0]!.sha256, sha(PNG));
+      assert.ok((await fileBytes(h, 'files/after-cut.png'))?.equals(PNG), 'the snapshot, not the older GIF');
+    } finally {
+      await h.framework.stop();
+      rmSync(h.tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('[image A, huge text, image B] truncated: index 0 is B, index 1 is A — order survives the cut', async () => {
+    const h = await startTurn({
+      prefix: 'sri-sandwich-',
+      toolResultInlineMaxChars: 1000,
+      responses: [
+        [{ type: 'tool_use', id: 'call_sandwich', name: 'world--snap_sandwich', input: {} } as ContentBlock],
+        [saveCall('call_save_b', { path: 'files/b.gif', index: 0 })],
+        [saveCall('call_save_a', { path: 'files/a.png', index: 1 })],
+        done,
+      ],
+    });
+    try {
+      const stored = await waitForToolResult(h.framework, 'call_sandwich');
+      assert.deepStrictEqual(
+        parseImagePlaceholders(stored.content).map((p) => (p.kind === 'inline' ? p.ref : p.refId)),
+        [refOf(h, 1), refOf(h, 2)],
+        'both slots, in the original order',
+      );
+      const b = saved(await waitForToolResult(h.framework, 'call_save_b'));
+      assert.strictEqual(b[0]!.sha256, sha(GIF));
+      assert.strictEqual(b[0]!.ref, refOf(h, 2));
+      const a = saved(await waitForToolResult(h.framework, 'call_save_a'));
+      assert.strictEqual(a[0]!.sha256, sha(PNG));
+      assert.strictEqual(a[0]!.ref, refOf(h, 1));
+    } finally {
+      await h.framework.stop();
+      rmSync(h.tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('a save dispatched in the SAME batch as the snapshot waits for it and saves it', async () => {
+    // One tool_use round: [snap, save]. Module calls are only enqueued while
+    // the save runs at once — without the barrier the inventory is empty at
+    // scan time and the older GIF gets saved under the snapshot's name.
+    const h = await startTurn({
+      prefix: 'sri-same-batch-',
+      world: (world) => { world.snapDelayMs = 150; },
+      responses: [
+        [snapCall('call_snap'), saveCall('call_save', { path: 'files/batched.png', index: 0 })],
+        done,
+      ],
+    });
+    try {
+      const receipt = saved(await waitForToolResult(h.framework, 'call_save'));
+      assert.strictEqual(receipt[0]!.source, 'tool-result');
+      assert.strictEqual(receipt[0]!.toolCallId, 'call_snap');
+      assert.strictEqual(receipt[0]!.sha256, sha(PNG));
+      assert.ok((await fileBytes(h, 'files/batched.png'))?.equals(PNG));
+      // Early retention and commit-time serialization agree on the ref.
+      const snap = await waitForToolResult(h.framework, 'call_snap');
+      assert.match(snap.content, new RegExp(`ref ${receipt[0]!.ref}\\]`));
+    } finally {
+      await h.framework.stop();
+      rmSync(h.tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('same-batch siblings are classified like the commit path: withheld data is no slot, a uri image is a reference slot', async () => {
+    const h = await startTurn({
+      prefix: 'sri-same-batch-class-',
+      responses: [
+        [
+          { type: 'tool_use', id: 'call_contra', name: 'world--snap_contradiction', input: {} } as ContentBlock,
+          saveCall('call_save_contra', { path: 'files/contra.png', index: 0 }),
+        ],
+        [
+          { type: 'tool_use', id: 'call_uri', name: 'world--snap_uri', input: {} } as ContentBlock,
+          saveCall('call_save_uri', { path: 'files/uri.png', index: 0 }),
+        ],
+        done,
+      ],
+    });
+    try {
+      // The withheld image is not a slot in either representation: index 0
+      // is the GIF attachment, and its bytes never entered the ledger.
+      const contra = saved(await waitForToolResult(h.framework, 'call_save_contra'));
+      assert.strictEqual(contra[0]!.source, 'attachment');
+      assert.strictEqual(contra[0]!.sha256, sha(GIF));
+      assert.strictEqual(h.ledger.size, 0, 'withheld bytes must not be retained');
+      const stored = await waitForToolResult(h.framework, 'call_contra');
+      assert.strictEqual(parseImagePlaceholders(stored.content).length, 0);
+
+      const uri = await waitForToolResult(h.framework, 'call_save_uri');
+      assert.strictEqual(uri.isError, true);
+      assert.match(uri.content, /index 0 is a reference \(ref_[0-9a-z]+_[0-9a-z]+, image\/png, from world--snap_uri \(call call_uri\)\)/);
+      assert.strictEqual(await fileBytes(h, 'files/uri.png'), null);
+    } finally {
+      await h.framework.stop();
+      rmSync(h.tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('a placeholder from a previous process (other nonce) is a defined miss by index AND by ref', async () => {
+    const h = await startTurn({
+      prefix: 'sri-stale-',
+      responses: [
+        [saveCall('call_save_idx', { path: 'files/stale.png', index: 0 })],
+        [saveCall('call_save_ref', { path: 'files/stale-ref.png', ref: 'img_zzzzzz_7' })],
+        done,
+      ],
+      seedHistory: (framework) => {
+        framework.getAgent('prime')!.getContextManager().addMessage('user', [{
+          type: 'tool_result',
+          toolUseId: 'call_yesterday',
+          toolName: 'world--snap',
+          content: 'yesterday\n[image: image/png, ~691KB, ref img_zzzzzz_7]',
+          isError: false,
+        }] as ContentBlock[]);
+      },
+    });
+    try {
+      // Seven fresh images in this process: a bare `img_7` would collide.
+      for (let i = 1; i <= 7; i++) {
+        h.ledger.retain({ toolCallId: `call_today_${i}`, toolName: 'world--snap', blockIndex: 0, data: PNG.toString('base64'), mediaType: 'image/png' });
+      }
+      const byIndex = await waitForToolResult(h.framework, 'call_save_idx');
+      assert.strictEqual(byIndex.isError, true);
+      assert.match(byIndex.content, /index 0 \(img_zzzzzz_7, from world--snap \(call call_yesterday\)\) is no longer retained — this process has no record/);
+      const byRef = await waitForToolResult(h.framework, 'call_save_ref');
+      assert.strictEqual(byRef.isError, true);
+      // The stale placeholder IS visible, so the ref resolves through it and fails the same way.
+      assert.match(byRef.content, /img_zzzzzz_7, from world--snap \(call call_yesterday\)\) is no longer retained — this process has no record/);
+      assert.strictEqual(await fileBytes(h, 'files/stale.png'), null);
+      assert.strictEqual(await fileBytes(h, 'files/stale-ref.png'), null);
+    } finally {
+      await h.framework.stop();
+      rmSync(h.tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('a direct `ref` is saved through its placeholder in context — a retained ref that is not visible is refused', async () => {
+    const ledger = new ToolImageLedger();
+    const ghost = ledger.retain({ toolCallId: 'call_ghost', toolName: 'world--snap', blockIndex: 1, data: PNG.toString('base64'), mediaType: 'image/png' });
+    const h = await startTurn({
+      prefix: 'sri-ref-context-',
+      ledger,
+      responses: [
+        [saveCall('call_save', { path: 'files/ghost.png', ref: ghost.ref })],
+        done,
+      ],
+    });
+    try {
+      const result = await waitForToolResult(h.framework, 'call_save');
+      assert.strictEqual(result.isError, true);
+      assert.match(result.content, new RegExp(`ref ${ghost.ref} \\(from world--snap \\(call call_ghost\\)\\) does not appear in your recent context`));
+      assert.strictEqual(await fileBytes(h, 'files/ghost.png'), null);
+    } finally {
+      await h.framework.stop();
+      rmSync(h.tempDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('ToolImageLedger', () => {
@@ -388,16 +629,37 @@ describe('ToolImageLedger', () => {
     const a = ledger.retain({ toolCallId: 'c1', toolName: 't', blockIndex: 1, data: PNG.toString('base64'), mediaType: 'image/png' });
     const again = ledger.retain({ toolCallId: 'c1', toolName: 't', blockIndex: 1, data: PNG.toString('base64'), mediaType: 'image/png' });
     const b = ledger.retain({ toolCallId: 'c1', toolName: 't', blockIndex: 3, data: GIF.toString('base64'), mediaType: 'image/gif' });
-    assert.strictEqual(a.ref, 'img_1');
-    assert.strictEqual(again.ref, 'img_1');
-    assert.strictEqual(b.ref, 'img_2');
+    assert.match(a.ref, REF_1);
+    assert.strictEqual(a.ref, `img_${ledger.nonce}_1`);
+    assert.ok(TOOL_IMAGE_REF_RE.test(a.ref));
+    assert.strictEqual(again.ref, a.ref);
+    assert.strictEqual(b.ref, `img_${ledger.nonce}_2`);
     assert.strictEqual(a.sha256, sha(PNG));
     assert.strictEqual(a.byteSize, PNG.byteLength);
-    assert.strictEqual(ledger.refFor('c1', 3), 'img_2');
-    const hit = ledger.lookup('img_1');
+    assert.strictEqual(ledger.refFor('c1', 3), b.ref);
+    const hit = ledger.lookup(a.ref);
     assert.strictEqual(hit.status, 'retained');
     assert.strictEqual(hit.status === 'retained' ? hit.image.data : null, PNG.toString('base64'));
-    assert.strictEqual(ledger.lookup('img_9').status, 'unknown');
+    assert.strictEqual(ledger.lookup(`img_${ledger.nonce}_9`).status, 'unknown');
+    // Another ledger is another namespace: the same sequence is a stranger.
+    const other = new ToolImageLedger();
+    assert.notStrictEqual(other.nonce, ledger.nonce);
+    assert.strictEqual(other.lookup(a.ref).status, 'unknown');
+    assert.strictEqual(ledger.lookup('img_1').status, 'unknown');
+  });
+
+  it('digests large payloads chunked with the same result as a whole decode', () => {
+    const big = Buffer.alloc(1_500_000);
+    for (let i = 0; i < big.length; i++) big[i] = (i * 7919) & 0xff;
+    const ledger = new ToolImageLedger();
+    const kept = ledger.retain({ toolCallId: 'c', toolName: 't', blockIndex: 0, data: big.toString('base64'), mediaType: 'image/png' });
+    assert.strictEqual(kept.byteSize, big.byteLength);
+    assert.strictEqual(kept.sha256, sha(big));
+    // Whitespace-bearing base64 (legal for decoders) falls back to a whole decode — same answer.
+    const wrapped = big.toString('base64').replace(/(.{76})/g, '$1\n');
+    const same = ledger.retain({ toolCallId: 'c2', toolName: 't', blockIndex: 0, data: wrapped, mediaType: 'image/png' });
+    assert.strictEqual(same.byteSize, Buffer.from(wrapped, 'base64').byteLength);
+    assert.strictEqual(same.sha256, sha(Buffer.from(wrapped, 'base64')));
   });
 
   it('evicts oldest-first over the budget but keeps provenance for the error', () => {
@@ -406,11 +668,11 @@ describe('ToolImageLedger', () => {
       ledger.retain({ toolCallId: `c${i}`, toolName: 'snap', blockIndex: 0, data: PNG.toString('base64'), mediaType: 'image/png' });
     }
     assert.strictEqual(ledger.size, 2);
-    const evicted = ledger.lookup('img_1');
+    const evicted = ledger.lookup(`img_${ledger.nonce}_1`);
     assert.strictEqual(evicted.status, 'evicted');
     assert.strictEqual(evicted.status === 'evicted' ? evicted.image.toolCallId : null, 'c0');
-    assert.strictEqual(ledger.lookup('img_2').status, 'retained');
-    assert.strictEqual(ledger.lookup('img_3').status, 'retained');
+    assert.strictEqual(ledger.lookup(`img_${ledger.nonce}_2`).status, 'retained');
+    assert.strictEqual(ledger.lookup(`img_${ledger.nonce}_3`).status, 'retained');
   });
 
   it('placeholders round-trip through the serializer, with and without a ref', () => {
@@ -427,13 +689,13 @@ describe('ToolImageLedger', () => {
     ]);
     const seen: number[] = [];
     const withRefs = toolResultDataToHistoryString(data, undefined, {
-      imageRef: (blockIndex) => { seen.push(blockIndex); return `img_${blockIndex}`; },
+      imageRef: (blockIndex) => { seen.push(blockIndex); return `img_abc123_${blockIndex}`; },
     });
     assert.deepStrictEqual(seen, [1, 2], 'block indices are positions in the content array');
     // Size label is the serializer's base64-derived estimate, not the exact byte count.
-    assert.match(withRefs, /\[image: image\/png, \d+B, ref img_1\]/);
-    assert.strictEqual(formatToolImagePlaceholder('image/png', '~691KB', 'img_7'), '[image: image/png, ~691KB, ref img_7]');
-    assert.deepStrictEqual(refsOf(withRefs), ['img_1', 'img_2']);
+    assert.match(withRefs, /\[image: image\/png, \d+B, ref img_abc123_1\]/);
+    assert.strictEqual(formatToolImagePlaceholder('image/png', '~691KB', 'img_k7x3q2_7'), '[image: image/png, ~691KB, ref img_k7x3q2_7]');
+    assert.deepStrictEqual(refsOf(withRefs), ['img_abc123_1', 'img_abc123_2']);
     assert.ok(!withRefs.includes(PNG.toString('base64')));
   });
 
@@ -448,14 +710,67 @@ describe('ToolImageLedger', () => {
     );
     const parsed = parseImagePlaceholders(text);
     assert.strictEqual(parsed.length, 1, `placeholder must re-parse: ${text}`);
-    assert.strictEqual(parsed[0]!.kind === 'inline' ? parsed[0]!.ref : null, 'img_1');
+    assert.strictEqual(parsed[0]!.kind === 'inline' ? parsed[0]!.ref : null, retained.ref);
     assert.strictEqual(parsed[0]!.mediaType, 'image/png');
+  });
+
+  it('any mime a tool sends normalizes to a type/subtype essence that round-trips', () => {
+    assert.strictEqual(normalizeMediaType('image/png; charset=binary'), 'image/png');
+    assert.strictEqual(normalizeMediaType(' IMAGE/JPEG '), 'image/jpeg');
+    assert.strictEqual(normalizeMediaType('image/x_custom'), 'image/x_custom');
+    assert.strictEqual(normalizeMediaType('image/svg+xml'), 'image/svg+xml');
+    assert.strictEqual(normalizeMediaType('garbage'), FALLBACK_MEDIA_TYPE);
+    assert.strictEqual(normalizeMediaType('image/has space'), FALLBACK_MEDIA_TYPE);
+    assert.strictEqual(normalizeMediaType(''), FALLBACK_MEDIA_TYPE);
+    // The invariant the formatter relies on: whatever comes in, the
+    // placeholder written for it re-parses to the normalized mime.
+    for (const raw of ['image/png; charset=binary', 'Image/PNG', 'image/x_custom', 'garbage', 'image/a,b', 'image/]', 'text/plain;x=1;y=2']) {
+      const mime = normalizeMediaType(raw);
+      const parsed = parseImagePlaceholders(formatToolImagePlaceholder(raw, '~1KB', 'img_abc123_1'));
+      assert.strictEqual(parsed.length, 1, `must re-parse: ${raw}`);
+      assert.strictEqual(parsed[0]!.mediaType, mime, raw);
+    }
+  });
+
+  it('splitting for truncation keeps every slot at or past the cut, and never leaves a partial one in the head', () => {
+    const png = '[image: image/png, ~12KB, ref img_abc123_1]';
+    const stub = '[ref_1_ab3d] cam.png — image/jpeg, 1.2MB claimed — from tool result — fetch with fetch_reference';
+    const text = `head text\n${png}\nmiddle text that is long enough\n${stub}\ntail\n[image: image/gif, 4B, ref img_abc123_2]`;
+    // Cut exactly at the start of the middle text: png stays, stub + gif move.
+    const cut1 = text.indexOf('middle');
+    const a = splitPreservingImageSlots(text, cut1);
+    assert.strictEqual(a.head, text.slice(0, cut1));
+    assert.deepStrictEqual(a.tail, [stub, '[image: image/gif, 4B, ref img_abc123_2]']);
+    // Cut in the middle of the stub line: the cut moves back to the stub's start.
+    const cut2 = text.indexOf('1.2MB');
+    const b = splitPreservingImageSlots(text, cut2);
+    assert.strictEqual(b.head, text.slice(0, text.indexOf(stub)));
+    assert.deepStrictEqual(b.tail, [stub, '[image: image/gif, 4B, ref img_abc123_2]']);
+    // Cut in the middle of the png placeholder.
+    const cut3 = text.indexOf('~12KB');
+    const c = splitPreservingImageSlots(text, cut3);
+    assert.strictEqual(c.head, 'head text\n');
+    assert.strictEqual(c.tail.length, 3);
+    // Head + preserved tail parse to exactly the original slots, in order.
+    for (const cut of [cut1, cut2, cut3, 1, text.length - 3]) {
+      const { head, tail } = splitPreservingImageSlots(text, cut);
+      const rejoined = head + '\n\n[truncated — original was N chars]' + formatPreservedImageSlots(tail);
+      assert.deepStrictEqual(
+        parseImagePlaceholders(rejoined).map((p) => p.text),
+        parseImagePlaceholders(text).map((p) => p.text),
+        `cut at ${cut}`,
+      );
+    }
+    // The generic history truncation uses the same rule.
+    const truncated = truncateForHistory(text, cut3);
+    assert.strictEqual(parseImagePlaceholders(truncated).length, 3);
+    assert.match(truncated, /\[truncated — original was \d+ chars\]/);
   });
 
   it('parses image-typed reference stubs as slots, in text order with inline placeholders', () => {
     const text = [
       'frame one',
-      '[image: image/png, ~12KB, ref img_3]',
+      '[image: image/png, ~12KB, ref img_abc123_3]',
       '[ref_1_ab3d] cam.png — image/jpeg, 1.2MB claimed — from tool result — fetch with fetch_reference',
       '[ref_2_zz9q] chord.wav — audio/wav, ~4.0MB claimed — from tool result — fetch with fetch_reference',
     ].join('\n');
@@ -463,7 +778,7 @@ describe('ToolImageLedger', () => {
     assert.deepStrictEqual(
       slots.map((s) => (s.kind === 'inline' ? ['inline', s.ref, s.mediaType] : ['reference', s.refId, s.mediaType])),
       [
-        ['inline', 'img_3', 'image/png'],
+        ['inline', 'img_abc123_3', 'image/png'],
         ['reference', 'ref_1_ab3d', 'image/jpeg'],
         ['reference', 'ref_2_zz9q', null],
       ],


### PR DESCRIPTION
## Problem

`save_recent_image` could not reach an image a tool had just returned. History stores every tool result through the text serializer, which turns image blocks into `[image: mime, size]` placeholders; only the live wire copy of that turn carries the bytes. The scanner walked past the byteless placeholder and saved whichever **older** attachment came next, under the filename the resident chose for the snapshot (Mica/Sill 2026-08-08), or reported "no images found" when there was none (Fable, twice). Not a same-turn race: tool results are committed to the store before the stream resumes, so the snapshot was inside the scanned window, just empty.

## Repair (two layers, per the disposition on #104)

**Retention with provenance** — new `src/tool-image-ledger.ts`. At ingestion (`buildStoredToolResultContent`) every image block in a tool result is retained in a per-agent ledger under a stable ref bound to `{toolCallId, blockIndex}` with mime, byte size and sha256. The placeholder now carries the handle: `[image: image/png, ~691KB, ref img_7]`. In-memory and bounded (64 images / 96 MB of base64, oldest-first), so it adds nothing to blob growth; provenance for evicted refs is kept so the error can name the tool call. Idempotent per block, so early retention and commit-time serialization agree.

**Fail-closed selection** — `save_recent_image` walks one ordered inventory: attachment image blocks *and* tool-result placeholders in true recency order, plus same-batch results that completed before the save. If the image at the requested index cannot be produced (evicted, minted by an earlier process, or a placeholder written before retention existed) the call fails **at that index** and writes nothing. It never slides to an older image. New `ref` argument saves by provenance directly; every receipt carries source, tool call, block, mime, size and sha256.

## Known limit
Retention is in-memory: images from before a restart cannot be saved, and the error says so. Durable blob-backed retention can follow if wanted; the Context Manager's content-addressed blob store is the obvious substrate.

## Tests
`test/save-recent-image.test.ts`: index 0 after a tool image is that image byte-exactly with an older attachment in context (index 1 is the attachment); evicted newest image → specific error, nothing written, older attachment untouched; pre-retention placeholder → unsaveable slot, not a skipped one; `ref` save and a defined miss; ledger idempotency/eviction; placeholder round-trip. The puppet harness gains the new field. Full suite: 641 tests, 0 failed, 4 skipped.

Refs #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FovMwcEYCYsG7sfzscJuWv
