### PR TITLE
workspace: accept JPEG trailing bytes after EOI in read_image validation

### DIFF
--- a/changelog.d/143-jpeg-trailing-bytes.fixed.md
+++ b/changelog.d/143-jpeg-trailing-bytes.fixed.md
@@ -1,0 +1,7 @@
+- `read_image` / workspace `read_image` no longer reject a JPEG that carries
+  padding after its EOI marker (#143). Hardware encoders such as the Raspberry
+  Pi camera pad every still to a 4-byte boundary (`ff d9 00 00 00`), and
+  decoders stop at EOI, so these are valid images; the validator used to
+  require EOI to be the final byte and reported them as `Invalid JPEG image`,
+  which made an rpi camera unviewable for a resident. The SOI..EOI stream is
+  still fully validated.

--- a/src/modules/workspace/index.ts
+++ b/src/modules/workspace/index.ts
@@ -369,9 +369,13 @@ function validateJpeg(bytes: Buffer, mountPrefixedPath: string): void {
     offset += 1;
 
     if (marker === JPEG_EOI) {
-      if (!sawSof || !sawSos || offset !== bytes.length) {
+      if (!sawSof || !sawSos) {
         invalidImage('JPEG', mountPrefixedPath);
       }
+      // Bytes after EOI are tolerated: hardware encoders (e.g. Raspberry Pi
+      // camera stills) pad each frame to a 4-byte boundary with NULs after
+      // the EOI marker, and every mainstream decoder stops at EOI. The image
+      // proper (SOI..EOI) has been fully validated by this point.
       return;
     }
     if (marker === JPEG_TEM || (marker >= 0xd0 && marker <= 0xd7)) {

--- a/test/workspace-read-image.test.ts
+++ b/test/workspace-read-image.test.ts
@@ -331,6 +331,15 @@ test('valid tiny PNG, JPEG, GIF, and WebP return native image content with exact
   }
 });
 
+test('JPEG with trailing pad bytes after EOI is accepted (hardware encoders pad to 4-byte boundary)', async (t) => {
+  const { mountDir, workspace } = setupWorkspace(t);
+  // Raspberry Pi camera stills end `ff d9 00 00 00`; decoders stop at EOI.
+  const padded = { mimeType: 'image/jpeg', bytes: Buffer.concat([TINY_IMAGES.jpeg.bytes, Buffer.from([0x00, 0x00, 0x00])]) };
+  writeFileSync(join(mountDir, 'padded.jpg'), padded.bytes);
+  const result = await callReadImage(workspace, 'work/padded.jpg');
+  expectImageResult(result, 'work/padded.jpg', padded);
+});
+
 test('pre-existing Chronicle binary blob is preferred even when the filesystem file is absent', async (t) => {
   const { mountDir, store, workspace, treeStateId } = setupWorkspace(t);
   const image = TINY_IMAGES.png;


### PR DESCRIPTION
## Bug
`validateJpeg` demanded that the EOI marker be the final byte of the file (`offset !== bytes.length` → invalid). Hardware encoders pad each still to a 4-byte boundary after EOI — every frame from a Raspberry Pi camera ends `ff d9 00 00 00` — so **no still from such a camera could ever be viewed** via `read_image` / `workspace--read_image`. The files are valid (PIL, `sips`, browsers all decode them; decoders stop at EOI).

Observed live on Rhys (keep) 2026-09-05 23:20Z: `Invalid JPEG image: notes/hurricane-20260905.jpg` while `file` said "JPEG image data" → the agent concluded the reader was broken and burned ~15 rounds on workarounds (Discord echo loop, `save_recent_image` wrong picture).

## Fix
Tolerate bytes after a complete, validated SOI..EOI stream. Everything before EOI is validated exactly as before (SOF/SOS presence, segment lengths, entropy scan). Returned bytes are the file as-is, consistent with the tool's exact-bytes contract.

## Test
`test/workspace-read-image.test.ts`: tiny JPEG + 3 NUL pad bytes → success with exact bytes/MIME. Suite 14/14 locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015rjrGST915XQX384nNDwkK