### PR TITLE
fix: contain whole-response tool wrappers emitted as prose

### DIFF
--- a/changelog.d/133-tool-wrapper-prose-guard.added.md
+++ b/changelog.d/133-tool-wrapper-prose-guard.added.md
@@ -1,0 +1,1 @@
+- Add a default-off, per-agent guard that contains an exact whole-response textual wrapper for a tool registered on that inference. The wrapper is neither executed, published, nor stored as assistant continuity; a content-free system receipt records that no tool was called.

--- a/docs/tool-wrapper-prose-guard.md
+++ b/docs/tool-wrapper-prose-guard.md
@@ -1,0 +1,17 @@
+# Tool-wrapper prose containment
+
+`toolWrapperProseGuard: true` is a default-off per-agent safety boundary for a narrow failure mode: the provider emits a complete textual rendering of a tool invocation instead of a structured `tool_use` block.
+
+The guard matches only when the entire visible prose is one wrapper naming a tool registered on that exact inference. Signed thinking may precede the visible wrapper. It does not parse or execute the wrapper body.
+
+Guarded turns buffer prose until completion so outgoing preview/voice surfaces cannot expose a wrapper before classification. Ordinary non-wrapper prose is then delivered normally at turn completion.
+
+On a match, Agent Framework:
+
+- does not execute a tool;
+- does not publish the wrapper;
+- does not store the wrapper as assistant continuity;
+- stores a fixed model-visible system receipt saying only that no tool was called; the tool name remains in metadata/host diagnostics, not prose;
+- leaves the exact provider response in the host's inference trace/ledger.
+
+The guard does not match unknown tools, quotation, code fences, mixed prose, partial wrappers, or any turn that executed a genuine structured call; trailing prose after a real tool round remains ordinary history. It is containment rather than a prose-to-tool parser.

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -84,6 +84,8 @@ export class Agent {
   readonly refusalHandling: AgentConfig['refusalHandling'];
   /** Prose delivery mode (see AgentConfig.proseRouting). Default 'locus'. */
   readonly proseRouting: 'locus' | 'explicit' | 'hybrid' | 'disabled';
+  /** Exact whole-response known-tool wrapper containment (default off). */
+  readonly toolWrapperProseGuard: boolean;
   /** Prompt-cache TTL forwarded to the provider (see AgentConfig.cacheTtl). */
   readonly cacheTtl: NonNullable<AgentConfig['cacheTtl']>;
   /** Emit prompt-cache markers on requests (see AgentConfig.promptCaching). */
@@ -137,6 +139,7 @@ export class Agent {
     this.thinking = config.thinking;
     this.refusalHandling = config.refusalHandling;
     this.proseRouting = config.proseRouting ?? 'locus';
+    this.toolWrapperProseGuard = config.toolWrapperProseGuard ?? false;
     this.cacheTtl = config.cacheTtl ?? '1h';
     this.promptCaching = config.promptCaching ?? true;
     this.prefillUserMessage = config.prefillUserMessage;

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -67,6 +67,7 @@ import { HookOrchestrator } from './mcpl/hook-orchestrator.js';
 import { PushHandler, type McplPushEvent } from './mcpl/push-handler.js';
 import { parseProsePrefix, parseHybridProsePrefix } from './mcpl/prose-grammar.js';
 import { ProseStreamRouter } from './mcpl/prose-stream-router.js';
+import { detectKnownToolWrapperProse } from './tool-wrapper-prose-guard.js';
 import { InferenceRouter } from './mcpl/inference-router.js';
 import { ChannelRegistry, type ChannelToolOrigin } from './mcpl/channel-registry.js';
 import { ConversationRouter } from './mcpl/conversation-router.js';
@@ -788,6 +789,12 @@ export class AgentFramework {
   private frameworkCancelledStreams: Map<string, 'turn_ended' | 'budget_restart'> = new Map();
   /** Active runEphemeralToCompletion runs, keyed by agent name. */
   private ephemeralRuns: Map<string, EphemeralRun> = new Map();
+  /** Ephemeral namespaces/names are single-generation for this framework
+   * lifetime. Reusing one while an old stream drains would let name-keyed
+   * liveness/settlement state cross generations. */
+  private usedEphemeralAgentNames: Set<string> = new Set();
+  /** One-shot generation tickets minted by createEphemeralAgent. */
+  private ephemeralCandidates: WeakMap<Agent, ContextManager> = new WeakMap();
   /** Per-agent count of consecutive exhausted inferences (reset on any success).
    *  Drives hard-down escalation — see noteInferenceExhausted. */
   private consecutiveInferenceFailures: Map<string, number> = new Map();
@@ -873,6 +880,10 @@ export class AgentFramework {
   getActiveTurnTrigger(agentName: string): InferenceRequest | undefined {
     return this.activeTurnTriggers.get(agentName);
   }
+
+  /** Structured calls executed in the current logical turn. Unlike the
+   * per-stream local this survives framework retries and budget restarts. */
+  private logicalTurnToolCalls: WeakMap<Agent, { turnToken: number; count: number }> = new WeakMap();
   private nextTurnToken = 1;
 
   // Undo/redo state
@@ -2421,6 +2432,13 @@ export class AgentFramework {
     contextManager: ContextManager;
     cleanup: () => void;
   }> {
+    // Names are Chronicle namespaces and generation identities. Reserve before
+    // opening the namespace so a second creation cannot append to an earlier
+    // generation before runEphemeralToCompletion has a chance to reject it.
+    if (this.usedEphemeralAgentNames.has(config.name) || this.agents.has(config.name)) {
+      throw new Error(`Ephemeral agent name \"${config.name}\" is already registered or has been used in this framework`);
+    }
+    this.usedEphemeralAgentNames.add(config.name);
     const namespace = `subagent/${config.name}`;
 
     const contextManager = await ContextManager.open({
@@ -2433,6 +2451,7 @@ export class AgentFramework {
     });
 
     const agent = new Agent(config, contextManager, this.membrane);
+    this.ephemeralCandidates.set(agent, contextManager);
 
     const cleanup = () => {
       // Don't close the store — it's shared. Just release the CM.
@@ -2460,6 +2479,17 @@ export class AgentFramework {
       run.inferenceStarted = true;
     }
     run.lastActivity = Date.now();
+  }
+
+  /** Record structured calls for the current logical turn. Ignore late stream
+   * events after an ephemeral/conversation agent has been disposed. */
+  private recordLogicalTurnToolCalls(agent: Agent, turnToken: number, count: number): void {
+    if (count <= 0 || this.agents.get(agent.name) !== agent) return;
+    const state = this.logicalTurnToolCalls.get(agent);
+    // The Agent object is the generation: a late stream from a disposed
+    // ephemeral/conversation fork cannot contaminate a same-name successor.
+    if (!state || state.turnToken !== turnToken) return;
+    this.logicalTurnToolCalls.set(agent, { turnToken, count: state.count + count });
   }
 
   private recordEphemeralToolCalls(agentName: string, count: number): void {
@@ -2505,7 +2535,18 @@ export class AgentFramework {
     contextManager: ContextManager,
     watchdogs?: { startupTimeoutMs?: number; idleTimeoutMs?: number; idlePollMs?: number },
   ): Promise<{ speech: string; toolCallsCount: number }> {
-    // Register temporarily so the event loop can drive it
+    // Only a fresh object returned by createEphemeralAgent may enter this path.
+    // Never overwrite a resident/conversation owner or a concurrent run: their
+    // cleanup is name-keyed and could cancel/deregister the legitimate owner.
+    if (this.ephemeralCandidates.get(agent) !== contextManager) {
+      throw new Error(`Ephemeral agent "${agent.name}" has no fresh generation ticket from this framework`);
+    }
+    // Consume before any await/registration: the exact (Agent, ContextManager)
+    // generation is one-shot even if startup later fails.
+    this.ephemeralCandidates.delete(agent);
+    if (this.agents.has(agent.name) || this.ephemeralRuns.has(agent.name)) {
+      throw new Error(`Ephemeral agent "${agent.name}" is already registered or running`);
+    }
     this.agents.set(agent.name, agent);
     const run: EphemeralRun = {
       settle: this.createDeferred<AgentSettleResult>(),
@@ -2570,8 +2611,21 @@ export class AgentFramework {
     } finally {
       if (startupWatchdog) clearTimeout(startupWatchdog);
       if (completionWatchdog) clearInterval(completionWatchdog);
-      this.ephemeralRuns.delete(agent.name);
-      this.agents.delete(agent.name);
+      // Cancel before deregistration. Adapters may still yield a queued event;
+      // driveStream's Agent-identity check above discards it before dispatch.
+      agent.cancelStream();
+      if (this.ephemeralRuns.get(agent.name) === run) this.ephemeralRuns.delete(agent.name);
+      if (this.agents.get(agent.name) === agent) {
+        // Exact-generation disposal owns these name-keyed entries. Remove them
+        // before deregistration; the late driveStream finally will see the
+        // generation mismatch and leave any future owner untouched.
+        this.activeStreams.delete(agent.name);
+        this.pendingAssistantBlocks.delete(agent.name);
+        // The late stream finalizer intentionally refuses name-keyed cleanup once
+        // deregistered, so disposal must release EventGate liveness itself.
+        this.eventGate?.onInferenceEnded(agent.name);
+        this.agents.delete(agent.name);
+      }
       // Spawn-and-dispose bookkeeping (main, d453165/fee96a7): without this,
       // ephemeral agents leave checkpoint-tree keys and diagnostics map
       // entries behind for the life of the store/session.
@@ -2583,6 +2637,7 @@ export class AgentFramework {
       // of the map, and a late driveStream finally token-match no-ops.
       this.activeTurnTokens.delete(agent.name);
       this.activeTurnTriggers.delete(agent.name);
+      this.logicalTurnToolCalls.delete(agent);
     }
   }
 
@@ -4757,6 +4812,10 @@ export class AgentFramework {
     if (!template || !templateConfig) {
       throw new Error(`conversation template agent "${router.templateAgent}" not found`);
     }
+    if (this.usedEphemeralAgentNames.has(name) || this.agents.has(name)) {
+      throw new Error(`Conversation agent name "${name}" is already registered or reserved`);
+    }
+    this.usedEphemeralAgentNames.add(name);
 
     const contextManager = await ContextManager.open({
       store: this.store,
@@ -4815,10 +4874,12 @@ export class AgentFramework {
   private disposeConversationAgent(agentName: string): void {
     this.closingConversationAgents.delete(agentName);
     const channelId = this.conversationAgentHomes.get(agentName);
+    const agent = this.agents.get(agentName);
     this.agents.delete(agentName);
     this.agentConfigs.delete(agentName);
     this.conversationAgentHomes.delete(agentName);
     this.evictTurnCheckpoints(agentName);
+    if (agent) this.logicalTurnToolCalls.delete(agent);
     this.emitTrace({
       type: 'mcpl:conversation-disposed',
       agentName,
@@ -5906,8 +5967,21 @@ export class AgentFramework {
     // BEFORE this turn compiles, so the agent always knows where its voice
     // goes (announce-on-change only — no per-turn chatter, append-only for
     // KV stability).
+    if (trigger?.reason === 'context_budget_restart') {
+      const previousLogicalToolState = this.logicalTurnToolCalls.get(agent);
+      this.logicalTurnToolCalls.set(agent, { turnToken, count: previousLogicalToolState?.count ?? 0 });
+    }
+
     if (trigger?.reason !== 'context_budget_restart') {
       if (attempt === 0) this.maybePrimeProseMode(agent);
+      const previousLogicalToolState = this.logicalTurnToolCalls.get(agent);
+      if (attempt === 0) {
+        // A true new turn gets a fresh generation and count.
+        this.logicalTurnToolCalls.set(agent, { turnToken, count: 0 });
+      } else {
+        // A framework retry is a new physical stream in the same logical turn.
+        this.logicalTurnToolCalls.set(agent, { turnToken, count: previousLogicalToolState?.count ?? 0 });
+      }
       // Fresh turn: forget the previous turn's explicit-send engagements and
       // prose deliveries — both are strictly turn-scoped (a restart continues
       // the same logical turn and keeps them).
@@ -5941,7 +6015,11 @@ export class AgentFramework {
       // context-budget restart, which skips the re-pin but re-emits this).
       channelId: this.turnLocusPins.get(agent.name),
     });
-    this.eventGate?.onInferenceStarted(agent.name);
+    // A budget restart continues the same logical inference window. The
+    // predecessor keeps EventGate liveness until its successor terminates.
+    if (trigger?.reason !== 'context_budget_restart') {
+      this.eventGate?.onInferenceStarted(agent.name);
+    }
     this.lastInferenceAt.set(agent.name, { ...this.lastInferenceAt.get(agent.name), startedAt: Date.now() });
 
     // Typing indicator, started at TURN START. It says "attending", which is
@@ -6004,12 +6082,30 @@ export class AgentFramework {
         }
       }
 
+      // An ephemeral watchdog may dispose this Agent while hooks/compile await.
+      // Do not create a provider stream after its generation lost ownership.
+      if (this.agents.get(agent.name) !== agent) {
+        this.channelRegistry?.stopTyping();
+        this.eventGate?.onInferenceEnded(agent.name);
+        if (ownsProviderGate) this.releasePrimaryProviderGate(agent.name);
+        if (this.activeTurnTokens.get(agent.name) === turnToken) this.activeTurnTokens.delete(agent.name);
+        return false;
+      }
       const {
         stream,
         request: compiledRequest,
         takeKvSubmission,
         drainKvSubmissionIds,
       } = await agent.startStreamWithInjections(tools, injections);
+      if (this.agents.get(agent.name) !== agent) {
+        stream.cancel();
+        agent.cancelStream();
+        this.channelRegistry?.stopTyping();
+        this.eventGate?.onInferenceEnded(agent.name);
+        if (ownsProviderGate) this.releasePrimaryProviderGate(agent.name);
+        if (this.activeTurnTokens.get(agent.name) === turnToken) this.activeTurnTokens.delete(agent.name);
+        return false;
+      }
 
       const handle = this.driveStream(
         agent,
@@ -6021,6 +6117,7 @@ export class AgentFramework {
         ownsProviderGate,
         takeKvSubmission,
         drainKvSubmissionIds,
+        new Set(tools.map((tool) => tool.name)),
       );
       this.activeStreams.set(agent.name, handle);
       // Handoff: driveStream captured the token in its synchronous prefix;
@@ -6105,6 +6202,7 @@ export class AgentFramework {
     ownsProviderGate = false,
     takeKvSubmission?: () => { submissionId: string; wireReceipt: CacheWireReceipt } | undefined,
     drainKvSubmissionIds?: () => string[],
+    knownToolNames: ReadonlySet<string> = new Set(),
   ): Promise<void> {
     const startTime = Date.now();
     const requestId = `${agent.name}-${startTime}-${Math.random().toString(36).slice(2, 8)}`;
@@ -6124,6 +6222,7 @@ export class AgentFramework {
     // means no successor turn can have replaced it while we compiled.
     const myTurnToken = this.activeTurnTokens.get(agent.name);
     let hadToolCalls = false;
+    let generationLost = false;
 
     // ---- Present-while-acting turn state ---------------------------------
     // Output locus for the WHOLE logical turn: frozen in startAgentStream
@@ -6207,13 +6306,20 @@ export class AgentFramework {
     // failed, a framework-cancelled stream sets aborted. Best-effort
     // notifications — consumers dedupe by inferenceId and keep a timeout.
     let lifecyclePhase: 'completed' | 'aborted' | 'failed' = 'completed';
+    let preserveEventGateForSuccessor = false;
     this.hookOrchestrator?.emitLifecycle({
       inferenceId: outgoingInferenceId,
       conversationId: agent.name,
       turnIndex: 0,
       phase: 'started',
     });
-    const proseStream = this.channelRegistry && agent.proseRouting !== 'disabled'
+    // The wrapper guard needs the complete response before it can distinguish
+    // an exact invocation-shaped body from ordinary XML/prose. Buffer guarded
+    // turns until completion: otherwise speculative outgoing chunks could
+    // expose the wrapper before the fail-closed classifier runs.
+    const proseStream = this.channelRegistry &&
+      agent.proseRouting !== 'disabled' &&
+      !agent.toolWrapperProseGuard
       ? new ProseStreamRouter({
           mode: agent.proseRouting === 'explicit' ? 'explicit' : agent.proseRouting === 'hybrid' ? 'hybrid' : 'locus',
           initialTarget: typingChannel,
@@ -6243,6 +6349,14 @@ export class AgentFramework {
 
     try {
       for await (const event of stream) {
+        // Ignore every late event from an Agent generation that no longer owns
+        // this name (ephemeral watchdog/disposal, conversation replacement).
+        if (this.agents.get(agent.name) !== agent || agent.streamId !== myStreamId) {
+          generationLost = true;
+          lifecyclePhase = 'aborted';
+          stream.cancel();
+          break;
+        }
         this.touchEphemeralRun(agent.name, true);
         switch (event.type) {
           case 'tokens':
@@ -6310,6 +6424,7 @@ export class AgentFramework {
           case 'tool-calls': {
             adoptInjectedRound();
             hadToolCalls = true;
+            this.recordLogicalTurnToolCalls(agent, myTurnToken ?? -1, event.calls.length);
             this.recordEphemeralToolCalls(agent.name, event.calls.length);
             this.emitTrace({
               type: 'inference:tool_calls_yielded',
@@ -6515,7 +6630,30 @@ export class AgentFramework {
             const terminalContent = lastToolIdx >= 0
               ? response.content.slice(lastToolIdx + 1)
               : response.content;
-            if (lastToolIdx >= 0) {
+            // This is a whole-response boundary, not a trailing-prose
+            // classifier. If the turn executed any genuine structured tool
+            // call, preserve its later prose exactly as ordinary history.
+            const logicalToolState = this.logicalTurnToolCalls.get(agent);
+            const logicalTurnHadToolCalls = logicalToolState?.turnToken === myTurnToken && (logicalToolState?.count ?? 0) > 0;
+            const guardedWrapperTool = agent.toolWrapperProseGuard && !logicalTurnHadToolCalls
+              ? detectKnownToolWrapperProse(response.content, knownToolNames)
+              : null;
+            if (guardedWrapperTool) {
+              // AF #133: containment only. Never execute wrapper text, never
+              // publish it, and never retain it as the freshest assistant
+              // self-seed. Exact raw output remains in the provider ledger.
+              agent.getContextManager().addMessage('user', [{
+                type: 'text',
+                text: '[tool-boundary] No tool was called.',
+              }], {
+                system: true,
+                kind: 'tool-wrapper-prose-contained',
+                toolName: guardedWrapperTool,
+              });
+              console.error(
+                `[tool-boundary] ${agent.name}: contained whole-response prose wrapper for registered tool ${guardedWrapperTool}; no tool called`,
+              );
+            } else if (lastToolIdx >= 0) {
               if (terminalContent.length > 0) {
                 agent.addAssistantResponse(terminalContent);
               }
@@ -6541,7 +6679,9 @@ export class AgentFramework {
             // text is speech.
             const isTextBlock = (block: ContentBlock): block is ContentBlock & { type: 'text' } =>
               block.type === 'text';
-            const allText = response.content.filter(isTextBlock);
+            const allText = guardedWrapperTool
+              ? []
+              : response.content.filter(isTextBlock);
 
             const speechContent = hadToolCalls ? [] : allText;
             const thoughts = hadToolCalls ? allText : [];
@@ -6556,19 +6696,30 @@ export class AgentFramework {
                 }
               : undefined;
 
+            // Async completion work may overlap a replacement stream. Recheck
+            // physical ownership before any terminal state/settlement side effect.
+            if (this.agents.get(agent.name) !== agent || agent.streamId !== myStreamId) {
+              generationLost = true;
+              lifecyclePhase = 'aborted';
+              stream.cancel();
+              return;
+            }
+
             // Reset agent state before emitting inference:completed. Traces are
             // observability-only, but external synchronous listeners should
             // still see the terminal state at the terminal trace boundary.
             // Speech dispatch happens after but doesn't depend on the status
             // field.
             agent.reset();
-            this.eventGate?.onInferenceEnded(agent.name);
+            if (this.agents.get(agent.name) === agent && agent.streamId === myStreamId) this.eventGate?.onInferenceEnded(agent.name);
             this.settleAgent(agent.name, {
               stopReason: 'completed',
-              speech: terminalContent
-                .filter((block: ContentBlock): block is ContentBlock & { type: 'text' } => block.type === 'text')
-                .map((block) => block.text)
-                .join('\n'),
+              speech: guardedWrapperTool
+                ? ''
+                : terminalContent
+                    .filter((block: ContentBlock): block is ContentBlock & { type: 'text' } => block.type === 'text')
+                    .map((block) => block.text)
+                    .join('\n'),
             });
 
             this.emitTrace({
@@ -6942,7 +7093,7 @@ export class AgentFramework {
 
             if (ownsProviderGate && this.holdProviderAcceleration(agent, err, trigger)) {
               lifecyclePhase = 'failed';
-              this.eventGate?.onInferenceEnded(agent.name);
+              if (this.agents.get(agent.name) === agent && agent.streamId === myStreamId) this.eventGate?.onInferenceEnded(agent.name);
               break;
             }
 
@@ -6966,7 +7117,7 @@ export class AgentFramework {
                 // itself) means retrying the same context can never succeed.
                 ...this.classifyInferenceError(err),
               });
-              this.eventGate?.onInferenceEnded(agent.name);
+              if (this.agents.get(agent.name) === agent && agent.streamId === myStreamId) this.eventGate?.onInferenceEnded(agent.name);
               if (action.emit) {
                 this.pushEvent(action.emit);
               }
@@ -6988,7 +7139,13 @@ export class AgentFramework {
               if (cancelKind !== undefined) {
                 this.frameworkCancelledStreams.delete(cancelKey);
                 lifecyclePhase = 'aborted'; // §10.5 — terminal emitted in finally
-                this.eventGate?.onInferenceEnded(agent.name);
+                // A budget restart continues the same EventGate window. Do not
+                // end it here or in finally; the replacement owns final release.
+                if (cancelKind === 'budget_restart') {
+                  preserveEventGateForSuccessor = true;
+                } else if (this.agents.get(agent.name) === agent && agent.streamId === myStreamId) {
+                  this.eventGate?.onInferenceEnded(agent.name);
+                }
                 // endTurn IS a logical turn end — earlier rounds may have
                 // live-routed prose (narrate → skip_reply is a real shape),
                 // so settle the delivery chain and drop the receipt. A
@@ -7035,7 +7192,7 @@ export class AgentFramework {
                 request: compiledRequest ?? { note: 'streaming request aborted' },
                 durationMs,
               });
-              this.eventGate?.onInferenceEnded(agent.name);
+              if (this.agents.get(agent.name) === agent && agent.streamId === myStreamId) this.eventGate?.onInferenceEnded(agent.name);
             }
             break;
           }
@@ -7128,6 +7285,14 @@ export class AgentFramework {
         }
       }
     } catch (error) {
+      // A superseded physical stream may throw after its replacement starts.
+      // It has no authority to settle, reset, gate-release, or publish failure.
+      if (this.agents.get(agent.name) !== agent || agent.streamId !== myStreamId) {
+        generationLost = true;
+        lifecyclePhase = 'aborted';
+        stream.cancel();
+        return;
+      }
       // Stream itself threw. Organization acceleration is deferred from a
       // fresh compile; every other throw keeps the ordinary exhausted path.
       const err = error instanceof Error ? error : new Error(String(error));
@@ -7138,7 +7303,7 @@ export class AgentFramework {
           error: `Provider acceleration cooldown: ${err.message}`,
           request: compiledRequest ?? { note: 'streaming request rate-limited' }, durationMs });
         this.abortAgentScript(agent.name, 'provider acceleration cooldown');
-        lifecyclePhase = 'failed'; agent.reset(); this.eventGate?.onInferenceEnded(agent.name);
+        lifecyclePhase = 'failed'; agent.reset(); if (this.agents.get(agent.name) === agent && agent.streamId === myStreamId) this.eventGate?.onInferenceEnded(agent.name);
         return;
       }
       this.emitTrace({
@@ -7173,7 +7338,7 @@ export class AgentFramework {
       this.abortAgentScript(agent.name, 'stream threw');
       lifecyclePhase = 'failed'; // §10.5 — terminal emitted in finally
       agent.reset();
-      this.eventGate?.onInferenceEnded(agent.name);
+      if (this.agents.get(agent.name) === agent && agent.streamId === myStreamId) this.eventGate?.onInferenceEnded(agent.name);
     } finally {
       const unsettledKvSubmissions = drainKvSubmissionIds?.() ?? [];
       if (unsettledKvSubmissions.length > 0) {
@@ -7186,6 +7351,11 @@ export class AgentFramework {
           }
         } catch { /* receipt cleanup must not mask inference teardown */ }
       }
+      // A framework retry/budget restart can overlap physical streams on the
+      // same Agent object. Name + Agent identity is not enough: only the
+      // current stream generation may mutate name-keyed teardown state.
+      const ownsPhysicalStream =
+        this.agents.get(agent.name) === agent && agent.streamId === myStreamId;
       // §10.5: exactly one terminal per `started`, on every exit path the
       // host controls. Which one was decided by the path taken (default
       // completed; catch → failed; framework-cancel → aborted). A host
@@ -7204,30 +7374,36 @@ export class AgentFramework {
       // all incoming events → the agent silently stops waking on messages
       // (typing still stops, compression still runs — matching the observed
       // wedge). onInferenceEnded is idempotent, so a redundant call is safe.
-      this.eventGate?.onInferenceEnded(agent.name);
-      this.lastInferenceAt.set(agent.name, { ...this.lastInferenceAt.get(agent.name), endedAt: Date.now() });
+      if (ownsPhysicalStream && !preserveEventGateForSuccessor) {
+        this.eventGate?.onInferenceEnded(agent.name);
+      }
+      if (!generationLost && ownsPhysicalStream) {
+        this.lastInferenceAt.set(agent.name, { ...this.lastInferenceAt.get(agent.name), endedAt: Date.now() });
+      }
       if (ownsProviderGate) this.releasePrimaryProviderGate(agent.name);
 
       // Stop the typing indicator on every exit path (complete, error,
       // exhausted, abort) so it never sticks after the turn ends.
-      this.channelRegistry?.stopTyping();
+      if (ownsPhysicalStream && !preserveEventGateForSuccessor) this.channelRegistry?.stopTyping();
 
       // Spec 14.3: flush any held line-start text, then close each streamed
       // channel with its final moderated content — the consumer's signal to
       // finalize (end the TTS utterance, settle the rendered message).
-      if (proseStream) {
+      if (!generationLost && ownsPhysicalStream && proseStream) {
         emitOutgoing(proseStream.finish());
         for (const [channelId, text] of proseStream.byChannel()) {
           this.channelRegistry!.sendOutgoingComplete(channelId, agent.name, outgoingInferenceId, text);
         }
       }
       this.frameworkCancelledStreams.delete(`${agent.name}:${myStreamId}`);
-      this.activeStreams.delete(agent.name);
-      this.pendingAssistantBlocks.delete(agent.name);
+      if (ownsPhysicalStream) {
+        this.activeStreams.delete(agent.name);
+        this.pendingAssistantBlocks.delete(agent.name);
+      }
 
       // A conversation fork whose TTL closure turn just finished is done for
       // good — dispose it so the agent map doesn't grow monotonically.
-      if (this.closingConversationAgents.has(agent.name)) {
+      if (ownsPhysicalStream && this.closingConversationAgents.has(agent.name)) {
         this.disposeConversationAgent(agent.name);
       }
 
@@ -7244,7 +7420,7 @@ export class AgentFramework {
       }
 
       // Flush any deferred messages (e.g. if stream failed while tools were pending)
-      if (this.deferredMessages.length > 0 && this.pendingAssistantBlocks.size === 0) {
+      if (ownsPhysicalStream && this.deferredMessages.length > 0 && this.pendingAssistantBlocks.size === 0) {
         const deferred = this.deferredMessages.splice(0);
         for (const msg of deferred) {
           this.addMessage(msg.participant, msg.content, msg.metadata);

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -795,6 +795,10 @@ export class AgentFramework {
   private usedEphemeralAgentNames: Set<string> = new Set();
   /** One-shot generation tickets minted by createEphemeralAgent. */
   private ephemeralCandidates: WeakMap<Agent, ContextManager> = new WeakMap();
+  /** Physical ephemeral frames deliberately disposed by their run watchdog/caller.
+   * The name is single-generation, so these frames still own their terminal
+   * typing/outgoing close even after runEphemeralToCompletion deregisters them. */
+  private disposedEphemeralFrames: WeakSet<Agent> = new WeakSet();
   /** Per-agent count of consecutive exhausted inferences (reset on any success).
    *  Drives hard-down escalation — see noteInferenceExhausted. */
   private consecutiveInferenceFailures: Map<string, number> = new Map();
@@ -2616,6 +2620,10 @@ export class AgentFramework {
     } finally {
       if (startupWatchdog) clearTimeout(startupWatchdog);
       if (completionWatchdog) clearInterval(completionWatchdog);
+      // Mark before cancellation: an adapter may synchronously settle its
+      // iterator, and this physical frame still owns terminal typing/outgoing
+      // closure even though the ephemeral name is about to be deregistered.
+      this.disposedEphemeralFrames.add(agent);
       // Cancel before deregistration. Adapters may still yield a queued event;
       // driveStream's Agent-identity check above discards it before dispatch.
       agent.cancelStream();
@@ -7369,7 +7377,13 @@ export class AgentFramework {
       // runEphemeralToCompletion may already have deregistered the name. The
       // terminal frame still owns its typing/outgoing completion unless it was
       // genuinely superseded or handed EventGate liveness to a budget restart.
-      const frameReachedTerminal = !generationLost && !preserveEventGateForSuccessor;
+      const disposedEphemeralWithoutSuccessor =
+        generationLost &&
+        this.disposedEphemeralFrames.has(agent) &&
+        !this.agents.has(agent.name);
+      const frameReachedTerminal =
+        (!generationLost || disposedEphemeralWithoutSuccessor) &&
+        !preserveEventGateForSuccessor;
       // §10.5: exactly one terminal per `started`, on every exit path the
       // host controls. Which one was decided by the path taken (default
       // completed; catch → failed; framework-cancel → aborted). A host

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -2439,26 +2439,31 @@ export class AgentFramework {
       throw new Error(`Ephemeral agent name \"${config.name}\" is already registered or has been used in this framework`);
     }
     this.usedEphemeralAgentNames.add(config.name);
-    const namespace = `subagent/${config.name}`;
+    try {
+      const namespace = `subagent/${config.name}`;
 
-    const contextManager = await ContextManager.open({
-      store: this.store,
-      namespace,
-      isolate: true,
-      strategy: config.strategy ?? new PassthroughStrategy(),
-      membrane: this.membrane,
-      debugLogContext: !!process.env.DEBUG_CONTEXT,
-    });
+      const contextManager = await ContextManager.open({
+        store: this.store,
+        namespace,
+        isolate: true,
+        strategy: config.strategy ?? new PassthroughStrategy(),
+        membrane: this.membrane,
+        debugLogContext: !!process.env.DEBUG_CONTEXT,
+      });
 
-    const agent = new Agent(config, contextManager, this.membrane);
-    this.ephemeralCandidates.set(agent, contextManager);
+      const agent = new Agent(config, contextManager, this.membrane);
+      this.ephemeralCandidates.set(agent, contextManager);
 
-    const cleanup = () => {
-      // Don't close the store — it's shared. Just release the CM.
-      // Data persists in the store under the namespace for investigation.
-    };
+      const cleanup = () => {
+        // Don't close the store — it's shared. Just release the CM.
+        // Data persists in the store under the namespace for investigation.
+      };
 
-    return { agent, contextManager, cleanup };
+      return { agent, contextManager, cleanup };
+    } catch (error) {
+      this.usedEphemeralAgentNames.delete(config.name);
+      throw error;
+    }
   }
 
   private createDeferred<T>(): Deferred<T> {
@@ -4816,41 +4821,46 @@ export class AgentFramework {
       throw new Error(`Conversation agent name "${name}" is already registered or reserved`);
     }
     this.usedEphemeralAgentNames.add(name);
+    try {
 
-    const contextManager = await ContextManager.open({
-      store: this.store,
-      namespace: `conversations/${name}`,
-      isolate: true,
-      // Strategy instances are stateful — never share the template's.
-      strategy: router.strategyFactory?.() ?? new PassthroughStrategy(),
-      // Dynamic conversation forks retain the established provider policy in
-      // this bounded first slice. Provider cooldown ownership belongs to the
-      // persistent resident only; generation-unique forks must not leak gates.
-      membrane: this.membrane,
-      debugLogContext: !!process.env.DEBUG_CONTEXT,
-    });
+      const contextManager = await ContextManager.open({
+        store: this.store,
+        namespace: `conversations/${name}`,
+        isolate: true,
+        // Strategy instances are stateful — never share the template's.
+        strategy: router.strategyFactory?.() ?? new PassthroughStrategy(),
+        // Dynamic conversation forks retain the established provider policy in
+        // this bounded first slice. Provider cooldown ownership belongs to the
+        // persistent resident only; generation-unique forks must not leak gates.
+        membrane: this.membrane,
+        debugLogContext: !!process.env.DEBUG_CONTEXT,
+      });
 
-    // Seed with the template's compiled context, renaming the template
-    // participant so the fork reads its inheritance as its own history.
-    // Guard: only seed a genuinely fresh namespace. Generation counters are
-    // persisted precisely so names aren't reused, but if this namespace has
-    // history anyway (counter state lost, crash between spawn and persist),
-    // seeding again would stack another template copy on top of it.
-    const { messages: existing } = await contextManager.compile();
-    if (existing.length === 0) {
-      const { messages: compiled } = await template.getContextManager().compile();
-      for (const msg of compiled) {
-        const participant = msg.participant === template.name ? name : msg.participant;
-        contextManager.addMessage(participant, msg.content);
+      // Seed with the template's compiled context, renaming the template
+      // participant so the fork reads its inheritance as its own history.
+      // Guard: only seed a genuinely fresh namespace. Generation counters are
+      // persisted precisely so names aren't reused, but if this namespace has
+      // history anyway (counter state lost, crash between spawn and persist),
+      // seeding again would stack another template copy on top of it.
+      const { messages: existing } = await contextManager.compile();
+      if (existing.length === 0) {
+        const { messages: compiled } = await template.getContextManager().compile();
+        for (const msg of compiled) {
+          const participant = msg.participant === template.name ? name : msg.participant;
+          contextManager.addMessage(participant, msg.content);
+        }
       }
-    }
 
-    const config: AgentConfig = { ...templateConfig, name, strategy: undefined };
-    const agent = new Agent(config, contextManager, this.membrane);
-    this.agents.set(name, agent);
-    this.agentConfigs.set(name, config);
-    this.conversationAgentHomes.set(name, channelId);
-    return agent;
+      const config: AgentConfig = { ...templateConfig, name, strategy: undefined };
+      const agent = new Agent(config, contextManager, this.membrane);
+      this.agents.set(name, agent);
+      this.agentConfigs.set(name, config);
+      this.conversationAgentHomes.set(name, channelId);
+      return agent;
+    } catch (error) {
+      this.usedEphemeralAgentNames.delete(name);
+      throw error;
+    }
   }
 
   /** Persist the router's generation counters (see hydration in create()). */
@@ -5316,6 +5326,9 @@ export class AgentFramework {
           `[inference-dropped] agent=${agentName} reason=policy-skip ` +
           `requests=${requests.length} triggers=${requests.map((r) => r.reason).join(',')}`,
         );
+        // A context-budget restart inherits the predecessor's EventGate liveness.
+        // If policy drops the queued successor, no driveStream remains to release it.
+        if (budgetRestart) this.eventGate?.onInferenceEnded(agentName);
         const gate = this.providerGates.get(agentName);
         if (gate?.primaryPending && this.providerAccelerationRecoveries.has(agentName)) {
           gate.primaryPending = false;
@@ -6087,8 +6100,6 @@ export class AgentFramework {
       if (this.agents.get(agent.name) !== agent) {
         this.channelRegistry?.stopTyping();
         this.eventGate?.onInferenceEnded(agent.name);
-        if (ownsProviderGate) this.releasePrimaryProviderGate(agent.name);
-        if (this.activeTurnTokens.get(agent.name) === turnToken) this.activeTurnTokens.delete(agent.name);
         return false;
       }
       const {
@@ -6102,8 +6113,6 @@ export class AgentFramework {
         agent.cancelStream();
         this.channelRegistry?.stopTyping();
         this.eventGate?.onInferenceEnded(agent.name);
-        if (ownsProviderGate) this.releasePrimaryProviderGate(agent.name);
-        if (this.activeTurnTokens.get(agent.name) === turnToken) this.activeTurnTokens.delete(agent.name);
         return false;
       }
 
@@ -7356,6 +7365,11 @@ export class AgentFramework {
       // current stream generation may mutate name-keyed teardown state.
       const ownsPhysicalStream =
         this.agents.get(agent.name) === agent && agent.streamId === myStreamId;
+      // Ephemeral completion resolves its caller before this finally runs, so
+      // runEphemeralToCompletion may already have deregistered the name. The
+      // terminal frame still owns its typing/outgoing completion unless it was
+      // genuinely superseded or handed EventGate liveness to a budget restart.
+      const frameReachedTerminal = !generationLost && !preserveEventGateForSuccessor;
       // §10.5: exactly one terminal per `started`, on every exit path the
       // host controls. Which one was decided by the path taken (default
       // completed; catch → failed; framework-cancel → aborted). A host
@@ -7384,12 +7398,12 @@ export class AgentFramework {
 
       // Stop the typing indicator on every exit path (complete, error,
       // exhausted, abort) so it never sticks after the turn ends.
-      if (ownsPhysicalStream && !preserveEventGateForSuccessor) this.channelRegistry?.stopTyping();
+      if (frameReachedTerminal) this.channelRegistry?.stopTyping();
 
       // Spec 14.3: flush any held line-start text, then close each streamed
       // channel with its final moderated content — the consumer's signal to
       // finalize (end the TTS utterance, settle the rendered message).
-      if (!generationLost && ownsPhysicalStream && proseStream) {
+      if (frameReachedTerminal && proseStream) {
         emitOutgoing(proseStream.finish());
         for (const [channelId, text] of proseStream.byChannel()) {
           this.channelRegistry!.sendOutgoingComplete(channelId, agent.name, outgoingInferenceId, text);
@@ -7420,7 +7434,7 @@ export class AgentFramework {
       }
 
       // Flush any deferred messages (e.g. if stream failed while tools were pending)
-      if (ownsPhysicalStream && this.deferredMessages.length > 0 && this.pendingAssistantBlocks.size === 0) {
+      if (frameReachedTerminal && this.deferredMessages.length > 0 && this.pendingAssistantBlocks.size === 0) {
         const deferred = this.deferredMessages.splice(0);
         for (const msg of deferred) {
           this.addMessage(msg.participant, msg.content, msg.metadata);

--- a/src/tool-wrapper-prose-guard.ts
+++ b/src/tool-wrapper-prose-guard.ts
@@ -1,0 +1,38 @@
+import type { ContentBlock } from '@animalabs/membrane';
+
+/**
+ * Recognize ONLY a whole-response textual invocation wrapper for a tool that
+ * was registered on this exact inference. This is containment, not parsing:
+ * callers must never execute the returned tool name or wrapper body.
+ */
+export function detectKnownToolWrapperProse(
+  content: ContentBlock[],
+  knownToolNames: ReadonlySet<string>,
+): string | null {
+  if (knownToolNames.size === 0) return null;
+
+  // Signed thinking may precede visible prose. Any other non-text block makes
+  // this a mixed response, not an exact textual wrapper.
+  const text: string[] = [];
+  for (const block of content) {
+    if (block.type === 'text') text.push(block.text);
+    else if (block.type !== 'thinking' && block.type !== 'redacted_thinking') return null;
+  }
+  const body = text.join('\n').trim();
+  if (!body) return null;
+
+  const tagName = '[A-Za-z_][A-Za-z0-9_.:-]*';
+  let match = body.match(new RegExp(`^<(${tagName})\\s*/>$`));
+  if (match && knownToolNames.has(match[1]!)) return match[1]!;
+
+  match = body.match(new RegExp(`^<(${tagName})\\s*>([\\s\\S]*?)<\\/\\1\\s*>$`));
+  if (match && knownToolNames.has(match[1]!)) return match[1]!;
+
+  // Legacy XML formatter shape used by older Claude harnesses.
+  match = body.match(/^<invoke\s*>\s*<tool\s+name=(['"])([^'"]+)\1(?:\s+[^>]*)?\s*\/>\s*<\/invoke\s*>$/);
+  if (match && knownToolNames.has(match[2]!)) return match[2]!;
+  match = body.match(/^<invoke\s*>\s*<tool\s+name=(['"])([^'"]+)\1(?:\s+[^>]*)?\s*>([\s\S]*?)<\/tool\s*>\s*<\/invoke\s*>$/);
+  if (match && knownToolNames.has(match[2]!)) return match[2]!;
+
+  return null;
+}

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -184,6 +184,14 @@ export interface AgentConfig {
    *   send externally; prose remains in Chronicle with a private suppression receipt.
    */
   proseRouting?: 'locus' | 'explicit' | 'hybrid' | 'disabled';
+
+  /**
+   * Fail-closed containment for a text response whose entire visible prose is
+   * an invocation-shaped wrapper naming a tool registered on that exact turn.
+   * The wrapper is neither executed nor stored as assistant continuity; a
+   * content-free system receipt is stored instead. Default false.
+   */
+  toolWrapperProseGuard?: boolean;
 }
 
 /** The intentionally small set of agent settings that may change in-process. */

--- a/test/tool-wrapper-prose-guard-integration.test.ts
+++ b/test/tool-wrapper-prose-guard-integration.test.ts
@@ -1,0 +1,372 @@
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Module, ModuleContext, ProcessEvent, ProcessState, EventResponse, ToolDefinition, ToolCall, ToolResult } from '../src/index.js';
+import { AgentFramework } from '../src/index.js';
+import { MockMembrane, MockYieldingStream, createMockResponse } from './helpers/mock-membrane.js';
+import type { ContentBlock, NormalizedRequest, NormalizedResponse, StreamEvent, YieldingStream } from '@animalabs/membrane';
+
+class HeartbeatModule implements Module {
+  readonly name = 'mcpl';
+  calls = 0;
+  async start(_ctx: ModuleContext): Promise<void> {}
+  async stop(): Promise<void> {}
+  getTools(): ToolDefinition[] {
+    return [{ name: 'heartbeat--heartbeat_status', description: 'Read heartbeat status', inputSchema: { type: 'object', properties: {} } }];
+  }
+  async handleToolCall(_call: ToolCall): Promise<ToolResult> { this.calls++; return { success: true, data: { ok: true } }; }
+  async onProcess(event: ProcessEvent, _state: ProcessState): Promise<EventResponse> {
+    if (event.type !== 'external-message') return {};
+    return { addMessages: [{ participant: 'user', content: [{ type: 'text', text: 'check' }] }], requestInference: true };
+  }
+}
+
+class ToolThenErrorStream implements YieldingStream {
+  private events: StreamEvent[] = [{
+    type: 'tool-calls',
+    calls: [{ id: 'toolu_retry', name: 'mcpl--heartbeat--heartbeat_status', input: {} }],
+    context: { rawText: '', preamble: '', depth: 0, previousResults: [], accumulated: '', roundContent: [{ type: 'tool_use', id: 'toolu_retry', name: 'mcpl--heartbeat--heartbeat_status', input: {} }] },
+  } as StreamEvent];
+  private wake: (() => void) | null = null; private done = false;
+  get isWaitingForTools() { return !this.done; } get pendingToolCallIds() { return this.done ? [] : ['toolu_retry']; } get toolDepth() { return 0; }
+  provideToolResults(): void { this.done = true; this.events.push({ type: 'error', error: new Error('retry after tool') } as StreamEvent); this.wake?.(); this.wake = null; }
+  cancel(): void { this.done = true; this.wake?.(); this.wake = null; }
+  async *[Symbol.asyncIterator](): AsyncIterator<StreamEvent> {
+    while (true) { while (this.events.length) yield this.events.shift()!; if (this.done) return; await new Promise<void>((r) => { this.wake = r; }); }
+  }
+}
+class SequentialStreamMembrane {
+  calls = 0;
+  constructor(readonly responses: NormalizedResponse[]) {}
+  async complete(_request: NormalizedRequest): Promise<NormalizedResponse> { return this.responses[Math.min(this.calls++, this.responses.length - 1)]!; }
+  streamYielding(_request: NormalizedRequest): YieldingStream { return new MockYieldingStream([this.responses[Math.min(this.calls++, this.responses.length - 1)]!]); }
+  asMembrane(): import('@animalabs/membrane').Membrane { return this as unknown as import('@animalabs/membrane').Membrane; }
+}
+
+class ToolThenFrameworkRetryMembrane {
+  calls = 0;
+  readonly final = createMockResponse([{ type: 'text', text: '<mcpl--heartbeat--heartbeat_status>\n</mcpl--heartbeat--heartbeat_status>' }] as ContentBlock[]);
+  async complete(_request: NormalizedRequest): Promise<NormalizedResponse> { return this.final; }
+  streamYielding(_request: NormalizedRequest): YieldingStream { return this.calls++ === 0 ? new ToolThenErrorStream() : new MockYieldingStream([this.final]); }
+  asMembrane(): import('@animalabs/membrane').Membrane { return this as unknown as import('@animalabs/membrane').Membrane; }
+}
+
+class RetryingWrapperMembrane {
+  readonly response = createMockResponse([{ type: 'text', text: '<mcpl--heartbeat--heartbeat_status>\n</mcpl--heartbeat--heartbeat_status>' }] as ContentBlock[]);
+  async complete(_request: NormalizedRequest): Promise<NormalizedResponse> { return this.response; }
+  streamYielding(_request: NormalizedRequest): YieldingStream {
+    const response = this.response;
+    return {
+      isWaitingForTools: false, pendingToolCallIds: [], toolDepth: 0,
+      provideToolResults: () => { throw new Error('not waiting for tools'); }, cancel: () => {},
+      async *[Symbol.asyncIterator](): AsyncIterator<StreamEvent> {
+        yield { type: 'tokens', content: '<mcpl--heartbeat--heartbeat_status>', meta: { type: 'text', visible: true, blockIndex: 0 } } as StreamEvent;
+        yield { type: 'retrying', attempt: 1, maxAttempts: 1, reason: 'refusal', category: 'test' } as StreamEvent;
+        yield { type: 'tokens', content: '<mcpl--heartbeat--heartbeat_status>\n</mcpl--heartbeat--heartbeat_status>', meta: { type: 'text', visible: true, blockIndex: 0 } } as StreamEvent;
+        yield { type: 'complete', response } as StreamEvent;
+      },
+    } as YieldingStream;
+  }
+  asMembrane(): import('@animalabs/membrane').Membrane { return this as unknown as import('@animalabs/membrane').Membrane; }
+}
+
+const dirs: string[] = [];
+afterEach(() => { while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true }); });
+
+async function run(enabled?: boolean, allowedTools?: string[]) {
+  const dir = mkdtempSync(join(tmpdir(), 'af-wrapper-guard-')); dirs.push(dir);
+  const membrane = new MockMembrane();
+  membrane.pushResponse(createMockResponse([{ type: 'text', text: '<mcpl--heartbeat--heartbeat_status>\n</mcpl--heartbeat--heartbeat_status>' }] as ContentBlock[]));
+  const module = new HeartbeatModule();
+  const framework = await AgentFramework.create({
+    storePath: join(dir, 'store'), membrane: membrane.asMembrane(),
+    agents: [{ name: 'assistant', model: 'test', systemPrompt: 'sys', toolWrapperProseGuard: enabled, ...(allowedTools ? { allowedTools } : {}) }],
+    modules: [module],
+  });
+  const routed: string[] = [];
+  const outgoing: string[] = [];
+  (framework as unknown as { channelRegistry: unknown }).channelRegistry = new Proxy({
+    resolveLocus: () => 'world:test',
+    routeSpeech: async (_agent: string, speech: string) => { routed.push(speech); return { delivered: true, channelId: 'world:test' }; },
+    sendOutgoingChunk: (_channel: string, _agent: string, _id: string, _index: number, delta: string) => { outgoing.push(delta); },
+    getDefaultPublishChannel: () => null, isChannelOpen: () => true, getDescriptor: () => undefined, getChannelTools: () => [],
+  }, { get: (target, prop: string) => (prop in target ? (target as Record<string, unknown>)[prop] : () => undefined) });
+  framework.pushEvent({ type: 'external-message', source: 'test', content: 'go', metadata: {} } as unknown as ProcessEvent);
+  await framework.runUntilIdle();
+  const all = framework.getAgent('assistant')!.getContextManager().getAllMessages() as Array<{ content: ContentBlock[]; metadata?: Record<string, unknown> }>;
+  await framework.stop();
+  return { routed, outgoing, all, module };
+}
+
+class LateToolAfterIdleMembrane {
+  streamYielding(): YieldingStream {
+    return {
+      isWaitingForTools: false, pendingToolCallIds: [], toolDepth: 0,
+      provideToolResults: () => {}, cancel: () => {},
+      async *[Symbol.asyncIterator](): AsyncIterator<StreamEvent> {
+        yield { type: 'tokens', content: 'starting', meta: { type: 'text', visible: true, blockIndex: 0 } } as StreamEvent;
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        yield { type: 'tool-calls', calls: [{ id: 'late', name: 'mcpl--heartbeat--heartbeat_status', input: {} }], context: { rawText: '', preamble: '', depth: 0, previousResults: [], accumulated: '', roundContent: [{ type: 'tool_use', id: 'late', name: 'mcpl--heartbeat--heartbeat_status', input: {} }] } } as StreamEvent;
+        yield { type: 'complete', response: createMockResponse([{ type: 'text', text: 'late' }]) } as StreamEvent;
+      },
+    } as YieldingStream;
+  }
+  async complete(): Promise<NormalizedResponse> { throw new Error('not used'); }
+  asMembrane(): import('@animalabs/membrane').Membrane { return this as unknown as import('@animalabs/membrane').Membrane; }
+}
+
+describe('tool wrapper prose guard integration', () => {
+  it('default-off preserves and routes wrapper prose', async () => {
+    const { routed, outgoing, all } = await run();
+    assert.deepEqual(routed, ['<mcpl--heartbeat--heartbeat_status>\n</mcpl--heartbeat--heartbeat_status>']);
+    assert.equal(outgoing.join(''), '<mcpl--heartbeat--heartbeat_status>\n</mcpl--heartbeat--heartbeat_status>', 'default-off mutation exposes the wrapper on outgoing preview');
+    assert.ok(all.some((m) => m.content.some((b) => b.type === 'text' && b.text.includes('<mcpl--heartbeat--heartbeat_status>'))));
+  });
+  it('does not claim authority for a globally registered but request-disallowed tool', async () => {
+    const { routed, all, module } = await run(true, ['some--other']);
+    assert.deepEqual(routed, ['<mcpl--heartbeat--heartbeat_status>\n</mcpl--heartbeat--heartbeat_status>']);
+    assert.equal(module.calls, 0);
+    assert.ok(!all.some((m) => m.metadata?.kind === 'tool-wrapper-prose-contained'));
+  });
+
+  it('buffers abandoned retry tokens and contains only the final wrapper response', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'af-wrapper-guard-retry-')); dirs.push(dir);
+    const module = new HeartbeatModule(); const membrane = new RetryingWrapperMembrane();
+    const routed: string[] = []; const outgoing: string[] = [];
+    const framework = await AgentFramework.create({
+      storePath: join(dir, 'store'), membrane: membrane.asMembrane(),
+      agents: [{ name: 'assistant', model: 'test', systemPrompt: 'sys', toolWrapperProseGuard: true }], modules: [module],
+    });
+    (framework as unknown as { channelRegistry: unknown }).channelRegistry = new Proxy({
+      resolveLocus: () => 'world:test', routeSpeech: async (_a: string, text: string) => { routed.push(text); return { delivered: true, channelId: 'world:test' }; },
+      sendOutgoingChunk: (_c: string, _a: string, _id: string, _i: number, delta: string) => { outgoing.push(delta); },
+      getDefaultPublishChannel: () => null, isChannelOpen: () => true, getDescriptor: () => undefined, getChannelTools: () => [],
+    }, { get: (target, prop: string) => (prop in target ? (target as Record<string, unknown>)[prop] : () => undefined) });
+    framework.pushEvent({ type: 'external-message', source: 'test', content: 'go', metadata: {} } as unknown as ProcessEvent);
+    await framework.runUntilIdle();
+    const all = framework.getAgent('assistant')!.getContextManager().getAllMessages() as Array<{ content: ContentBlock[]; metadata?: Record<string, unknown> }>;
+    await framework.stop();
+    assert.deepEqual(routed, []); assert.deepEqual(outgoing, []); assert.equal(module.calls, 0);
+    assert.equal(all.filter((m) => m.metadata?.kind === 'tool-wrapper-prose-contained').length, 1);
+    assert.ok(!all.some((m) => m.content.some((b) => b.type === 'text' && b.text.includes('<mcpl--heartbeat--heartbeat_status>'))));
+  });
+
+  it('preserves structured-tool history across a framework error retry', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'af-wrapper-guard-framework-retry-')); dirs.push(dir);
+    const module = new HeartbeatModule(); const membrane = new ToolThenFrameworkRetryMembrane(); const routed: string[] = [];
+    const framework = await AgentFramework.create({ storePath: join(dir, 'store'), membrane: membrane.asMembrane(), agents: [{ name: 'assistant', model: 'test', systemPrompt: 'sys', toolWrapperProseGuard: true }], modules: [module] });
+    (framework as unknown as { channelRegistry: unknown }).channelRegistry = new Proxy({
+      resolveLocus: () => 'world:test', routeSpeech: async (_a: string, text: string) => { routed.push(text); return { delivered: true, channelId: 'world:test' }; },
+      getDefaultPublishChannel: () => null, isChannelOpen: () => true, getDescriptor: () => undefined, getChannelTools: () => [],
+    }, { get: (target, prop: string) => (prop in target ? (target as Record<string, unknown>)[prop] : () => undefined) });
+    framework.pushEvent({ type: 'external-message', source: 'test', content: 'go', metadata: {} } as unknown as ProcessEvent); await framework.runUntilIdle();
+    const all = framework.getAgent('assistant')!.getContextManager().getAllMessages() as Array<{ content: ContentBlock[]; metadata?: Record<string, unknown> }>;
+    await framework.stop();
+    assert.equal(module.calls, 1); assert.equal(membrane.calls, 2); assert.deepEqual(routed, ['<mcpl--heartbeat--heartbeat_status>\n</mcpl--heartbeat--heartbeat_status>']);
+    assert.ok(!all.some((m) => m.metadata?.kind === 'tool-wrapper-prose-contained'));
+  });
+
+  it('preserves structured-tool history across a context-budget restart', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'af-wrapper-guard-budget-restart-')); dirs.push(dir);
+    const module = new HeartbeatModule(); const routed: string[] = [];
+    const membrane = new SequentialStreamMembrane([
+      createMockResponse([{ type: 'tool_use', id: 'toolu_budget', name: 'mcpl--heartbeat--heartbeat_status', input: {} }] as ContentBlock[]),
+      createMockResponse([{ type: 'text', text: '<mcpl--heartbeat--heartbeat_status>\n</mcpl--heartbeat--heartbeat_status>' }] as ContentBlock[]),
+    ]);
+    const framework = await AgentFramework.create({ storePath: join(dir, 'store'), membrane: membrane.asMembrane(), agents: [{ name: 'assistant', model: 'test', systemPrompt: 'sys', maxStreamTokens: 1, toolWrapperProseGuard: true }], modules: [module] });
+    (framework as unknown as { channelRegistry: unknown }).channelRegistry = new Proxy({
+      resolveLocus: () => 'world:test', routeSpeech: async (_a: string, text: string) => { routed.push(text); return { delivered: true, channelId: 'world:test' }; },
+      getDefaultPublishChannel: () => null, isChannelOpen: () => true, getDescriptor: () => undefined, getChannelTools: () => [],
+    }, { get: (target, prop: string) => (prop in target ? (target as Record<string, unknown>)[prop] : () => undefined) });
+    framework.pushEvent({ type: 'external-message', source: 'test', content: 'go', metadata: {} } as unknown as ProcessEvent); await framework.runUntilIdle();
+    const all = framework.getAgent('assistant')!.getContextManager().getAllMessages() as Array<{ content: ContentBlock[]; metadata?: Record<string, unknown> }>;
+    await framework.stop();
+    assert.equal(module.calls, 1); assert.equal(membrane.calls, 2); assert.deepEqual(routed, ['<mcpl--heartbeat--heartbeat_status>\n</mcpl--heartbeat--heartbeat_status>']);
+    assert.ok(!all.some((m) => m.metadata?.kind === 'tool-wrapper-prose-contained'));
+  });
+
+  it('buffers then delivers ordinary prose when enabled', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'af-wrapper-guard-ordinary-')); dirs.push(dir);
+    const membrane = new MockMembrane();
+    membrane.pushResponse(createMockResponse([{ type: 'text', text: 'Ordinary answer.' }] as ContentBlock[]));
+    const routed: string[] = []; const outgoing: string[] = [];
+    const framework = await AgentFramework.create({
+      storePath: join(dir, 'store'), membrane: membrane.asMembrane(),
+      agents: [{ name: 'assistant', model: 'test', systemPrompt: 'sys', toolWrapperProseGuard: true }], modules: [new HeartbeatModule()],
+    });
+    (framework as unknown as { channelRegistry: unknown }).channelRegistry = new Proxy({
+      resolveLocus: () => 'world:test',
+      routeSpeech: async (_agent: string, text: string) => { routed.push(text); return { delivered: true, channelId: 'world:test' }; },
+      sendOutgoingChunk: (_channel: string, _agent: string, _id: string, _index: number, delta: string) => { outgoing.push(delta); },
+      getDefaultPublishChannel: () => null, isChannelOpen: () => true, getDescriptor: () => undefined, getChannelTools: () => [],
+    }, { get: (target, prop: string) => (prop in target ? (target as Record<string, unknown>)[prop] : () => undefined) });
+    (framework as unknown as Record<string, unknown>).channelEventModule = { getChannelId: () => 'world:test' };
+    framework.pushEvent({ type: 'external-message', source: 'test', content: 'go', metadata: {} } as unknown as ProcessEvent);
+    await framework.runUntilIdle();
+    const all = framework.getAgent('assistant')!.getContextManager().getAllMessages() as Array<{ content: ContentBlock[]; metadata?: Record<string, unknown> }>;
+    await framework.stop();
+    assert.deepEqual(routed, ['Ordinary answer.']);
+    assert.deepEqual(outgoing, [], 'guarded turns buffer ordinary prose until completion');
+    assert.ok(all.some((m) => m.content.some((b) => b.type === 'text' && b.text === 'Ordinary answer.')));
+    assert.ok(!all.some((m) => m.metadata?.kind === 'tool-wrapper-prose-contained'));
+  });
+
+  it('does not reinterpret wrapper-shaped trailing prose after a genuine structured tool call', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'af-wrapper-guard-tool-')); dirs.push(dir);
+    const membrane = new MockMembrane();
+    membrane.pushResponse(createMockResponse([{
+      type: 'tool_use', id: 'toolu_1', name: 'mcpl--heartbeat--heartbeat_status', input: {},
+    }] as ContentBlock[]));
+    membrane.pushResponse(createMockResponse([{
+      type: 'text', text: '<mcpl--heartbeat--heartbeat_status>\n</mcpl--heartbeat--heartbeat_status>',
+    }] as ContentBlock[]));
+    const module = new HeartbeatModule(); const routed: string[] = [];
+    const framework = await AgentFramework.create({
+      storePath: join(dir, 'store'), membrane: membrane.asMembrane(),
+      agents: [{ name: 'assistant', model: 'test', systemPrompt: 'sys', toolWrapperProseGuard: true }],
+      modules: [module],
+    });
+    (framework as unknown as { channelRegistry: unknown }).channelRegistry = new Proxy({
+      resolveLocus: () => 'world:test', routeSpeech: async (_a: string, text: string) => { routed.push(text); return { delivered: true, channelId: 'world:test' }; },
+      getDefaultPublishChannel: () => null, isChannelOpen: () => true, getDescriptor: () => undefined, getChannelTools: () => [],
+    }, { get: (target, prop: string) => (prop in target ? (target as Record<string, unknown>)[prop] : () => undefined) });
+    framework.pushEvent({ type: 'external-message', source: 'test', content: 'go', metadata: {} } as unknown as ProcessEvent);
+    await framework.runUntilIdle();
+    const all = framework.getAgent('assistant')!.getContextManager().getAllMessages() as Array<{ content: ContentBlock[]; metadata?: Record<string, unknown> }>;
+    await framework.stop();
+    assert.equal(module.calls, 1, 'genuine structured tool executes exactly once');
+    assert.deepEqual(routed, ['<mcpl--heartbeat--heartbeat_status>\n</mcpl--heartbeat--heartbeat_status>']);
+    assert.ok(all.some((m) => m.content.some((b) => b.type === 'text' && b.text.includes('<mcpl--heartbeat--heartbeat_status>'))));
+    assert.ok(!all.some((m) => m.metadata?.kind === 'tool-wrapper-prose-contained'));
+  });
+
+  it('returns empty speech to ephemeral callers for a contained wrapper', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'af-wrapper-guard-ephemeral-')); dirs.push(dir);
+    const membrane = new MockMembrane();
+    membrane.pushResponse(createMockResponse([{
+      type: 'text', text: '<mcpl--heartbeat--heartbeat_status>\n</mcpl--heartbeat--heartbeat_status>',
+    }] as ContentBlock[]));
+    const framework = await AgentFramework.create({
+      storePath: join(dir, 'store'), membrane: membrane.asMembrane(), agents: [], modules: [new HeartbeatModule()],
+    });
+    const created = await framework.createEphemeralAgent({
+      name: 'ephemeral-wrapper', model: 'test', systemPrompt: 'sys', allowedTools: 'all', toolWrapperProseGuard: true,
+    });
+    created.contextManager.addMessage('user', [{ type: 'text', text: 'check' }]);
+    const run = framework.runEphemeralToCompletion(created.agent, created.contextManager);
+    framework.start();
+    const result = await run;
+    const internals = framework as unknown as {
+      logicalTurnToolCalls: WeakMap<object, { turnToken: number; count: number }>;
+      recordLogicalTurnToolCalls(agent: object, turnToken: number, count: number): void;
+    };
+    assert.equal(internals.logicalTurnToolCalls.has(created.agent), false, 'normal ephemeral cleanup removes logical-turn state');
+    internals.recordLogicalTurnToolCalls(created.agent, 1, 1);
+    assert.equal(internals.logicalTurnToolCalls.has(created.agent), false, 'late stream events cannot recreate disposed ephemeral state');
+    await framework.stop();
+    assert.deepEqual(result, { speech: '', toolCallsCount: 0 });
+  });
+
+  it('cleans logical-turn state when an ephemeral startup watchdog fires', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'af-wrapper-guard-ephemeral-watchdog-')); dirs.push(dir);
+    const framework = await AgentFramework.create({ storePath: join(dir, 'store'), membrane: new MockMembrane().asMembrane(), agents: [], modules: [new HeartbeatModule()] });
+    const created = await framework.createEphemeralAgent({ name: 'ephemeral-wrapper-watchdog', model: 'test', systemPrompt: 'sys', allowedTools: 'all', toolWrapperProseGuard: true });
+    created.contextManager.addMessage('user', [{ type: 'text', text: 'check' }]);
+    const internals = framework as unknown as { logicalTurnToolCalls: WeakMap<object, { turnToken: number; count: number }> };
+    internals.logicalTurnToolCalls.set(created.agent, { turnToken: 1, count: 1 });
+    await assert.rejects(framework.runEphemeralToCompletion(created.agent, created.contextManager, { startupTimeoutMs: 20 }), /failed to start inference/);
+    assert.equal(internals.logicalTurnToolCalls.has(created.agent), false);
+    await framework.stop();
+  });
+
+  it('refuses an ephemeral name that collides with a registered resident', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'af-wrapper-guard-resident-name-')); dirs.push(dir);
+    const framework = await AgentFramework.create({ storePath: join(dir, 'store'), membrane: new MockMembrane().asMembrane(), agents: [{ name: 'resident', model: 'test', systemPrompt: 'sys' }], modules: [new HeartbeatModule()] });
+    await assert.rejects(
+      framework.createEphemeralAgent({ name: 'resident', model: 'test', systemPrompt: 'sys', allowedTools: 'all' }),
+      /already registered or has been used/,
+    );
+    assert.ok(framework.getAgent('resident'));
+    await framework.stop();
+  });
+
+  it('idle-watchdog disposal cancels and ignores late tool events', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'af-wrapper-guard-late-tool-')); dirs.push(dir);
+    const module = new HeartbeatModule();
+    const framework = await AgentFramework.create({ storePath: join(dir, 'store'), membrane: new LateToolAfterIdleMembrane().asMembrane(), agents: [], modules: [module] });
+    await framework.start();
+    const created = await framework.createEphemeralAgent({ name: 'late-tool-after-idle', model: 'test', systemPrompt: 'sys', allowedTools: 'all', toolWrapperProseGuard: true });
+    created.contextManager.addMessage('user', [{ type: 'text', text: 'check' }]);
+    await assert.rejects(framework.runEphemeralToCompletion(created.agent, created.contextManager, { startupTimeoutMs: 100, idleTimeoutMs: 20, idlePollMs: 5 }), /stalled/);
+    await new Promise((resolve) => setTimeout(resolve, 260));
+    assert.equal(module.calls, 0, 'late structured call never executes after disposal');
+    assert.equal(framework.getAgent(created.agent.name), null);
+    const internals = framework as unknown as { activeStreams: Map<string, unknown>; pendingAssistantBlocks: Map<string, unknown> };
+    assert.equal(internals.activeStreams.has(created.agent.name), false, 'disposal removes the old active stream handle');
+    assert.equal(internals.pendingAssistantBlocks.has(created.agent.name), false, 'disposal removes pending tool blocks');
+    await framework.stop();
+  });
+
+  it('refuses ephemeral name reuse before a stale stream can bind to a successor', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'af-wrapper-guard-ephemeral-name-')); dirs.push(dir);
+    const framework = await AgentFramework.create({ storePath: join(dir, 'store'), membrane: new MockMembrane().asMembrane(), agents: [], modules: [new HeartbeatModule()] });
+    const first = await framework.createEphemeralAgent({ name: 'single-generation-name', model: 'test', systemPrompt: 'sys', allowedTools: 'all', toolWrapperProseGuard: true });
+    first.contextManager.addMessage('user', [{ type: 'text', text: 'check' }]);
+    await assert.rejects(framework.runEphemeralToCompletion(first.agent, first.contextManager, { startupTimeoutMs: 20 }), /failed to start inference/);
+    await assert.rejects(
+      framework.createEphemeralAgent({ name: 'single-generation-name', model: 'test', systemPrompt: 'sys', allowedTools: 'all', toolWrapperProseGuard: true }),
+      /already registered or has been used/,
+    );
+    assert.equal(framework.getAgent('single-generation-name'), null);
+    await framework.stop();
+  });
+
+  it('ignores late tool events from a disposed generation after name reuse', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'af-wrapper-guard-generation-')); dirs.push(dir);
+    const framework = await AgentFramework.create({ storePath: join(dir, 'store'), membrane: new MockMembrane().asMembrane(), agents: [], modules: [new HeartbeatModule()] });
+    const oldAgent = { name: 'reused' }; const newAgent = { name: 'reused' };
+    const internals = framework as unknown as {
+      logicalTurnToolCalls: WeakMap<object, { turnToken: number; count: number }>;
+      recordLogicalTurnToolCalls(agent: object, turnToken: number, count: number): void;
+      agents: Map<string, object>;
+    };
+    internals.agents.set('reused', newAgent);
+    internals.logicalTurnToolCalls.set(oldAgent, { turnToken: 1, count: 1 });
+    internals.logicalTurnToolCalls.set(newAgent, { turnToken: 2, count: 0 });
+    internals.recordLogicalTurnToolCalls(oldAgent, 1, 1);
+    assert.deepEqual(internals.logicalTurnToolCalls.get(newAgent), { turnToken: 2, count: 0 });
+    internals.agents.delete('reused');
+    await framework.stop();
+  });
+
+  it('conversation disposal reclaims logical-turn state', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'af-wrapper-guard-conversation-cleanup-')); dirs.push(dir);
+    const framework = await AgentFramework.create({ storePath: join(dir, 'store'), membrane: new MockMembrane().asMembrane(), agents: [], modules: [new HeartbeatModule()] });
+    const internals = framework as unknown as {
+      logicalTurnToolCalls: WeakMap<object, { turnToken: number; count: number }>;
+      disposeConversationAgent(agentName: string): void;
+      agents: Map<string, object>;
+    };
+    const fork = { name: 'fork' };
+    internals.agents.set('fork', fork);
+    internals.logicalTurnToolCalls.set(fork, { turnToken: 1, count: 1 });
+    internals.disposeConversationAgent('fork');
+    assert.equal(internals.logicalTurnToolCalls.has(fork), false);
+    await framework.stop();
+  });
+
+  it('enabled contains wrapper before continuity and publication, with content-free system receipt', async () => {
+    const { routed, outgoing, all, module } = await run(true);
+    assert.deepEqual(routed, []);
+    assert.deepEqual(outgoing, [], 'wrapper never reaches outgoing preview/voice streaming');
+    assert.equal(module.calls, 0, 'textual wrapper never executes the registered tool');
+    assert.ok(!all.some((m) => m.content.some((b) => b.type === 'text' && b.text.includes('<mcpl--heartbeat--heartbeat_status>'))));
+    const receipt = all.find((m) => m.metadata?.kind === 'tool-wrapper-prose-contained');
+    assert.ok(receipt, 'structured system receipt exists');
+    const receiptText = receipt!.content.filter((b) => b.type === 'text').map((b) => b.text).join('');
+    assert.equal(receiptText, '[tool-boundary] No tool was called.');
+    assert.ok(!receiptText.includes('heartbeat'), 'receipt does not echo the tool name or wrapper syntax');
+  });
+});

--- a/test/tool-wrapper-prose-guard-integration.test.ts
+++ b/test/tool-wrapper-prose-guard-integration.test.ts
@@ -369,4 +369,54 @@ describe('tool wrapper prose guard integration', () => {
     assert.equal(receiptText, '[tool-boundary] No tool was called.');
     assert.ok(!receiptText.includes('heartbeat'), 'receipt does not echo the tool name or wrapper syntax');
   });
+
+  it('successful ephemeral completion stops typing and finalizes outgoing after caller disposal', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'af-wrapper-guard-ephemeral-terminal-')); dirs.push(dir);
+    const membrane = new MockMembrane();
+    membrane.pushResponse(createMockResponse([{ type: 'text', text: 'Ordinary ephemeral answer.' }] as ContentBlock[]));
+    const framework = await AgentFramework.create({ storePath: join(dir, 'store'), membrane: membrane.asMembrane(), agents: [], modules: [] });
+    const typing: string[] = [];
+    const outgoing: Array<[string, string]> = [];
+    (framework as unknown as { channelRegistry: unknown }).channelRegistry = new Proxy({
+      resolveLocus: () => 'world:test',
+      startTyping: (channel: string) => typing.push(`start:${channel}`),
+      stopTyping: (channel?: string) => typing.push(`stop:${channel ?? '(all)'}`),
+      routeSpeech: async () => ({ delivered: true, channelId: 'world:test' }),
+      sendOutgoingChunk: (_channel: string, _agent: string, _id: string, _index: number, delta: string) => outgoing.push(['chunk', delta]),
+      sendOutgoingComplete: (_channel: string, _agent: string, _id: string, text: string) => outgoing.push(['complete', text]),
+      getDefaultPublishChannel: () => 'world:test', isChannelOpen: () => true, getDescriptor: () => undefined, getChannelTools: () => [],
+      resolveProseTarget: () => ({ channelId: 'world:test' }),
+    }, { get: (target, prop: string) => (prop in target ? (target as Record<string, unknown>)[prop] : () => undefined) });
+    const created = await framework.createEphemeralAgent({ name: 'ephemeral-terminal', model: 'test', systemPrompt: 'sys', allowedTools: 'all' });
+    created.contextManager.addMessage('user', [{ type: 'text', text: 'go' }]);
+    const run = framework.runEphemeralToCompletion(created.agent, created.contextManager);
+    framework.start();
+    assert.deepEqual(await run, { speech: 'Ordinary ephemeral answer.', toolCallsCount: 0 });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.ok(typing.includes('stop:(all)'), 'terminal physical frame stops typing after ephemeral caller disposal');
+    assert.ok(outgoing.some(([kind, text]) => kind === 'complete' && text === 'Ordinary ephemeral answer.'), 'terminal physical frame finalizes outgoing stream');
+    await framework.stop();
+  });
+
+  it('releases a conversation name reservation after transient creation failure', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'af-wrapper-guard-conversation-retry-')); dirs.push(dir);
+    const framework = await AgentFramework.create({
+      storePath: join(dir, 'store'), membrane: new MockMembrane().asMembrane(),
+      agents: [{ name: 'trunk', model: 'test', systemPrompt: 'sys' }], modules: [],
+      conversations: { templateAgent: 'trunk', bind: { channel: 'mention' } },
+    });
+    const internals = framework as unknown as { store: Record<PropertyKey, unknown>; createConversationAgent(name: string, channelId: string): Promise<{ name: string }> };
+    const goodStore = internals.store;
+    internals.store = new Proxy(goodStore, { get(target, prop) {
+      if (prop === 'getMessages' || prop === 'appendMessage' || prop === 'getStateJson') throw new Error('transient store failure');
+      const value = Reflect.get(target, prop);
+      return typeof value === 'function' ? value.bind(target) : value;
+    } });
+    await assert.rejects(internals.createConversationAgent('trunk-chan-g1', 'world:chan'), /transient store failure/);
+    internals.store = goodStore;
+    const retried = await internals.createConversationAgent('trunk-chan-g1', 'world:chan');
+    assert.equal(retried.name, 'trunk-chan-g1');
+    await framework.stop();
+  });
+
 });

--- a/test/tool-wrapper-prose-guard-integration.test.ts
+++ b/test/tool-wrapper-prose-guard-integration.test.ts
@@ -53,6 +53,38 @@ class ToolThenFrameworkRetryMembrane {
   asMembrane(): import('@animalabs/membrane').Membrane { return this as unknown as import('@animalabs/membrane').Membrane; }
 }
 
+class LateCompletionAfterIdleStream implements YieldingStream {
+  private events: StreamEvent[] = [];
+  private wake: (() => void) | null = null;
+  get isWaitingForTools() { return false; }
+  get pendingToolCallIds() { return []; }
+  get toolDepth() { return 0; }
+  provideToolResults(): void {}
+  cancel(): void { /* Simulate a provider that ignores cancellation and terminates later. */ }
+  constructor() {
+    setTimeout(() => {
+      this.events.push({ type: 'complete', response: createMockResponse([{ type: 'text', text: 'late answer' }] as ContentBlock[]) } as StreamEvent);
+      this.wake?.(); this.wake = null;
+    }, 120);
+  }
+  async *[Symbol.asyncIterator](): AsyncIterator<StreamEvent> {
+    yield { type: 'tokens', content: 'partial', meta: { type: 'text', visible: true, blockIndex: 0 } } as StreamEvent;
+    while (true) {
+      while (this.events.length) {
+        const event = this.events.shift()!;
+        yield event;
+        if (event.type === 'complete') return;
+      }
+      await new Promise<void>((resolve) => { this.wake = resolve; });
+    }
+  }
+}
+class LateCompletionAfterIdleMembrane {
+  async complete(): Promise<NormalizedResponse> { throw new Error('not used'); }
+  streamYielding(): YieldingStream { return new LateCompletionAfterIdleStream(); }
+  asMembrane(): import('@animalabs/membrane').Membrane { return this as unknown as import('@animalabs/membrane').Membrane; }
+}
+
 class RetryingWrapperMembrane {
   readonly response = createMockResponse([{ type: 'text', text: '<mcpl--heartbeat--heartbeat_status>\n</mcpl--heartbeat--heartbeat_status>' }] as ContentBlock[]);
   async complete(_request: NormalizedRequest): Promise<NormalizedResponse> { return this.response; }
@@ -416,6 +448,33 @@ describe('tool wrapper prose guard integration', () => {
     internals.store = goodStore;
     const retried = await internals.createConversationAgent('trunk-chan-g1', 'world:chan');
     assert.equal(retried.name, 'trunk-chan-g1');
+    await framework.stop();
+  });
+
+
+  it('idle-disposed ephemeral stops typing and finalizes every started outgoing stream', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'af-wrapper-guard-idle-terminal-')); dirs.push(dir);
+    const framework = await AgentFramework.create({ storePath: join(dir, 'store'), membrane: new LateCompletionAfterIdleMembrane().asMembrane(), agents: [], modules: [] });
+    const events: string[] = [];
+    (framework as unknown as { channelRegistry: unknown }).channelRegistry = new Proxy({
+      resolveLocus: () => 'world:test',
+      startTyping: (channel: string) => events.push(`start:${channel}`),
+      stopTyping: (channel?: string) => events.push(`stop:${channel ?? '(all)'}`),
+      routeSpeech: async () => ({ delivered: true, channelId: 'world:test' }),
+      sendOutgoingChunk: (_channel: string, _agent: string, _id: string, _index: number, delta: string) => events.push(`chunk:${delta}`),
+      sendOutgoingComplete: (_channel: string, _agent: string, _id: string, text: string) => events.push(`complete:${text}`),
+      getDefaultPublishChannel: () => 'world:test', isChannelOpen: () => true, getDescriptor: () => undefined, getChannelTools: () => [],
+      resolveProseTarget: () => ({ channelId: 'world:test' }),
+    }, { get: (target, prop: string) => (prop in target ? (target as Record<string, unknown>)[prop] : () => undefined) });
+    const created = await framework.createEphemeralAgent({ name: 'idle-terminal', model: 'test', systemPrompt: 'sys', allowedTools: 'all' });
+    created.contextManager.addMessage('user', [{ type: 'text', text: 'go' }]);
+    const run = framework.runEphemeralToCompletion(created.agent, created.contextManager, { startupTimeoutMs: 500, idleTimeoutMs: 20, idlePollMs: 5 });
+    framework.start();
+    await assert.rejects(run, /stalled/);
+    await new Promise((resolve) => setTimeout(resolve, 180));
+    assert.ok(events.includes('stop:(all)'), 'disposer-owned frame stops typing');
+    assert.ok(events.some((event) => event.startsWith('chunk:')), 'probe actually opened an outgoing stream');
+    assert.ok(events.some((event) => event.startsWith('complete:')), 'every started outgoing stream receives a terminal complete');
     await framework.stop();
   });
 

--- a/test/tool-wrapper-prose-guard.test.ts
+++ b/test/tool-wrapper-prose-guard.test.ts
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import type { ContentBlock } from '@animalabs/membrane';
+import { detectKnownToolWrapperProse } from '../src/tool-wrapper-prose-guard.js';
+
+const known = new Set(['mcpl--heartbeat--heartbeat_status', 'skip_reply']);
+const text = (value: string): ContentBlock[] => [{ type: 'text', text: value }];
+
+test('whole-response known-tool prose guard: matches paired heartbeat wrapper', () => {
+  assert.equal(detectKnownToolWrapperProse(text('<mcpl--heartbeat--heartbeat_status>\n</mcpl--heartbeat--heartbeat_status>'), known), 'mcpl--heartbeat--heartbeat_status');
+});
+test('whole-response known-tool prose guard: matches self-closing and legacy invoke wrappers', () => {
+  assert.equal(detectKnownToolWrapperProse(text('<skip_reply/>'), known), 'skip_reply');
+  assert.equal(detectKnownToolWrapperProse(text('<invoke><tool name="skip_reply"/></invoke>'), known), 'skip_reply');
+  assert.equal(detectKnownToolWrapperProse(text('<invoke><tool name="skip_reply"><parameter name="reason">quiet</parameter></tool></invoke>'), known), 'skip_reply');
+});
+test('whole-response known-tool prose guard: allows signed thinking before only visible wrapper', () => {
+  const blocks = [{ type: 'thinking', thinking: 'private', signature: 'sig' }, ...text('<skip_reply/>')] as ContentBlock[];
+  assert.equal(detectKnownToolWrapperProse(blocks, known), 'skip_reply');
+});
+test('whole-response known-tool prose guard: unknown tools do not match', () => {
+  assert.equal(detectKnownToolWrapperProse(text('<delete_everything/>'), known), null);
+});
+test('whole-response known-tool prose guard: quotation, code, mixed prose, and partial wrappers do not match', () => {
+  for (const value of ['The form `<skip_reply/>` is malformed.','```xml\n<skip_reply/>\n```','<skip_reply/>\nI tried to be quiet.','prefix <skip_reply/>','<skip_reply>','<skip_reply></other>']) {
+    assert.equal(detectKnownToolWrapperProse(text(value), known), null, value);
+  }
+});
+test('whole-response known-tool prose guard: real structured calls do not match', () => {
+  const blocks = [{ type: 'tool_use', id: 't1', name: 'skip_reply', input: {} }] as ContentBlock[];
+  assert.equal(detectKnownToolWrapperProse(blocks, known), null);
+});
+test('whole-response known-tool prose guard: empty prose and empty surface do not match', () => {
+  assert.equal(detectKnownToolWrapperProse(text('  '), known), null);
+  assert.equal(detectKnownToolWrapperProse(text('<skip_reply/>'), new Set()), null);
+});


### PR DESCRIPTION
## Summary

Adds default-off `toolWrapperProseGuard` for the failure mode where a provider emits a complete textual rendering of an available tool invocation instead of structured `tool_use`.

On an exact whole-visible-response match, the framework executes nothing, publishes nothing, omits the wrapper from assistant continuity, preserves raw provider tracing, and records only `[tool-boundary] No tool was called.` as a system boundary. Unknown tools, quotation/code/mixed prose, genuine structured calls, and ordinary prose remain unchanged.

## Lifecycle safety

- successful ephemeral completion closes typing and outgoing completion after caller disposal
- transient creation failure releases conversation/ephemeral reservation
- watchdog-disposed ephemerals close every started outgoing stream without authorizing a stale successor frame
- late disposed-generation tool events cannot execute
- logical tool-call state survives retry/context-budget restart
- EventGate and KV receipt ownership remain generation/frame scoped

## Evidence

Exact head: `dce7eacced743ea17409f9b48f0503c26db3048d`

- typecheck/build clean
- focused wrapper/lifecycle `25/25`
- full sequential compiled suite `721 total / 717 pass / 0 fail / 4 skip`
- hostile Opus review: **ACCEPT**, 0 blockers
- all three review-cycle lifecycle blockers have red mutation controls
- direct timeout probe emits `chunk -> stop typing -> outgoing complete`

## Boundaries

Default off. This PR does not enable the guard for any resident, alter any resident store, or authorize deployment/restart. Guarded turns deliberately do not expose speculative outgoing preview/TTS before whole-response classification; authoritative ordinary delivery occurs at turn completion.
