### PR TITLE
Turn provenance: getActiveTurnTrigger + counterparty on channel-triggered requests

### DIFF
--- a/changelog.d/141-turn-trigger-provenance.added.md
+++ b/changelog.d/141-turn-trigger-provenance.added.md
@@ -1,0 +1,6 @@
+- `InferenceRequest.counterparty` carries the adapter-namespaced author id of
+  the channel message that triggered the turn, and
+  `getActiveTurnTrigger(agentName)` exposes the trigger of the turn in
+  progress (kept beside the turn token, cleared wherever it is) so a host can
+  stamp gateway telemetry with why the call exists and who woke the agent
+  (#141).

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -5282,19 +5282,27 @@ export class AgentFramework {
       // newest (2026-07-21 Cairn lounge misroute, turn-start variant).
       // Non-channel wakes (heartbeats, module events, reactions — which never
       // carry channelId) leave both undefined → global fallback.
-      let ambientChannel: string | undefined;
-      let addressedChannel: string | undefined;
+      // Track the winning REQUEST, not just its channel: channel, addressed
+      // and counterparty must come from the same message, or a batch of
+      // "ambient from A, then addressed from B" would report B's channel
+      // with A's author (review finding on the provenance change).
+      let ambientReq: InferenceRequest | undefined;
+      let addressedReq: InferenceRequest | undefined;
       for (const r of requests) {
         if (!r.channelId) continue;
-        ambientChannel = r.channelId;
-        if (r.addressed) addressedChannel = r.channelId;
+        ambientReq = r;
+        if (r.addressed) addressedReq = r;
       }
-      const triggerChannel = addressedChannel ?? ambientChannel;
-      const triggerAddressed = addressedChannel !== undefined;
+      const channelReq = addressedReq ?? ambientReq;
       await this.startAgentStream(agent, {
         ...trigger,
-        channelId: triggerChannel,
-        addressed: triggerAddressed,
+        channelId: channelReq?.channelId,
+        addressed: addressedReq !== undefined,
+        // A context-budget restart continues the same logical turn: it keeps
+        // the channel for routing but names no author — the restart is its
+        // own cause, and borrowing another request's author would be false
+        // provenance.
+        counterparty: budgetRestart ? undefined : channelReq?.counterparty,
       });
     }
   }

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -860,6 +860,19 @@ export class AgentFramework {
   // (KV bust). Invariant: nothing enters the window between a turn's dequeue
   // and its settle except that turn's own blocks.
   private activeTurnTokens: Map<string, number> = new Map();
+  /**
+   * The InferenceRequest that started each agent's turn in progress — set and
+   * cleared exactly where the turn token is. Read-only outside: the host
+   * stamps gateway telemetry (why this call exists, in which channel, woken
+   * by whom) from it, so a household ledger can attribute wakes without
+   * guessing from the newest message in the window.
+   */
+  private activeTurnTriggers: Map<string, InferenceRequest | undefined> = new Map();
+
+  /** The trigger of `agentName`'s turn in progress, if a turn is running. */
+  getActiveTurnTrigger(agentName: string): InferenceRequest | undefined {
+    return this.activeTurnTriggers.get(agentName);
+  }
   private nextTurnToken = 1;
 
   // Undo/redo state
@@ -2569,6 +2582,7 @@ export class AgentFramework {
       // unbounded map growth. Blind delete is safe: the agent is already out
       // of the map, and a late driveStream finally token-match no-ops.
       this.activeTurnTokens.delete(agent.name);
+      this.activeTurnTriggers.delete(agent.name);
     }
   }
 
@@ -4621,6 +4635,7 @@ export class AgentFramework {
           // Route this turn's auto-published speech back to THIS channel, not
           // the global most-recent-inbound locus (item-3 redux, trunk agents).
           channelId: event.channelId,
+          counterparty: event.author?.id ? `${event.serverId}:user:${event.author.id}` : undefined,
           // Addressed messages outrank ambient chatter when a batched wake
           // picks the turn's frozen speech locus.
           addressed,
@@ -4722,6 +4737,7 @@ export class AgentFramework {
         // A fork's home channel wins in routeSpeech regardless, but carry the
         // triggering channel too so the trunk/active path stays consistent.
         channelId: event.channelId,
+        counterparty: event.author?.id ? `${event.serverId}:user:${event.author.id}` : undefined,
         addressed: isAddressedMessage(event.tags, event.metadata),
       });
     }
@@ -5778,12 +5794,14 @@ export class AgentFramework {
     // no-ops instead of clobbering a successor's marker.
     const turnToken = this.nextTurnToken++;
     this.activeTurnTokens.set(agent.name, turnToken);
+    this.activeTurnTriggers.set(agent.name, trigger);
     let tokenHandedOff = false;
     try {
       tokenHandedOff = await this.beginAgentTurn(agent, trigger, attempt, turnToken, ownsProviderGate);
     } finally {
       if (!tokenHandedOff && this.activeTurnTokens.get(agent.name) === turnToken) {
         this.activeTurnTokens.delete(agent.name);
+        this.activeTurnTriggers.delete(agent.name);
       }
       if (!tokenHandedOff && ownsProviderGate) this.releasePrimaryProviderGate(agent.name);
     }
@@ -6035,6 +6053,7 @@ export class AgentFramework {
         // the eventGate `inferring` leak) — every exit path must clear it.
         if (this.activeTurnTokens.get(agent.name) === turnToken) {
           this.activeTurnTokens.delete(agent.name);
+          this.activeTurnTriggers.delete(agent.name);
         }
         this.settleAgent(agent.name, {
           stopReason: 'exhausted',
@@ -7213,6 +7232,7 @@ export class AgentFramework {
       // injection / teardown delivers the messages at a correct position.
       if (myTurnToken !== undefined && this.activeTurnTokens.get(agent.name) === myTurnToken) {
         this.activeTurnTokens.delete(agent.name);
+        this.activeTurnTriggers.delete(agent.name);
       }
 
       // Flush any deferred messages (e.g. if stream failed while tools were pending)

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -310,4 +310,12 @@ export interface InferenceRequest {
    * not capture the agent's voice just by being newest.
    */
   addressed?: boolean;
+  /**
+   * Who spoke the message that triggered this inference, as an adapter-
+   * namespaced opaque id (`<serverId>:user:<authorId>`) — never a display
+   * name. Undefined for wakes without an author (heartbeat, timers, module
+   * events). Read by the host to stamp gateway telemetry (x-gate-counterparty)
+   * so a household ledger can say who woke whom; carries no content.
+   */
+  counterparty?: string;
 }

--- a/test/turn-trigger-provenance.test.ts
+++ b/test/turn-trigger-provenance.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Turn provenance: the trigger the framework exposes for the turn in progress
+ * (getActiveTurnTrigger / the InferenceRequest handed to startAgentStream)
+ * must be internally consistent — channel, addressed and counterparty from
+ * ONE request — so a host stamping gateway telemetry never reports one
+ * person's channel with another person's id.
+ */
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { tmpdir } from 'node:os';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { AgentFramework } from '../src/index.js';
+import type { InferenceRequest } from '../src/index.js';
+import { MockMembrane, createMockResponse } from './helpers/mock-membrane.js';
+
+function internals(framework: AgentFramework) {
+  return framework as unknown as {
+    pendingRequests: InferenceRequest[];
+    processInferenceRequests(): Promise<void>;
+    startAgentStream(agent: unknown, trigger?: InferenceRequest): Promise<void>;
+  };
+}
+
+describe('Turn trigger provenance', () => {
+  let tempDir: string;
+  let membrane: MockMembrane;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'turn-trigger-test-'));
+    membrane = new MockMembrane();
+  });
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  async function makeFramework() {
+    return AgentFramework.create({
+      storePath: join(tempDir, 'test.chronicle'),
+      membrane: membrane.asMembrane(),
+      agents: [{ name: 'scout', model: 'test-model', systemPrompt: 'You are scout.' }],
+      modules: [],
+    });
+  }
+
+  /** Spy on startAgentStream: capture the merged trigger and the value the
+   *  getter exposes while the turn is alive. */
+  function spy(framework: AgentFramework) {
+    const i = internals(framework);
+    const captured: { handed?: InferenceRequest; exposed?: InferenceRequest } = {};
+    const orig = i.startAgentStream.bind(framework);
+    i.startAgentStream = async (agent: unknown, trigger?: InferenceRequest) => {
+      captured.handed = trigger;
+      const p = orig(agent, trigger);
+      captured.exposed = framework.getActiveTurnTrigger('scout');
+      return p;
+    };
+    return captured;
+  }
+
+  it('a batch where a later ADDRESSED request wins keeps its channel and author together', async () => {
+    membrane.pushResponse(createMockResponse([{ type: 'text', text: 'hi bob' }]));
+    const framework = await makeFramework();
+    const i = internals(framework);
+    const captured = spy(framework);
+    const t = Date.now();
+    i.pendingRequests.push(
+      { agentName: 'scout', reason: 'mcpl:channel-incoming', source: 'discord', timestamp: t,
+        channelId: 'discord:g:alice-room', counterparty: 'discord:user:alice', addressed: false },
+      { agentName: 'scout', reason: 'mcpl:channel-incoming', source: 'discord', timestamp: t + 1,
+        channelId: 'discord:g:bob-room', counterparty: 'discord:user:bob', addressed: true },
+    );
+    await i.processInferenceRequests();
+    await framework.runUntilIdle();
+
+    assert.equal(captured.handed?.channelId, 'discord:g:bob-room', 'addressed channel wins');
+    assert.equal(captured.handed?.addressed, true);
+    assert.equal(captured.handed?.counterparty, 'discord:user:bob', 'author must come from the SAME request as the channel');
+    assert.equal(captured.exposed?.counterparty, 'discord:user:bob', 'getActiveTurnTrigger exposes the same trigger while the turn runs');
+    assert.equal(captured.exposed?.channelId, 'discord:g:bob-room');
+    assert.equal(framework.getActiveTurnTrigger('scout'), undefined, 'cleared once the turn ended');
+    await framework.stop();
+  });
+
+  it('a context-budget restart keeps the channel for routing but names no author', async () => {
+    membrane.pushResponse(createMockResponse([{ type: 'text', text: 'continuing' }]));
+    const framework = await makeFramework();
+    const i = internals(framework);
+    const captured = spy(framework);
+    const t = Date.now();
+    i.pendingRequests.push(
+      { agentName: 'scout', reason: 'mcpl:channel-incoming', source: 'discord', timestamp: t,
+        channelId: 'discord:g:alice-room', counterparty: 'discord:user:alice', addressed: true },
+      { agentName: 'scout', reason: 'context_budget_restart', source: 'framework', timestamp: t + 1 },
+    );
+    await i.processInferenceRequests();
+    await framework.runUntilIdle();
+
+    assert.equal(captured.handed?.reason, 'context_budget_restart');
+    assert.equal(captured.handed?.channelId, 'discord:g:alice-room', 'routing channel is kept');
+    assert.equal(captured.handed?.counterparty, undefined, 'a restart is its own cause — no borrowed author');
+    await framework.stop();
+  });
+});


### PR DESCRIPTION
Read-only plumbing for gateway telemetry (connectome-host PR alongside: `x-gate-origin / channel / counterparty`).

- `InferenceRequest.counterparty?: string` — adapter-namespaced author id of the triggering channel message (`<serverId>:user:<authorId>`), set at both `mcpl:channel-incoming` request sites; undefined for wakes without an author (heartbeat, timers, module events). Never a display name.
- `activeTurnTriggers: Map<agent, InferenceRequest | undefined>` kept beside `activeTurnTokens`: set where the token is set, deleted at every site the token is deleted (turn start finally, exhausted branch, driveStream finally, ephemeral cleanup). `getActiveTurnTrigger(agentName)` exposes it.
- No behavior change; nothing reads the map inside the framework.

Why: the household ledger can already say whose words occupy each window (from the gateway's request capture); who *woke* the agent cannot be read from a request body — ambient digests enter context without requesting inference. The framework is the only place that knows the cause, and it already holds it as the turn's trigger.

`tsc --noEmit`: only the pre-existing `@animalabs/membrane` resolution errors in `test/xml-round-persist.test.ts` (present on main in this checkout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)